### PR TITLE
Fix a duplicated ID

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -516,7 +516,7 @@ resource objects by the client.
       "author": "9",
       "comments": [ "4", "5" ]
    }}, {
-    "id": "1",
+    "id": "3",
     "title": "Dependency Injection is Not a Virtue",
     "links": {
       "author": "9",


### PR DESCRIPTION
The primary resource `posts` had two entities with an ID equal to `1`.
