### PR TITLE
These are members, shouldn't be plural

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -86,7 +86,7 @@ The following post is represented as a resource object:
 
 ```javascript
 {
-  "posts": {
+  "post": {
     "id": "1",
     // ... attributes of this post
   }
@@ -97,7 +97,7 @@ This post is represented simply by its ID:
 
 ```javascript
 {
-  "posts": "1"
+  "post": "1"
 }
 ```
 

--- a/format/index.md
+++ b/format/index.md
@@ -149,7 +149,7 @@ Here's how a post (i.e. a resource of type "posts") might appear in a document:
 
 ```javascript
 {
-  "posts": {
+  "post": {
     "id": "1",
     "title": "Rails is Omakase"
   }


### PR DESCRIPTION
Our example shows a single entity and not a list, and per the
spec it should be a singular object key.
