### PR TITLE
Relaxing the definition of what Client-Generated IDs can be.

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -892,7 +892,7 @@ Servers **MAY** use other HTTP error codes to represent errors.  Clients
 
 A server **MAY** accept client-generated IDs along with requests to create one
 or more resources. IDs **MUST** be specified with an `"id"` key, the value of
-which **MUST** be a properly generated and formatted *UUID*.
+which **MAY** be a properly generated and formatted *UUID*.
 
 For example:
 


### PR DESCRIPTION
Hi,

In the current version of the jsonapi format document, the server can craft all sorts of ids as long as they are strings, with alphanum chars, underscores and dashes. However the client generated id are limited to UUIDs. Why is that? 

My opinion is that the client should be allowed to define an arbitrary id, as well as granting the server the right and responsibility to either grant or deny the creation of a given resource with the client-supplied id.

By doing so,
If the user wants to POST the resource with "id" :"2", well I guess it should be possible. Weather the resource is actually created or not, well this is up to the server to determine.

My suggestion: when defining id's, provide the same semantic flexibility both for client- and server- crafted id's
