### PR TITLE
unify id and ids

### DIFF
--- a/extensions/bulk/index.md
+++ b/extensions/bulk/index.md
@@ -89,7 +89,7 @@ Multiple resources can be deleted by sending a `DELETE` request to a URL that
 represents a collection of resources to which they all belong.
 
 The body of the request **MUST** contain a `data` member whose value is an
-object that contains `type` and `ids`, or an array of objects that each
+object that contains `type` and `id`, or an array of objects that each
 contain a `type` and `id`.
 
 For example:
@@ -100,6 +100,6 @@ Content-Type: application/vnd.api+json; ext=bulk
 Accept: application/vnd.api+json; ext=bulk
 
 {
-  "data": { "type": "articles", "ids": ["1", "2"] }
+  "data": { "type": "articles", "id": ["1", "2"] }
 }
 ```

--- a/extensions/patch/index.md
+++ b/extensions/patch/index.md
@@ -138,7 +138,7 @@ A server **MUST** respond to Patch operations that target a *to-many
 relationship URL* as described below.
 
 For all operations, the `"value"` **MUST** contain an object that contains
-`type` and `ids` members, or an array of objects that each contain `type`
+`type` and `id` members, or an array of objects that each contain `type`
 and `id` members.
 
 If a client requests a `"replace"` operation to a *to-many relationship URL*, the
@@ -155,7 +155,7 @@ Content-Type: application/vnd.api+json; ext=patch
 Accept: application/vnd.api+json; ext=patch
 
 [
-  { "op": "replace", "path": "", "value": {"type": "tags", "ids": ["2", "3"]} }
+  { "op": "replace", "path": "", "value": {"type": "tags", "id": ["2", "3"]} }
 ]
 ```
 
@@ -172,7 +172,7 @@ Content-Type: application/vnd.api+json; ext=patch
 Accept: application/vnd.api+json; ext=patch
 
 [
-  { "op": "add", "path": "/-", "value": { "type": "comments", "ids": ["123"] } }
+  { "op": "add", "path": "/-", "value": { "type": "comments", "id": ["123"] } }
 ]
 ```
 
@@ -188,7 +188,7 @@ Content-Type: application/vnd.api+json; ext=patch
 Accept: application/vnd.api+json; ext=patch
 
 [
-  { "op": "remove", "path": "", "value": {"type": "comments", "ids": ["5", "13"]} }
+  { "op": "remove", "path": "", "value": {"type": "comments", "id": ["5", "13"]} }
 ]
 ```
 

--- a/format/index.md
+++ b/format/index.md
@@ -221,8 +221,8 @@ one of the following:
   relationship URLs. Linkage **MUST** be expressed as:
   * `type` and `id` members for to-one relationships. `type` is not required
     if the value of `id` is `null`.
-  * `type` and `ids` members for homogeneous to-many relationships. `type` is
-    not required if the value of `ids` is an empty array (`[]`).
+  * `type` and `id` members for homogeneous to-many relationships. `type` is
+    not required if the value of `id` is an empty array (`[]`).
   * A `data` member whose value is an array of objects each containing `type`
     and `id` members for heterogeneous to-many relationships.
 * A `"meta"` member that contains non-standard meta-information about the
@@ -316,7 +316,7 @@ A complete example document with multiple included relationships:
         "self": "http://example.com/articles/1/links/comments",
         "resource": "http://example.com/articles/1/comments",
         "type": "comments",
-        "ids": ["5", "12"]
+        "id": ["5", "12"]
       }
     }
   }],
@@ -798,8 +798,8 @@ Accept: application/vnd.api+json
 If a to-many relationship is included in the `links` section of a resource
 object, it **MUST** be an object containing:
 
-* `type` and `ids` members for homogeneous to-many relationships; to clear the
-  relationship, set the `ids` member to `[]`
+* `type` and `id` members for homogeneous to-many relationships; to clear the
+  relationship, set the `id` member to `[]`
 * a `data` member whose value is an array of objects each containing `type` and
   `id` members for heterogeneous to-many relationships; to clear the
   relationship, set the `data` member to `[]`
@@ -818,7 +818,7 @@ Accept: application/vnd.api+json
     "id": "1",
     "title": "Rails is a Melting Pot",
     "links": {
-      "tags": { "type": "tags", "ids": ["2", "3"] }
+      "tags": { "type": "tags", "id": ["2", "3"] }
     }
   }
 }
@@ -943,7 +943,7 @@ A server **MUST** respond to `PUT`, `POST`, and `DELETE` requests to a *to-many
 relationship URL* as described below.
 
 For all request types, the body **MUST** contain a `data` member whose value
-is an object that contains `type` and `ids` members, or an array of objects
+is an object that contains `type` and `id` members, or an array of objects
 that each contain `type` and `id` members.
 
 If a client makes a `PUT` request to a *to-many relationship URL*, the
@@ -960,7 +960,7 @@ Content-Type: application/vnd.api+json
 Accept: application/vnd.api+json
 
 {
-  "data": { "type": "tags", "ids": ["2", "3"] }
+  "data": { "type": "tags", "id": ["2", "3"] }
 }
 ```
 
@@ -990,7 +990,7 @@ Content-Type: application/vnd.api+json
 Accept: application/vnd.api+json
 
 {
-  "data": { "type": "comments", "ids": ["123"] }
+  "data": { "type": "comments", "id": ["123"] }
 }
 ```
 
@@ -1014,7 +1014,7 @@ Content-Type: application/vnd.api+json
 Accept: application/vnd.api+json
 
 {
-  "data": { "type": "comments", "ids": ["12", "13"] }
+  "data": { "type": "comments", "id": ["12", "13"] }
 }
 ```
 

--- a/index.md
+++ b/index.md
@@ -40,7 +40,7 @@ Here's an example response from a blog that implements JSON API:
         "self": "http://example.com/posts/1/links/comments",
         "resource": "http://example.com/posts/1/comments",
         "type": "comments",
-        "ids": ["5", "12"]
+        "id": ["5", "12"]
       }
     }
   }],


### PR DESCRIPTION
This distinction is unnecessary. Checking if `id` is a string, an
array or null is trivial for clients.
