### PR TITLE
Rename Python library

### DIFF
--- a/examples/index.md
+++ b/examples/index.md
@@ -46,7 +46,7 @@ has page describing how to emit conformant JSON.
 
 ### Python
 
-* [Hy](https://github.com/kalasjocke/hy) is a library for creating json-api responses.
+* [Hyp](https://github.com/kalasjocke/hyp) is a library for creating json-api responses.
 
 ## Messages
 


### PR DESCRIPTION
I was forced to rename the Hy Python library because of a naming conflict, Hyp is the new name.

This pull request renames and fixes the link in the examples page.
