### PR TITLE
cleanup URL-Based JSON API relationships example

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -276,7 +276,8 @@ The value of the `"rels"` key is a JSON object that represents related documents
     "title": "Rails is Omakase",
     "rels": {
       "author": "http://example.com/people/1",
-      "comments": "http://example.com/comments/5,12,17,20"
+      "comments": "http://example.com/comments?ids=5,12,17,20"
+      // or alternatively "comments": "http://example.com/posts/1/comments" 
     }
   }
 }


### PR DESCRIPTION
use comments?ids=1,2,3,4 rather than comments/1,2,3,4
or alternatively posts/1/comments
