### PR TITLE
Prescribe primary data format: object for singular, array for collection

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -83,6 +83,11 @@ objects, or a value representing a resource relationship.
 }
 ```
 
+A logical collection of resources (e.g., the target of a to-many relationship)
+**MUST** be represented as an array, even if it only contains one item.
+A logically singular resource (e.g., the target of a to-one relationship)
+**MUST** be represented as a single resource object.
+
 Error objects **MUST** appear under a top-level key named `"errors"`.
 
 A document's top level **MAY** also have the following members:


### PR DESCRIPTION
Currently, it's not possible for a generic client to look at a response and reliably figure out if the server is exposing a singular resource that can be manipulated via PUT or a collection that can be appended to via POST (short of attempting the operation, of course).

This PR adds a paragraph specifying that the representation (single object vs. array) must reflect the nature of the endpoint.

Specifically, the new clauses preclude
- representing a logically singular resource as an object wrapped in an array
- representing a collection with a length of 1 as an individual object.

A related issue is #249. Some applications might want to provide this information (to-one vs. to-many) directly in a link object. While this PR alleviates the issue somewhat, a client still needs to perform a dummy request for the resource(s) to get the info.
