### PR TITLE
Clarify updating of relationships

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -1074,7 +1074,7 @@ DELETE /articles/1/links/tags/1,2
 
 #### 204 No Content <a href="#crud-updating-responses-204" id="crud-updating-responses-204" class="headerlink"></a>
 
-A server **MUST** return a `204 No Content` status code if an update is
+A server **SHOULD** return a `204 No Content` status code if an update is
 successful and the client's current attributes remain up to date. This applies
 to `PUT` requests as well as `POST` and `DELETE` requests that modify links
 without affecting other attributes of a resource.

--- a/format/index.md
+++ b/format/index.md
@@ -8,18 +8,18 @@ title: "Format"
 ## Introduction <a href="#introduction" id="introduction" class="headerlink"></a>
 
 JSON API is a specification for how a client should request that resources be
-fetched or modified and how a server should respond to those requests. 
+fetched or modified and how a server should respond to those requests.
 
 JSON API is designed to minimize both the number of requests and the amount of
 data transmitted between clients and servers. This efficiency is achieved
 without compromising readability, flexibility, and discoverability.
 
 JSON API requires use of the JSON API media type
-([`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json)) 
+([`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json))
 for exchanging data.
 
-A JSON API server supports fetching of resources through the HTTP method GET. 
-In order to support creating, updating and deleting resources, it must support 
+A JSON API server supports fetching of resources through the HTTP method GET.
+In order to support creating, updating and deleting resources, it must support
 use of the HTTP methods POST, PUT and DELETE, respectively.
 
 A JSON API server may also optionally support modification of resources with
@@ -364,7 +364,7 @@ value. For example, the following post has no comments:
 
 ### Collection Objects <a href="#document-structure-collection-objects" id="document-structure-collection-objects" class="headerlink"></a>
 
-A "collection object" contains one or more of the members: 
+A "collection object" contains one or more of the members:
 
 * `"ids"` - an array of IDs for the referenced resources.
 * `"type"` - the resource type.
@@ -642,7 +642,7 @@ A server **MUST** represent "to-one" relationships as individual resources and
 A resource, or collection of resources, can be fetched by sending a `GET`
 request to the URL described above.
 
-Responses can be further refined with the optional features described below. 
+Responses can be further refined with the optional features described below.
 
 ### Filtering <a href="#fetching-filtering" id="fetching-filtering" class="headerlink"></a>
 
@@ -729,7 +729,7 @@ An endpoint **SHOULD** return a default set of fields in a resource object if no
 fields have been specified for its type, or if the endpoint does not support use
 of either `fields` or `fields[TYPE]`.
 
-An endpoint **MAY** also choose to always return a limited set of 
+An endpoint **MAY** also choose to always return a limited set of
 non-specified fields, such as `id` or `href`.
 
 Note: `fields` and `fields[TYPE]` can not be mixed. If the latter format is
@@ -891,7 +891,7 @@ Servers **MAY** use other HTTP error codes to represent errors.  Clients
 #### Client-Generated IDs <a href="#crud-creating-client-ids" id="crud-creating-client-ids" class="headerlink"></a>
 
 A server **MAY** accept client-generated IDs along with requests to create one
-or more resources. IDs **MUST** be specified with an `"id"` key, the value of 
+or more resources. IDs **MUST** be specified with an `"id"` key, the value of
 which **MUST** be a properly generated and formatted *UUID*.
 
 For example:
@@ -1227,9 +1227,9 @@ Content-Type: application/json-patch+json
 Accept: application/json
 
 [
-  { 
-    "op": "add", 
-    "path": "/-", 
+  {
+    "op": "add",
+    "path": "/-",
     "value": {
       "title": "Ember Hamster",
       "src": "http://example.com/images/productivity.png"
@@ -1400,17 +1400,17 @@ Content-Type: application/json-patch+json
 Accept: application/json
 
 [
-  { 
-    "op": "add", 
-    "path": "/-", 
+  {
+    "op": "add",
+    "path": "/-",
     "value": {
       "title": "Ember Hamster",
       "src": "http://example.com/images/productivity.png"
     }
   },
-  { 
-    "op": "add", 
-    "path": "/-", 
+  {
+    "op": "add",
+    "path": "/-",
     "value": {
       "title": "Mustaches on a Stick",
       "src": "http://example.com/images/mustaches.png"


### PR DESCRIPTION
This PR makes the following improvements to the consistency and correctness of updating relationships:
- A `PUT` request should be allowed to the URL of a to-one relationship
- A `POST` request sent to a to-one relationship URL that already contains a relationship should fail
- A `DELETE` request sent to a to-one relationship URL that doesn't contain a relationship should fail
- A single resource ID (or an array of IDs, as previously stated) can be POSTed to a to-many relationship URL
- 404 and 409 error responses 

Essentially, this establishes `PUT` as the safe way to replace a to-one relationship. `POST` and `DELETE` should only be used to verify expectations of the current value of a relationship.

In addition, I've pulled in the MUST -> SHOULD change from @harrison in #263 since it is compatible with these changes. There's also some whitespace cleanup in a separate commit.

One point of possible debate here is whether `409 Conflict` should be returned when POSTing a relationship that already exists. It seems like the most appropriate status code to me, but maybe @steveklabnik wants to weigh in :)
