### PR TITLE
Change 'posts' to 'photos' to match response attrs

### DIFF
--- a/source/write.md
+++ b/source/write.md
@@ -166,7 +166,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-  "posts": {
+  "photos": {
     "id": "550e8400-e29b-41d4-a716-446655440000",
     "href": "http://example.com/photos/12",
     "title": "Ember Hamster",


### PR DESCRIPTION
This example looks like a photo, not a post. Changing the name of the key to match.
