### PR TITLE
Align example of URL style with ID style

### DIFF
--- a/index.md
+++ b/index.md
@@ -40,7 +40,7 @@ and in the URL style:
     "id": "1",
     "title": "Rails is Omakase",
     "links": {
-      "author": "http://example.com/people/1",
+      "author": "http://example.com/people/9",
       "comments": "http://example.com/comments/5,12,17,20"
     }
   }]


### PR DESCRIPTION
Clarifying examples.
The ID style example used the ID 9 whereas the URL style used 1.
