### PR TITLE
Introduce `supported-ext` media type parameter.

### DIFF
--- a/extensions/bulk/index.md
+++ b/extensions/bulk/index.md
@@ -10,7 +10,7 @@ extension](/extensions/#official-extensions) of the JSON API specification.
 It provides support for performing multiple operations in a request,
 including adding and removing multiple resources.
 
-Servers **SHOULD** indicate support for the Bulk extension by including the
+Servers **MUST** indicate support for the Bulk extension by including the
 the media type query parameter `supported-ext=bulk` in the `Content-Type`
 header of every response. For example: `Content-Type:
 application/vnd.api+json; supported-ext=bulk`.

--- a/extensions/bulk/index.md
+++ b/extensions/bulk/index.md
@@ -10,9 +10,15 @@ extension](/extensions/#official-extensions) of the JSON API specification.
 It provides support for performing multiple operations in a request,
 including adding and removing multiple resources.
 
-Servers **SHOULD** indicate support for the JSON API media type's Bulk
-extension by including the header `Content-Type: application/vnd.api+json;
-ext=bulk` in every response.
+Servers **SHOULD** indicate support for the Bulk extension by including the
+the media type query parameter `supported-ext=bulk` in the `Content-Type`
+header of every response. For example: `Content-Type:
+application/vnd.api+json; supported-ext=bulk`.
+
+Servers **MUST** indicate that a response is formatted using the Bulk
+extension by including the the media type query parameter `ext=bulk` in the
+`Content-Type` header. For example: `Content-Type: application/vnd.api+json;
+ext=bulk; supported-ext=bulk,patch`.
 
 Clients **MAY** request the JSON API media type's Bulk extension by
 specifying the header `Accept: application/vnd.api+json; ext=bulk`. Servers

--- a/extensions/patch/index.md
+++ b/extensions/patch/index.md
@@ -14,7 +14,7 @@ It provides support for modification of resources with the HTTP PATCH method
 For the sake of brevity, operatons requested with `PATCH` and conforming
 with JSON Patch will be called "Patch operations".
 
-Servers **SHOULD** indicate support for the Patch extension by including the
+Servers **MUST** indicate support for the Patch extension by including the
 the media type query parameter `supported-ext=patch` in the `Content-Type`
 header of every response. For example: `Content-Type:
 application/vnd.api+json; supported-ext=patch`.

--- a/extensions/patch/index.md
+++ b/extensions/patch/index.md
@@ -14,9 +14,15 @@ It provides support for modification of resources with the HTTP PATCH method
 For the sake of brevity, operatons requested with `PATCH` and conforming
 with JSON Patch will be called "Patch operations".
 
-Servers **SHOULD** indicate support for the JSON API media type's Patch
-extension by including the header `Content-Type: application/vnd.api+json;
-ext=patch` in every response.
+Servers **SHOULD** indicate support for the Patch extension by including the
+the media type query parameter `supported-ext=patch` in the `Content-Type`
+header of every response. For example: `Content-Type:
+application/vnd.api+json; supported-ext=patch`.
+
+Servers **MUST** indicate that a response is formatted using the Patch
+extension by including the the media type query parameter `ext=patch` in the
+`Content-Type` header. For example: `Content-Type: application/vnd.api+json;
+ext=patch; supported-ext=bulk,patch`.
 
 Clients **MAY** request the JSON API media type's Patch extension by
 specifying the header `Accept: application/vnd.api+json; ext=patch`. Servers

--- a/format/index.md
+++ b/format/index.md
@@ -30,7 +30,7 @@ interpreted as described in RFC 2119
 The base JSON API specification **MAY** be extended to support additional
 capabilities.
 
-Servers that support one or more extensions to JSON API **SHOULD** return
+Servers that support one or more extensions to JSON API **MUST** return
 those extensions in every response in the `supported-ext` media type
 parameter of the `Content-Type` header. The value of the `supported-ext`
 parameter **MUST** be a comma-separated (U+002C COMMA, ",") list of

--- a/format/index.md
+++ b/format/index.md
@@ -31,13 +31,23 @@ The base JSON API specification **MAY** be extended to support additional
 capabilities.
 
 Servers that support one or more extensions to JSON API **SHOULD** return
-those extensions in every response in the `ext` media type parameter of the
-`Content-Type` header. The value of the `ext` parameter **MUST** be a
-comma-separated (U+002C COMMA, ",") list of extension names.
+those extensions in every response in the `supported-ext` media type
+parameter of the `Content-Type` header. The value of the `supported-ext`
+parameter **MUST** be a comma-separated (U+002C COMMA, ",") list of
+extension names.
 
 For example: a response that includes the header `Content-Type:
-application/vnd.api+json; ext=bulk,patch` indicates that the server supports
-both the "bulk" and "patch" extensions.
+application/vnd.api+json; supported-ext=bulk,patch` indicates that the
+server supports both the "bulk" and "patch" extensions.
+
+If an extension is used to form a particular request or response document,
+then it **MUST** be specified by including its name in the `ext` media type
+parameter with the `Content-Type` header. The `ext` media type parameter
+**MUST NOT** include more than one extension name.
+
+For example: a response that includes the header `Content-Type:
+application/vnd.api+json; ext=patch; supported-ext=bulk,patch` indicates
+that the document is formatted according to the "patch" extension.
 
 Clients **MAY** request a particular media type extension by including its
 name in the `ext` media type parameter with the `Accept` header. Servers


### PR DESCRIPTION
The `supported-ext` media type parameter is used by servers to indicate support for one or more media type extensions. The actual media type extension used in a particular document is still specified with the `ext` media type parameter.

This allows servers to clearly indicate support for multiple media type extensions AND specify the particular extension used to format a document.
