### PR TITLE
explicitly state type member is required in update

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -565,19 +565,19 @@ include media type extensions relevant to the request.
 A request **MUST** completely succeed or fail (in a single "transaction"). No
 partial updates are allowed.
 
+The `type` member is required in every resource object throughout requests and
+responses in JSON API. There are some cases, such as when `POST`ing to an
+endpoint representing heterogenous data, when the `type` could not be inferred
+from the endpoint. However, picking and choosing when it is required would be
+confusing; it would be hard to remember when it was required and when it was
+not. Therefore, to improve consistency and minimize confusion, `type` is
+always required.
+
 ### Creating Resources <a href="#crud-creating" id="crud-creating" class="headerlink"></a>
 
 A resource can be created by sending a `POST` request to a URL that represents
 a collection of resources. The request **MUST** include a single resource object
 as primary data. The resource object **MUST** contain at least a `type` member.
-
-> Note: The `type` member is required throughout requests and responses in
-JSON API. There are some cases, such as when `POST`ing to an endpoint
-representing heterogenous data, when the `type` could not be inferred from
-the endpoint. However, picking and choosing when it is required would be
-confusing; it would be hard to remember when it was required and when it was
-not. Therefore, to improve consistency and minimize confusion, `type` is
-always required.
 
 For instance, a new photo might be created with the following request:
 
@@ -708,6 +708,7 @@ The URL for a resource can be obtained:
 * for a *data object*, the original URL that was used to `GET` the document
 
 The `PUT` request **MUST** include a single resource object as primary data.
+The resource object **MUST** contain a `type` member.
 
 For example:
 


### PR DESCRIPTION
- Note explaining type is always required was only under 'Creating Resources'
  - Move note to general CRUD section introduction
  - Remove blockquote formatting, so it is more visible
- type member was explicitly required in 'Creating Resources,' not 'Updating Resources'
  - Explicitly called it out in 'Updating Resources'
  - Did _not_ call it out in any relationship updating sections

Feel free to tweak this PR. Mainly a convenient way of pointing out the issue locations.
