### PR TITLE
Notes section is really a Status section

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -10,18 +10,19 @@ See also:
 - [Extending](/extending)
 - [History](/history)
 
-## NOTE
+## Status
 
-_This document is a work in progress, and will likely change over the
-next month as implementation work progresses. It is currently missing
+**This document is a work in progress** and will likely change over the
+next month as implementation work progresses. Implementors should be
+aware that this specification is not stable. It is currently missing
 some details about the `meta` attribute and could be more precise about
-details of working with relationships._
+details of working with relationships.
 
-_Please feel free to help flesh it out or if you try to write an
-implementation, tell us where things were ambiguous._
-
-_You can do so by filing an Issue against [our GitHub
-repository.](https://github.com/json-api/json-api/issues)_
+Work on this specification is being done at its 
+[GitHub repository](https://github.com/json-api/json-api). Please feel 
+free to help flesh it out or, if you try to write an implementation, to 
+tell us where things were ambiguous. The best way to do so is to 
+[file an Issue](https://github.com/json-api/json-api/issues).
 
 ## Abstract
 


### PR DESCRIPTION
- Rename the "Notes" section as "Status".
- Remove the emphasis from the entire section and
  place emphasis on the "work in progress" sentence.
- Call out that the spec is not stable.
- Rework paragraph about contributing.
- Tweak some grammar and punctuation (take the commas 
  from over here and push them over there -- Patrick).
