### PR TITLE
Introduce `supported-ext` media type parameter.

### DIFF
--- a/extensions/bulk/index.md
+++ b/extensions/bulk/index.md
@@ -10,14 +10,9 @@ extension](/extensions/#official-extensions) of the JSON API specification.
 It provides support for performing multiple operations in a request,
 including adding and removing multiple resources.
 
-Servers **SHOULD** indicate support for the JSON API media type's Bulk
-extension by including the header `Content-Type: application/vnd.api+json;
-ext=bulk` in every response.
-
-Clients **MAY** request the JSON API media type's Bulk extension by
-specifying the header `Accept: application/vnd.api+json; ext=bulk`. Servers
-that do not support the Bulk extension **MUST** return a `415 Unsupported
-Media Type` status code.
+Servers and clients **MUST** negotiate support for and use of the Bulk extension
+[as described in the base specification](/format/#extending) using `bulk` as the
+name of the extension.
 
 ## Bulk Operations <a href="#bulk-operations" id="bulk-operations" class="headerlink"></a>
 

--- a/extensions/patch/index.md
+++ b/extensions/patch/index.md
@@ -14,14 +14,9 @@ It provides support for modification of resources with the HTTP PATCH method
 For the sake of brevity, operatons requested with `PATCH` and conforming
 with JSON Patch will be called "Patch operations".
 
-Servers **SHOULD** indicate support for the JSON API media type's Patch
-extension by including the header `Content-Type: application/vnd.api+json;
-ext=patch` in every response.
-
-Clients **MAY** request the JSON API media type's Patch extension by
-specifying the header `Accept: application/vnd.api+json; ext=patch`. Servers
-that do not support the Patch extension **MUST** return a `415 Unsupported
-Media Type` status code.
+Servers and clients **MUST** negotiate support for and use of the Patch
+extension [as described in the base specification](/format/#extending) using
+`patch` as the name of the extension.
 
 ## Patch Operations <a href="#patch-operations" id="patch-operations" class="headerlink"></a>
 

--- a/format/index.md
+++ b/format/index.md
@@ -33,14 +33,24 @@ capabilities.
 An extension **MAY** make changes to and deviate from the requirements of the
 base specification apart from this section, which remains binding.
 
-Servers that support one or more extensions to JSON API **SHOULD** return
-those extensions in every response in the `ext` media type parameter of the
-`Content-Type` header. The value of the `ext` parameter **MUST** be a
-comma-separated (U+002C COMMA, ",") list of extension names.
+Servers that support one or more extensions to JSON API **MUST** return
+those extensions in every response in the `supported-ext` media type
+parameter of the `Content-Type` header. The value of the `supported-ext`
+parameter **MUST** be a comma-separated (U+002C COMMA, ",") list of
+extension names.
 
 For example: a response that includes the header `Content-Type:
-application/vnd.api+json; ext=bulk,patch` indicates that the server supports
-both the "bulk" and "patch" extensions.
+application/vnd.api+json; supported-ext=bulk,patch` indicates that the
+server supports both the "bulk" and "patch" extensions.
+
+If an extension is used to form a particular request or response document,
+then it **MUST** be specified by including its name in the `ext` media type
+parameter with the `Content-Type` header. The `ext` media type parameter
+**MUST NOT** include more than one extension name.
+
+For example: a response that includes the header `Content-Type:
+application/vnd.api+json; ext=patch; supported-ext=bulk,patch` indicates
+that the document is formatted according to the "patch" extension.
 
 Clients **MAY** request a particular media type extension by including its
 name in the `ext` media type parameter with the `Accept` header. Servers


### PR DESCRIPTION
The `supported-ext` media type parameter is used by servers to indicate
support for a media type extension. The actual media type extension
used in a document is still specified with the `ext` media type 
parameter.

Also eliminates repetition of the base specification's extension rules
in the bulk and patch extensions.

[Closes #353]
