### PR TITLE
fix page alignment in some browsers (firefox)

### DIFF
--- a/stylesheets/all.css
+++ b/stylesheets/all.css
@@ -9,7 +9,7 @@ body {
   border: 1px solid #ccc;
   padding: 20px;
   border-radius: 10px;
-  margin: 10px;
+  margin: 10px auto;
   background-color: #f9f9f9;
   color: #222;
   line-height: 150%;

--- a/stylesheets/all.scss
+++ b/stylesheets/all.scss
@@ -12,7 +12,7 @@ body {
   border: 1px solid #ccc;
   padding: 20px;
   border-radius: 10px;
-  margin: 10px;
+  margin: 10px auto;
   background-color: #f9f9f9;
   color: #222;
   line-height: 150%;


### PR DESCRIPTION
In Firefox, it seems that the page is left aligned:
![screenshot from 2013-12-05 14 59 32](https://f.cloud.github.com/assets/1175095/1688086/73091828-5e00-11e3-889a-725cff59bb32.png)

By setting the horizontal margin to `auto`, that fixes it so that it's centered, consistent with how Chrome renders the page:
![screenshot from 2013-12-05 14 59 46](https://f.cloud.github.com/assets/1175095/1688091/93062fe4-5e00-11e3-9c78-32f755b64f1f.png)
