### PR TITLE
Split code snippet with an HTTP session into two snippets

### DIFF
--- a/extending/index.md
+++ b/extending/index.md
@@ -47,9 +47,11 @@ GET http://api.example.com/
 That document will de-reference to explain your link relations:
 
 ```text
-GET http://api.example.com/profile
+GET http://api.example.com/profile HTTP/1.1
+```
 
-200 OK
+```text
+HTTP/1.1 200 OK
 Content-Type: text/plain
 
 The Example.com API Profile


### PR DESCRIPTION
I split the code sample with an HTTP session into two: one with only the request line, and the other with the response. This way highlight.js is able to recognize and correctly highlight both snippets, including markdown in the HTTP response body.
