### PR TITLE
Removed mention of a URL-based JSON API

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -721,9 +721,7 @@ document created by the request. It **SHOULD** also include a request body
 describing that document. If absent, the client **SHOULD** treat the
 transmitted document as accepted without modification.
 
-The response body **MAY** include an `href` key in the attributes section. If
-a response body is present and the server is using the URL-based JSON API,
-this `href` attribute is **REQUIRED**. When present, the value of the `href`
+The response body **MAY** include an `href` key in the attributes section. When present, the value of the `href`
 attribute **MUST** match the URI in the `Location` header.
 
 Example:


### PR DESCRIPTION
Remove mention of a URL-based format since the formats were merged.
