### PR TITLE
pluralize {posts.author} and {posts.comments} href in sample

### DIFF
--- a/reading/index.md
+++ b/reading/index.md
@@ -373,11 +373,11 @@ In this case, a bit of extra metadata for each relationship can link together th
 {
   "links": {
     "posts.author": {
-      "href": "http://example.com/people/{post.author}",
+      "href": "http://example.com/people/{posts.author}",
       "type": "people"
     },
     "posts.comments": {
-      "href": "http://example.com/comments/{post.comments}",
+      "href": "http://example.com/comments/{posts.comments}",
       "type": "comments"
     }
   }


### PR DESCRIPTION
This change pluralizes the relations in the URL templates for compound documents.

`"/people/{post.author}"` becomes `"/people/{posts.author}"`

`"/comments/{post.comments}"` becomes `"/comments/{posts.comments}"`
