### PR TITLE
Remove language that associates ID-based linking with compound documents

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -217,10 +217,8 @@ one of the following:
   relationship. For example, it would allow a client to remove an `author` from
   an `article` without deleting the `people` resource itself.
 * A `resource` member, whose value is a related resource URL (as defined above).
-* Linkage to other resource objects ("object linkage") included in a compound
-  document. This allows a client to link together all of the resource objects
-  included in a compound document without having to `GET` one of the
-  relationship URLs. Linkage **MUST** be expressed as:
+* Linkage to other resources based on their identifying `id` and `type` members
+  ("resource linkage"). Linkage **MUST** be expressed as:
   * `type` and `id` members for to-one relationships. `type` is not required
     if the value of `id` is `null`.
   * `type` and `id` members for homogeneous to-many relationships. `type` is
@@ -234,7 +232,9 @@ A link object that represents a to-many relationship **MAY** also contain
 pagination links, as described below.
 
 If a link object refers to resource objects included in the same compound
-document, it **MUST** include object linkage to those resource objects.
+document, it **MUST** include resource linkage to those resource objects.
+This allows a client to link together all of the included resource objects
+without having to `GET` one of the relationship URLs.
 
 For example, the following article is associated with an `author` and `comments`:
 


### PR DESCRIPTION
RC2 introduced the concept of _object linkage_. Link objects of the (ID, type) variety are now explicitly tied to compound documents only.

This ignores another obvious use case for ID-based linking: the construction of canonical URLs.

Given a link object

```
"author": {
  "type": "people",
  "id": "9"
}
```

an application-specific client could determine that the resource is available at `http://example.com/people/9`.

It's pretty clear that applications are going to do this, so it would be wise to at least recognize the possibility, hence this PR.

With link templates, such URL construction would be possible for generic clients as well. Link templates were removed with the advent of heterogeneous collections, but that was throwing the baby out with the bathwater. For _canonical URLs_ they are still perfectly possible, keyed by type instead of association name. This, however, is a discussion to be had in a separate issue, and it can happen post-1.0.
