### PR TITLE
Change 204 response from MUST to MAY

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -1074,7 +1074,7 @@ DELETE /articles/1/links/tags/1,2
 
 #### 204 No Content <a href="#crud-updating-responses-204" id="crud-updating-responses-204" class="headerlink"></a>
 
-A server **MUST** return a `204 No Content` status code if an update is
+A server **SHOULD** return a `204 No Content` status code if an update is
 successful and the client's current attributes remain up to date. This applies
 to `PUT` requests as well as `POST` and `DELETE` requests that modify links
 without affecting other attributes of a resource.


### PR DESCRIPTION
Currently the spec states that you must return a 204 if an update is successful without affecting other attributes on the resource.

But if the update triggers changes to other attributes it should return a 200.

This seems overly strict and makes the implementation complex.

For simplicity we would like to always return a 200 with the full resource and not have to implement logic to figure if a there were other attributes updated by the server.

A 204 makes more sense when you replace the entire resource, but less sense when you can do partial updates.

Because it's so subtle it would be hard to rely on the current requirement for consistent behaviour across implementations.
