### PR TITLE
Deletions should not mandate a particular Accept header

### DIFF
--- a/source/write.md
+++ b/source/write.md
@@ -350,9 +350,6 @@ Servers **MAY** use other HTTP error codes to represent errors.  Clients
 A JSON API document is *deleted* by making a `DELETE` request to the
 document's URL.
 
-It **MUST** contain an `Accept` header with `application/json` as
-the only or highest quality factor.
-
 ```text
 DELETE /photos/1
 ```


### PR DESCRIPTION
It has no bearing on the semantics of the DELETE method, and the protocol's implied response message contains no body. Cases where the Accept header would control the response message clearly fall under "Other Responses".
