### PR TITLE
Enabling header links via with_toc_data and bbalter solution

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,3 +15,6 @@ exclude:
 markdown: redcarpet
 pygments: false
 port: 9876
+redcarpet:
+  extensions:
+    - with_toc_data

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,19 +2,22 @@
 <html>
   <head>
     <meta charset="utf-8">
-    
+
     <!-- Always force latest IE rendering engine or request Chrome Frame -->
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
-    
+
     <!-- Use title if it's in the page YAML frontmatter -->
     <title>{{ page..title }}</title>
-    
+
     <link href='http://fonts.googleapis.com/css?family=Titillium+Web:400,600,700,900' rel='stylesheet' type='text/css'>
     <link href="/stylesheets/normalize.css" media="screen" rel="stylesheet" type="text/css" />
     <link href="/stylesheets/highlight.css" media="screen" rel="stylesheet" type="text/css" />
     <link href="/stylesheets/all.css" media="screen" rel="stylesheet" type="text/css" />
+    <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
     <script src="/javascripts/all.js" type="text/javascript"></script>
     <script src="/javascripts/highlight.pack.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+    <script src="/javascripts/header-links.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
   </head>
 

--- a/javascripts/header-links.js
+++ b/javascripts/header-links.js
@@ -1,0 +1,16 @@
+// lovingly adapted from http://ben.balter.com/2014/03/13/pages-anchor-links/
+$(function () {
+  'use strict';
+  return $('h2, h3, h4, h5, h6').each(function (i, el) {
+    var $el, icon, id;
+    $el = $(el);
+    id = $el.attr('id');
+    icon = '<i class="fa fa-link"></i>';
+    if (id) {
+      return $el.append($('<a />')
+        .addClass('header-link')
+        .attr('href', '#' + id)
+        .html(icon));
+    }
+  });
+});

--- a/stylesheets/all.css
+++ b/stylesheets/all.css
@@ -87,3 +87,20 @@ header nav li a {
 
 footer {
   border-top: 5px solid #aba; }
+
+.header-link {
+  opacity: 0;
+
+  -webkit-transition: opacity 0.2s ease-in-out 0.1s;
+  -moz-transition: opacity 0.2s ease-in-out 0.1s;
+  -ms-transition: opacity 0.2s ease-in-out 0.1s;
+  padding-left: 3px;
+}
+
+h2:hover .header-link,
+h3:hover .header-link,
+h4:hover .header-link,
+h5:hover .header-link,
+h6:hover .header-link {
+  opacity: 1;
+}


### PR DESCRIPTION
which is almost OK, but I'm not happy about the crappy anchor names redcarpet assigns.  Overriding this with a custom TOC handler _would_ be possible if this didn't have to be `jekyll --safe` compatible, but that's kinda the deal with github pages.  One option would be to drop the `safe` option, add a li'l plugin to make sluggy anchor ids a la `#singular-resources` and require all compiled resources to be committed :scream_cat:.  Opinions wanted!
