### PR TITLE
Clarify the role of id keys within the URL-based JSON API

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -251,6 +251,13 @@ The `"id"` key in a document represents a unique identifier for the document,
 scoped to the document's type. It can be used with URL templates to fetch
 related records, as described below.
 
+NOTE: While an implementation could use the values of `"id"` keys as URLs
+(which are unique string identifiers, after all), it is not generally
+recommended. URLs can change, so they are unreliable for mapping a document to
+any client-side models that represent the same resource. It is recommended that
+URL values be left to the task of linking documents while `"id"` values remain
+opaque to solely provide a unique identity within some type.
+
 ### Attributes
 
 Other than the `"links"`, `"href"` and `"id"` keys, every key in a document represents an attribute. An attribute's value may be any JSON value.

--- a/format/index.md
+++ b/format/index.md
@@ -247,7 +247,9 @@ Each document in the list **MAY** contain an `id` key.
 
 ### IDs
 
-The `"id"` key in a document represents a unique identifier for the document, scoped to the document's type. It can be used with URL templates to fetch related records, as described below.
+The `"id"` key in a document represents a unique identifier for the document,
+scoped to the document's type. It can be used with URL templates to fetch
+related records, as described below.
 
 ### Attributes
 


### PR DESCRIPTION
This comes off of a discussion in json-api/json-api#179 and @steveklabnik's [call for a PR](https://github.com/json-api/json-api/pull/179#issuecomment-32909054).

I'm not sure if the additions align with what the team had in mind, but I wrote down [my earlier thoughts](https://github.com/json-api/json-api/pull/179#issuecomment-32897319) that are based on some experiences implementing a URL-based JSON API.
