### PR TITLE
Simplify the language around the Location header on create

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -825,7 +825,7 @@ When one or more resources has been created, the server **MUST** return a `201
 Created` status code.
 
 The response **MUST** include a `Location` header identifying the location of
-all resources created by the request.
+_all_ resources created by the request.
 
 If a single resource is created and that resource's object includes an `href`
 key, the `Location` URL **MUST** match the `href` value.

--- a/format/index.md
+++ b/format/index.md
@@ -825,13 +825,10 @@ When one or more resources has been created, the server **MUST** return a `201
 Created` status code.
 
 The response **MUST** include a `Location` header identifying the location of
-the primary resource created by the request.
+all resources created by the request.
 
 If a single resource is created and that resource's object includes an `href`
 key, the `Location` URL **MUST** match the `href` value.
-
-If more than one resource is created, the `Location` URL **MUST** locate all 
-created resources.
 
 The response **SHOULD** also include a document that contains the primary
 resource(s) created. If absent, the client **SHOULD** treat the transmitted


### PR DESCRIPTION
Before, there was a paragraph aimed at the case of a single resource being created and a separate one aimed at the case of a collection of resources being created. I merged these into one statement, which simply says the Location URL must locate _all_ created resources.

If, to be super explicit, you want to keep this as two separate paragraphs, then the paragraph that's talking about the one resource case should start with the clause "If a single resource is created, ". (Otherwise, its mention of a "primary resource is confusing and arguably contradictory.)
