### PR TITLE
Add Hy Python library

### DIFF
--- a/examples/index.md
+++ b/examples/index.md
@@ -44,6 +44,10 @@ has page describing how to emit conformant JSON.
 
 * [Oat](https://github.com/ismasan/oat#adapters) ships with a JSON API adapter.
 
+### Python
+
+* [Hy](https://github.com/kalasjocke/hy) is a library for creating json-api responses.
+
 ## Messages
 
 * [RestPack::Serializer provides examples](http://restpack-serializer-sample.herokuapp.com/) which demonstrate sample responses.

--- a/examples/index.md
+++ b/examples/index.md
@@ -54,7 +54,7 @@ has page describing how to emit conformant JSON.
 
 ## Related Tools
 
-### Ruby 
+### Ruby
 
 * [json-patch](https://github.com/guillec/json-patch) implementation of JSON Patch (rfc6902) 
 


### PR DESCRIPTION
I decided to start building a tiny Python library for creating json-api responses:

https://github.com/kalasjocke/hy

It's built upon an existing serialization library called Schematics, fantastic piece of software by the way, for handling serialization. So everything Hy does is to glue Schematics together with something that creates the actual responses.

What do you think? Is this something worth adding to the project just yet?
