### PR TITLE
Fix href for comments 4,5,6 in JSON read example

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -526,15 +526,15 @@ response by specifying a `"href"` key:
     "id": "3",
     "body": "What's Omakase?"
   }, {
-    "href": "/comments/1",
+    "href": "http://example.com/comments/4",
     "id": "4",
     "body": "Parley is a discussion, especially one between enemies"
   }, {
-    "href": "/comments/1",
+    "href": "http://example.com/comments/5",
     "id": "5",
     "body": "The parsley letter"
   }, {
-    "href": "/comments/1",
+    "href": "http://example.com/comments/6",
     "id": "6",
     "body": "Dependency Injection is Not a Vice"
   }]


### PR DESCRIPTION
These looks like remnants of a copy/paste. Updating to match the first three examples in the same response.
