### PR TITLE
Fix related document key to match link type

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -431,7 +431,7 @@ In this case, a bit of extra metadata for each relationship can link together th
       "comments": [ "6" ]
     }
   }],
-  "author": [{
+  "people": [{
     "id": "9",
     "name": "@d2h"
   }],


### PR DESCRIPTION
Perhaps I'm misinterpreting the spec, but I'm fairly certain this key is supposed to match the `type` specified in the link metadata.
