### PR TITLE
change link removal example to be "set-like" rather than "array-like"

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -780,7 +780,7 @@ To remove comment 5 from this photo, issue a `remove` operation:
 PATCH /photos/1
 
 [
-  { "op": "remove", "path": "/photos/0/links/comments/1" }
+  { "op": "remove", "path": "/photos/0/links/comments/5" }
 ]
 ```
 


### PR DESCRIPTION
The example of "removing comment 5 from this photo" uses "/photos/0/links/comments/1" as it's path. That references the array index of the comment in it's collection, treating it like an array, however the surrounding text explicitly states that "to-many relationships have set-like behavior in JSON API"

This set-like behavior isn't really defined (I don't see it mentioned anywhere in [the JSON Patch RFC](http://tools.ietf.org/html/rfc6902) ), but it seems like it should mean "values are returned as an array, but the items in that array should be treated as though they were object keys with ignorable values". Basically, the order of that array should be explicitly ignored, and references should be by ID rather that array index.

This would to imply that the example should be  "/photos/0/links/comments/_5_" (by ID -- it's a set, not by array index)
