### PR TITLE
provide accordance for viewing api in a browser

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -401,6 +401,10 @@ JSON API requests **MUST** include an `Accept` header specifying the JSON
 API media type. Servers **MUST** return a `406 Not Acceptable` status code
 if this header is missing or specifies an unsupported media type.
 
+> Note: Servers may support multiple media types at any endpoint. For example,
+a server may choose to support `text/html` in order to simplify viewing content
+via a web browser.
+
 Responses can be further refined with the optional features described below.
 
 ### Inclusion of Linked Resources <a href="#fetching-includes" id="fetching-includes" class="headerlink"></a>


### PR DESCRIPTION
I'm open to any derivation of this clause that allows a user to view json-api documents in a standard browser without modification. This addresses issue #358.
