### PR TITLE
DELETE: Added new semantic: resource collection deletion.

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -926,6 +926,16 @@ document's URL.
 DELETE /photos/1
 ```
 
+A server **MAY** choose to support resource collection *deletion*.
+
+An endpoint that supports it **MUST** respond to a `DELETE` request
+to the resource collection URL by removing every document listed as
+a resource by its corresponding `GET` request.
+
+```text
+DELETE /photos
+```
+
 ### 204 Responses
 
 If a server returns a `204 No Content` in response to a `DELETE`


### PR DESCRIPTION
If a client wants to remove every resource in a collection, say `/posts` or `/logs`, there is no current defined semantics for doing a bulk delete.

Of course, the client can make multiple _DELETE_ for each resource in the collection, or even make a DELETE to an URL like `/logs/1,2,3,7,8,9,10`, but those solutions don't work right when one have zillions of items in a collection.

This commit add semantics to _DELETE_ an entire collection by using the collection URL.

Hope you like it.
