### PR TITLE
Fix JSON Patch operation paths

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -670,7 +670,7 @@ PATCH /photos/1
 Content-Type: application/json-patch+json
 
 [
-  { "op": "replace", "path": "/src", "value": "http://example.com/hamster.png" }
+  { "op": "replace", "path": "/photos/0/src", "value": "http://example.com/hamster.png" }
 ]
 ```
 

--- a/format/index.md
+++ b/format/index.md
@@ -761,7 +761,7 @@ the `PATCH` request:
 PATCH /photos/1
 
 [
-  { "op": "add", "path": "/links/comments/-", "value": 30 }
+  { "op": "add", "path": "/photos/0/links/comments/-", "value": 30 }
 ]
 ```
 

--- a/format/index.md
+++ b/format/index.md
@@ -771,7 +771,7 @@ To remove comment 5 from this photo, issue a `remove` operation:
 PATCH /photos/1
 
 [
-  { "op": "remove", "path": "links/comments/5" }
+  { "op": "remove", "path": "/photos/0/links/comments/1" }
 ]
 ```
 

--- a/format/index.md
+++ b/format/index.md
@@ -719,7 +719,7 @@ Content-Type: application/json-patch+json
 Accept: application/json
 
 [
-  { "op": "replace", "path": "/links/author", "value": 2 }
+  { "op": "replace", "path": "/photos/0/links/author", "value": 2 }
 ]
 ```
 


### PR DESCRIPTION
I found this error in all the Patch operation examples:

If the target document is:
{
  "photos": [{
    "id": "1",
    "title": "Productivity",
    "src": "http://example.com/productivity.png"
  }]
}

And the JSON Patch document is this
[
  { "op": "replace", "path": "/src", "value": "http://example.com/hamster.png" }
]

"/src" wont be found.

We need to parse from "photos" no?
The paths should be something like so /photos/0/keep-drilling-down
