### PR TITLE
Add Yaks to the list of Ruby server side examples

### DIFF
--- a/examples/index.md
+++ b/examples/index.md
@@ -57,6 +57,8 @@ has a page describing how to emit conformant JSON.
 
 * [JSONAPI::Resources](https://github.com/cerebris/jsonapi-resources) provides a complete framework for developing a JSON API server. It is designed to work with Rails, and provides routes, controllers, and serializers.
 
+* [Yaks](https://github.com/plexus/yaks) Library for building hypermedia APIs, contains a JSON API output format.
+
 ### Python <a href="#server-python" id="server-python" class="headerlink"></a>
 
 * [Hyp](https://github.com/kalasjocke/hyp) is a library for creating json-api responses.


### PR DESCRIPTION
Yaks has been able to do JSON API for over a year now. Would be great if it could be added to the list!

https://github.com/plexus/yaks
