### PR TITLE
Prefixed filter queries are easier to parse

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -652,17 +652,20 @@ specific criteria.
 Filtering **SHOULD** be supported by appending parameters to the base URL for
 the collection of resources to be filtered.
 
+The filter fields **SHOULD** be wrapped in parentheses and prepended by the 
+filter keyword, for example: `filter[age]=23`
+
 For example, the following is a request for all comments associated with a
 particular post:
 
 ```text
-GET /comments?post=1
+GET /comments?filter[post]=1
 ```
 
 With this approach, multiple filters **MAY** be applied to a single request:
 
 ```text
-GET /comments?post=1&author=12
+GET /comments?filter[post]=1&filter[author]=12
 ```
 
 This specification only supports filtering based upon strict matching.


### PR DESCRIPTION
So I'm implementing the filter mechanic and I realized the annoyance I would have to go through in order to make it work.

In simple use cases the filtering mechanic is arguably simple to parse:

```
GET /comments?post=1
```

``` ruby
Comment.where(post: params["post"])
```

However scaling this to both multiple endpoints and with multiple includes becomes...cumbersome:

```
GET /profiles?account=1&age=23&visible=true&include=posts,comments&fields=id
```

``` ruby
models = Profile.where(account: params["account"], age: params["age"], visible: params["visible"]).includes(params["includes"].split(","))
models.map(&:to_hash).map { |hash| hash.slice(params["fields"].split(",")) }
```

The natural inclination is to mimic the other areas as demonstrated above, but it's not practical to parse. I propose with this pull request that we mimic the already established way of doing complex filters:

```
GET /profiles?filter[account]=1&filter[age]=23&filter[visible]=true&include=posts,comments&fields=id
```

``` ruby
models = Profile.where(params["filter"]).includes(params["includes"].split(","))
models.map(&:to_hash).map { |hash| hash.slice(params["fields"].split(",")) }
```
