### PR TITLE
Properly remove the whole resource in PATCH.

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -1348,7 +1348,7 @@ PATCH /article/1/links/author
 Content-Type: application/json-patch+json
 
 [
-  { "op": "remove", "path": "/" }
+  { "op": "remove", "path": "" }
 ]
 ```
 


### PR DESCRIPTION
Per [RFC 6901](https://tools.ietf.org/html/rfc6901), `path: "/"` would be a command to remove a key `""` from the object, whereas `path: ""` would remove the whole object. Assuming I'm reading that spec correctly.
