### PR TITLE
Specify what extensions are allowed to do

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -30,6 +30,10 @@ interpreted as described in RFC 2119
 The base JSON API specification **MAY** be extended to support additional
 capabilities.
 
+An extension **MAY** make changes to and deviate from the requirements of the
+base specification, including clauses using the key words "MUST" and "MUST NOT",
+apart from this section, which remains binding.
+
 Servers that support one or more extensions to JSON API **SHOULD** return
 those extensions in every response in the `ext` media type parameter of the
 `Content-Type` header. The value of the `ext` parameter **MUST** be a
@@ -43,6 +47,10 @@ Clients **MAY** request a particular media type extension by including its
 name in the `ext` media type parameter with the `Accept` header. Servers
 that do not support a requested extension **MUST** return a `415 Unsupported
 Media Type` status code.  
+
+Servers **MUST NOT** provide extended functionality that is incompatible with the
+base specification to clients that do not request the extension in the `ext`
+parameter of the `Content-Type` or the `Accept` header.
 
 ## Document Structure <a href="#document-structure" id="document-structure" class="headerlink"></a>
 


### PR DESCRIPTION
Adds two paragraphs to the _Extending_ section:
- Clarify that extensions may do whatever they want.
- Make extension negotiation mandatory to prevent an extension-unaware client from triggering extended functionality on the server. I noticed PR #353 adds:
  
  > If an extension is used to form a particular request or response document [...]
  
  But this seems to leave out operations that do not produce a document.

Btw, the _Extending_ section is not something that needs to be explained in detail right away. Perhaps it would be better placed at the end of the document. The intro section could include the blurb "The base JSON API specification may be extended to support additional capabilities" with a link to the details.

**EDIT:**

Amended the commit and changed

> [...] clients that do not indicate support for the extension in the `Content-Type` or the `Accept` header.

to

> [...] clients that do not request the extension in the `ext` parameter of the `Content-Type` or the `Accept` header.

because PR #353 decouples indicating support from actually wanting to use the extension.
