### PR TITLE
Clarify that `fields` only affects attributes and relationships

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -114,7 +114,7 @@ Here's how an article (i.e. a resource of type "articles") might appear in a doc
 // ...
 ```
 
-#### Resource Attributes <a href="#document-structure-resource-object-attributes" id="document-structure-resource-object-attributes" class="headerlink"></a>
+#### Resource Objects <a href="#document-structure-resource-objects" id="document-structure-resource-objects" class="headerlink"></a>
 
 A resource object **MUST** contain at least the following top-level members:
 
@@ -456,16 +456,23 @@ GET /articles/1?include=author,comments,comments.author
 
 ### Sparse Fieldsets <a href="#fetching-sparse-fieldsets" id="fetching-sparse-fieldsets" class="headerlink"></a>
 
-A client **MAY** request that an endpoint return only specific fields in the
-response on a per-type basis by including a `fields[TYPE]` parameter. The
-value of the parameter refers to an attribute name or a relationship name.
+A client **MAY** request that an endpoint return only specific fields in the 
+response on a per-type basis by including a `fields[TYPE]` parameter. The 
+value of the parameter refers to the names(s) of the attributes and 
+relationships to be returned.
 
 ```text
-GET /articles?include=author&fields[articles]=id,title&fields[people]=id,name
+GET /articles?include=author&fields[articles]=title,body&fields[people]=name
 ```
 
-If a client requests a restricted set of fields, an endpoint **MUST NOT** include other
-fields in the response.
+If a client requests a restricted set of fields, an endpoint **MUST NOT** 
+include additional attributes or relationships in the response.
+
+Resource object members that are not attributes or relationships are subject
+to the rules stated in the [Resource Objects](#document-structure-resource-objects)
+section. In particular, the `type` and `id` members **MUST** always be included 
+in each resource object, even if they are not specified in the `fields[TYPE]` 
+parameter.
 
 ### Sorting <a href="#fetching-sorting" id="fetching-sorting" class="headerlink"></a>
 

--- a/format/index.md
+++ b/format/index.md
@@ -102,6 +102,18 @@ The top level of a document **MUST NOT** contain any additional members.
 "Resource objects" appear in a JSON API document to represent primary data
 and linked resources.
 
+A resource object **MUST** contain at least the following top-level members:
+
+* `"id"`
+* `"type"`
+
+In addition, a resource object **MAY** contain any of these top-level members:
+
+* `"links"`: information about a resource's relationships (described
+  below).
+* `"meta"`: non-standard meta-information about a resource that can not be
+  represented as an attribute or relationship.
+
 Here's how an article (i.e. a resource of type "articles") might appear in a document:
 
 ```javascript
@@ -114,19 +126,10 @@ Here's how an article (i.e. a resource of type "articles") might appear in a doc
 // ...
 ```
 
-#### Resource Objects <a href="#document-structure-resource-objects" id="document-structure-resource-objects" class="headerlink"></a>
+#### Resource Attributes <a href="#document-structure-resource-object-attributes" id="document-structure-resource-object-attributes" class="headerlink"></a>
 
-A resource object **MUST** contain at least the following top-level members:
 
-* `"id"`
-* `"type"`
 
-In addition, a resource object **MAY** contain any of these top-level members:
-
-* `"links"`: information about a resource's relationships (described
-  below).
-* `"meta"`: non-standard meta-information about a resource that can not be
-  represented as an attribute or relationship.
 
 Any other member in a resource object represents an "attribute", which may
 contain any valid JSON value.


### PR DESCRIPTION
Previously, we [discussed](https://github.com/json-api/json-api/issues/260) whether a request with the `fields` parameter could still return the basic members of each resource object, like `type` and `id`, even if those weren't included in the `fields` param. Back then, the answer was yes, but changes in RC2 made this illegal. This PR makes the old behavior legal again, and actually mandates it.

The reasoning is that allowing the user to exclude `type` and `id`:
1. conflicts with the current definition of a resource object, which says that "A resource object MUST contain at least the following top-level members: id, type`.
2. accordingly, it creates an edge case for clients, which might otherwise reasonably rely on `type` and `id` always being present;
3. and it can complicate server-side implementations, which have to keep track of these properties anyway (e.g. to handle `include`s) throughout the process of building up the resource objects to respond with.

This PR resolves the issue by more clearly noting the separation between reserved top-level members (`"type"`, `"id"`, `"links"`, and `"meta"`) and attributes (the other top level members) and relationships (the contents of the `"links"` object, excluding `"self"`). Then, it specifies that the `fields[TYPE]` parameter only applies to attributes and relationships.
