### PR TITLE
Unify id requirement level across spec

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -52,7 +52,7 @@ wrapped inside an array:
 This simplifies processing, as you can know that a resource key will always be
 a list.
 
-The document **MUST** contain an `id` key.
+The document **SHOULD** contain an `id` key.
 
 ### Resource Collections
 
@@ -71,7 +71,7 @@ represents a list of documents.
 }
 ```
 
-Each document in the list **MUST** contain an `id` key.
+Each document in the list **SHOULD** contain an `id` key.
 
 ### IDs
 
@@ -224,7 +224,7 @@ wrapped inside an array:
 This simplifies processing, as you can know that a resource key will always be
 a list.
 
-The document **MAY** contain an `id` key.
+The document **SHOULD** contain an `id` key.
 
 ### Resource Collections
 
@@ -243,7 +243,7 @@ represents a list of documents.
 }
 ```
 
-Each document in the list **MAY** contain an `id` key.
+Each document in the list **SHOULD** contain an `id` key.
 
 ### IDs
 

--- a/format/index.md
+++ b/format/index.md
@@ -77,6 +77,10 @@ Each document in the list **SHOULD** contain an `id` key.
 
 The `"id"` key in a document represents a unique identifier for the document, scoped to the document's type. The type scope is implicit, and hardcoded into clients of the API.
 
+In scenarios where uniquely identifying information between client and server
+is unnecessary (e.g., read-only, transient entities), JSON API allows for
+omitting the `"id"` key.
+
 ### Attributes
 
 Other than the `"links"`, `"href"` and `"id"` keys, every key in a document represents an attribute. An attribute's value may be any JSON value.
@@ -250,6 +254,10 @@ Each document in the list **SHOULD** contain an `id` key.
 The `"id"` key in a document represents a unique identifier for the document,
 scoped to the document's type. It can be used with URL templates to fetch
 related records, as described below.
+
+In scenarios where uniquely identifying information between client and server
+is unnecessary (e.g., read-only, transient entities), JSON API allows for
+omitting the `"id"` key.
 
 NOTE: While an implementation could use the values of `"id"` keys as URLs
 (which are unique string identifiers, after all), it is not generally


### PR DESCRIPTION
The `id` requirement-level was inconsistent between the ID-based and URL-based formats. Based on a [GitHub discussion](json-api#181), it seems like `id` keys are _usually_ a good thing, but there are cases where a hard requirement would be unnecessary.

I have also added a [quick blurb](https://github.com/andrewsardone/json-api/commit/51ee09f68740bf47635f8a7cacc6c3902b18a637) that notes the possible omission, but I think it might require some additional explanation.

Closes json-api/json-api#181.
