### PR TITLE
Update examples to use single objects instead of arrays

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -380,13 +380,13 @@ Here's another example:
   "links": {
     "posts.comments": "http://example.com/comments/{posts.comments}"
   },
-  "posts": [{
+  "posts": {
     "id": "1",
     "title": "Rails is Omakase",
     "links": {
       "comments": [ "1", "2", "3", "4" ]
     }
-  }]
+  }
 }
 ```
 

--- a/index.md
+++ b/index.md
@@ -29,14 +29,14 @@ Here's an example response from JSON API:
       "type": "comments"
     }
   },
-  "posts": [{
+  "posts": {
     "id": "1",
     "title": "Rails is Omakase",
     "links": {
       "author": "9",
       "comments": [ "5", "12", "17", "20" ]
     }
-  }]
+  }
 }
 ```
 


### PR DESCRIPTION
This replaces arrays with a single object as defined in https://github.com/json-api/json-api/pull/237

I'm not sure, but on the front page it might look better to leave the array and add a second post.. 
