### PR TITLE
when creating a new resource, wrap the document in an array.

### DIFF
--- a/updating/index.md
+++ b/updating/index.md
@@ -57,10 +57,10 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "photos": {
+  "photos": [{
     "title": "Ember Hamster",
     "src": "http://example.com/images/productivity.png"
-  }
+  }]
 }
 ```
 


### PR DESCRIPTION
singular resource retrieval wraps the resource's representation document in an array, like so:

```
{
  "posts": [{
    // an individual post document
  }]
}
```

posting a new resource to the server with a client-side generated id also uses an array:

```
POST /photos
Content-Type: application/json
Accept: application/json

{
  "photos": [{
    "id": "550e8400-e29b-41d4-a716-446655440000",
    "title": "Ember Hamster",
    "src": "http://example.com/images/productivity.png"
  }]
}
```

in order to stay coherent, I suggest to wrap the content of the new document in an array when creating a new resource:

```
POST /photos
Content-Type: application/json
Accept: application/json

{
  "photos": [{
    "title": "Ember Hamster",
    "src": "http://example.com/images/productivity.png"
  }]
}
```

this would also allow posting multiple new documents at once.
