### PR TITLE
Minor Update to the FAQ for JSON Schema

### DIFF
--- a/faq/index.md
+++ b/faq/index.md
@@ -54,7 +54,11 @@ is still pending to be included in the standard since is still in
 
 ### Is there a JSON Schema describing JSON API? <a href="#is-there-a-json-schema-describing-json-api" id="is-there-a-json-schema-describing-json-api" class="headerlink">¶</a>
 
-Yes, you can find the JSON Schema definition at http://jsonapi.org/schema.
-Please note that this schema is not a perfect document. Just because a JSON
-document may validate against this schema, that does not necessarily mean it is
-a valid JSON API document. The schema is provided for a base level sanity check.
+Yes, you can find the JSON Schema definition at
+[http://jsonapi.org/schema](http://jsonapi.org/schema). Please note that this
+schema is not a perfect document. Just because a JSON document may validate
+against this schema, that does not necessarily mean it is a valid JSON API
+document. The schema is provided for a base level sanity check.
+
+You can find more information about the JSON Schema format at
+[http://json-schema.org](http://json-schema.org).


### PR DESCRIPTION
The JSON `schema` resource has been linked in the FAQ. In addition, a
single-sentence paragraph has been added that describes where you may
find more information about JSON Schema, as well as a link to the
JSON Schema website.
