### PR TITLE
Fix URL Template expansion example

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -380,7 +380,7 @@ Here is another example that uses a has-one relationship:
 }
 ```
 
-In this example, the author URL for all three posts is `/people/12`.
+In this example, the author URL for all three posts is `http://example.com/people/12`.
 
 Top-level URL templates allow you to specify relationships as IDs, but without requiring that clients hard-code information about how to form the URLs.
 


### PR DESCRIPTION
The third example on the /format page about "URL Template Shorthands" has a full URL for the template. The line after the example states that it expands to a relative URL. This made me think. It's a small issue, but the correct statement is:

"In this example, the author URL for all three posts is `http://example.com/people/12`."
