### PR TITLE
fix links to id/url based json api docs

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,8 +12,8 @@ currently going through the process of being registered with IANA.
 
 There are two JSON API styles:
 
-* [The ID Style](#toc_id-based-json-api)
-* [The URL Style](#toc_url-based-json-api)
+* [The ID Style](/reading#id-based-json-api)
+* [The URL Style](/reading#url-based-json-api)
 
 The ID style is the easiest to get started with, but requires that your
 clients be able to guess the URLs for related documents. It also locks

--- a/reading/index.md
+++ b/reading/index.md
@@ -5,6 +5,7 @@ title: "JSON API: Reading"
 
 {% include status.md %}
 
+<a id="id-based-json-api"></a>
 ## ID-Based JSON API
 
 ### Top Level
@@ -155,6 +156,7 @@ The related documents are provided as an additional top-level document or docume
 
 The linkage between the key under `"links"` and the top-level keys is hardcoded into the client.
 
+<a id="url-based-json-api"></a>
 ## URL-Based JSON API
 
 In the above description of ID-based JSON, there were several places where information about the location of related resources needed to be hardcoded into the client.


### PR DESCRIPTION
It seems like inserting a tags with an id attribute is the way to go in markdown. I tried configuring redcarpet with @with_toc_data@, but it would name all the H\* tags sequentially, breaking existing links once you add more h tags.
