### PR TITLE
Add Json-API package

### DIFF
--- a/examples/index.md
+++ b/examples/index.md
@@ -37,7 +37,7 @@ implementations. There is a [custom adapter](https://github.com/daliwali/ember-j
 
 ### Node.js <a href="#server-node-js" id="server-node-js" class="headerlink"></a>
 * [Fortune.js](http://fortunejs.com) is a framework built to implement json-api.
-* [json-api](https://www.npmjs.org/package/json-api) turns an Express + Mongoose app into a JSON-API server. (This package is largely undocumented, but far more compliant than Fortune.js.)
+* [json-api](https://www.npmjs.org/package/json-api) turns an Express + Mongoose app into a JSON-API server.
 
 ### Ruby <a href="#server-ruby" id="server-ruby" class="headerlink"></a>
 

--- a/examples/index.md
+++ b/examples/index.md
@@ -36,8 +36,8 @@ implementations. There is a [custom adapter](https://github.com/daliwali/ember-j
 * [FriendsOfSymfony / FOSRestBundle](https://github.com/FriendsOfSymfony/FOSRestBundle/issues/452)
 
 ### Node.js <a href="#server-node-js" id="server-node-js" class="headerlink"></a>
-
 * [Fortune.js](http://fortunejs.com) is a framework built to implement json-api.
+* [json-api](https://www.npmjs.org/package/json-api) turns an Express + Mongoose app into a JSON-API server. (This package is largely undocumented, but far more compliant than Fortune.js.)
 
 ### Ruby <a href="#server-ruby" id="server-ruby" class="headerlink"></a>
 


### PR DESCRIPTION
Like I mentioned in the text, the linked package, which I wrote, is largely undocumented and doesn't have test cases (i know, i know...). Still, it's the most complete and compliant server side js implementation I know of, so I think it should be included.
