### PR TITLE
Specify top-level `linked` must be exhaustive

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -293,7 +293,7 @@ To reduce the number of HTTP requests, servers **MAY** allow responses that
 include linked resources along with the requested primary resources. Such
 responses are called "compound documents".
 
-In a compound document, linked resources **MUST** be included as an array of
+In a compound document, all linked resources **MUST** be included as an array of
 resource objects in a top level `"linked"` member.
 
 A complete example document with multiple included relationships:


### PR DESCRIPTION
Minor grammatical change to call out that top-level `linked` array has to include a full list of included resource objects and not a partial list.

After clarifying with @dgeb and @steveklabnik, the top-level `linked` array must be an exhaustive list of resources to be a valid payload.

This means something like this is not valid JSONAPI response:

```
{
  'data': [
    {
       'id': 'foo',
       'type': 'posts',
       'name': 'my first post',
       'links' : {
         'comments' : {
             'id': ['1', '2', '3', '4'],
             'type': 'comments'
          }
       }
    }
  ],
  'linked': [
    {
       'id': '1',
       'type': 'comments',
       'reply': 'this was a good article',
       'links' : {
         'self' : 'http://localhost/comments/1'
       }
    }
  ]
}
```

---

May seem obvious, but the previous JSONAPI spec did not enforce linked being an exhaustive list so its worth calling out a bit more.
