### PR TITLE
Remove invalid href in write example

### DIFF
--- a/source/write.md
+++ b/source/write.md
@@ -134,8 +134,7 @@ Content-Type: application/json
 {
   "posts": [{
     "id": "550e8400-e29b-41d4-a716-446655440000",
-    "title": "Mustaches on a Stick",
-    "href": "http://example.com/images/mustaches.png"
+    "title": "Mustaches on a Stick"
   }],
   "links": {
     "posts": "http://example.com/posts/{posts.id}"


### PR DESCRIPTION
This href looks to be from a previous example where we were looking at photos. This href doesn't make sense for a `post` and we don't need it anyway because this example is showing the use of a url template.
