### PR TITLE
Error response section for ID-based JSON API

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -204,6 +204,19 @@ The related documents are provided as an additional top-level document or docume
 
 The linkage between the key under `"rels"` and the top-level keys is hardcoded into the client.
 
+### Error Responses
+
+An error response is comprised of an error object consisting of a key/values, the values being arrays.
+
+```js
+{
+  "errors": {
+    "title": ["can't be blank", "is too short (minimum is 2 characters)"],
+    "body": ["can't be blank"]
+  }
+}
+```
+
 ## URL-Based JSON API
 
 In the above description of ID-based JSON, there were several places where information about the location of related resources needed to be hardcoded into the client.


### PR DESCRIPTION
Relates to json-api/json-api#7

One question I have here is whether, for compound documents, we need to allow for multiple error objects, and if one part of a compound document can contain normal results while other parts contain errors.

I'm happy to revise this or scrap it, per the collective wisdom of you more experienced API developers.
