### PR TITLE
Replace use of PUT with PATCH in the base spec. Rename JSON Patch extension.

### DIFF
--- a/extensions/jsonpatch/index.md
+++ b/extensions/jsonpatch/index.md
@@ -1,11 +1,11 @@
 ---
 layout: page
-title: "Patch Extension"
+title: "JSON Patch Extension"
 ---
 
 ## Introduction <a href="#introduction" id="introduction" class="headerlink"></a>
 
-The "Patch extension" is an [official
+The "JSON Patch extension" is an [official
 extension](/extensions/#official-extensions) of the JSON API specification.
 It provides support for modification of resources with the HTTP PATCH method
 [[RFC5789](http://tools.ietf.org/html/rfc5789)] and the JSON Patch format
@@ -14,14 +14,14 @@ It provides support for modification of resources with the HTTP PATCH method
 For the sake of brevity, operatons requested with `PATCH` and conforming
 with JSON Patch will be called "Patch operations".
 
-Servers and clients **MUST** negotiate support for and use of the Patch
+Servers and clients **MUST** negotiate support for and use of the JSON Patch
 extension [as described in the base specification](/format/#extending) using
-`patch` as the name of the extension.
+`jsonpatch` as the name of the extension.
 
 ## Patch Operations <a href="#patch-operations" id="patch-operations" class="headerlink"></a>
 
 Patch operations **MUST** specify a `Content-Type` header of
-`application/vnd.api+json; ext=patch`.
+`application/vnd.api+json; ext=jsonpatch`.
 
 Patch operations **MUST** be sent as an array to conform with the JSON
 Patch format. A server **MAY** limit the type, order, and count of
@@ -52,8 +52,8 @@ For example, a new photo could be created with the following request:
 
 ```text
 PATCH /photos
-Content-Type: application/vnd.api+json; ext=patch
-Accept: application/vnd.api+json; ext=patch
+Content-Type: application/vnd.api+json; ext=jsonpatch
+Accept: application/vnd.api+json; ext=jsonpatch
 
 [
   {
@@ -78,8 +78,8 @@ photo at `/photos/1`:
 
 ```text
 PATCH /photos/1
-Content-Type: application/vnd.api+json; ext=patch
-Accept: application/vnd.api+json; ext=patch
+Content-Type: application/vnd.api+json; ext=jsonpatch
+Accept: application/vnd.api+json; ext=jsonpatch
 
 [
   { "op": "replace", "path": "/src", "value": "http://example.com/hamster.png" }
@@ -106,8 +106,8 @@ For instance, the following request should update the `author` of an article:
 
 ```text
 PATCH /article/1/links/author
-Content-Type: application/vnd.api+json; ext=patch
-Accept: application/vnd.api+json; ext=patch
+Content-Type: application/vnd.api+json; ext=jsonpatch
+Accept: application/vnd.api+json; ext=jsonpatch
 
 [
   { "op": "replace", "path": "", "value": {"type": "people", "id": "1"} }
@@ -119,8 +119,8 @@ relationship to change its value to `null`. For example:
 
 ```text
 PATCH /article/1/links/author
-Content-Type: application/vnd.api+json; ext=patch
-Accept: application/vnd.api+json; ext=patch
+Content-Type: application/vnd.api+json; ext=jsonpatch
+Accept: application/vnd.api+json; ext=jsonpatch
 
 [
   { "op": "replace", "path": "", "value": null }
@@ -146,8 +146,8 @@ For example, the following request replaces every tag for an article:
 
 ```text
 PATCH /photos/1/links/tags
-Content-Type: application/vnd.api+json; ext=patch
-Accept: application/vnd.api+json; ext=patch
+Content-Type: application/vnd.api+json; ext=jsonpatch
+Accept: application/vnd.api+json; ext=jsonpatch
 
 [
   { "op": "replace", "path": "", "value": {"type": "tags", "id": ["2", "3"]} }
@@ -163,8 +163,8 @@ comments for the article with ID `1`:
 
 ```text
 PATCH /articles/1/links/comments
-Content-Type: application/vnd.api+json; ext=patch
-Accept: application/vnd.api+json; ext=patch
+Content-Type: application/vnd.api+json; ext=jsonpatch
+Accept: application/vnd.api+json; ext=jsonpatch
 
 [
   { "op": "add", "path": "/-", "value": { "type": "comments", "id": ["123"] } }
@@ -179,8 +179,8 @@ from the list of comments for the article with ID `1`:
 
 ```text
 PATCH /articles/1/links/comments
-Content-Type: application/vnd.api+json; ext=patch
-Accept: application/vnd.api+json; ext=patch
+Content-Type: application/vnd.api+json; ext=jsonpatch
+Accept: application/vnd.api+json; ext=jsonpatch
 
 [
   { "op": "remove", "path": "", "value": {"type": "comments", "id": ["5", "13"]} }
@@ -196,8 +196,8 @@ For instance, photo `1` might be deleted with the following request:
 
 ```text
 PATCH /photos/1
-Content-Type: application/vnd.api+json; ext=patch
-Accept: application/vnd.api+json; ext=patch
+Content-Type: application/vnd.api+json; ext=jsonpatch
+Accept: application/vnd.api+json; ext=jsonpatch
 
 [
   { "op": "remove", "path": "" }
@@ -220,7 +220,7 @@ attribute or a computed `sha`), it **MUST** return a `200 OK` response as well
 as a representation of the updated resources.
 
 The server **MUST** specify a `Content-Type` header of `application/vnd.api+json;
-ext=patch`. The body of the response **MUST** contain an array of JSON objects,
+ext=jsonpatch`. The body of the response **MUST** contain an array of JSON objects,
 each of which **MUST** conform to the JSON API media type
 (`application/vnd.api+json`). Response objects in this array **MUST** be in
 sequential order and correspond to the operations in the request document.
@@ -229,8 +229,8 @@ For instance, a request may create two photos in separate operations:
 
 ```text
 PATCH /photos
-Content-Type: application/vnd.api+json; ext=patch
-Accept: application/vnd.api+json; ext=patch
+Content-Type: application/vnd.api+json; ext=jsonpatch
+Accept: application/vnd.api+json; ext=jsonpatch
 
 [
   {
@@ -259,7 +259,7 @@ within an array:
 
 ```text
 HTTP/1.1 200 OK
-Content-Type: application/vnd.api+json; ext=patch
+Content-Type: application/vnd.api+json; ext=jsonpatch
 
 [
   {

--- a/format/index.md
+++ b/format/index.md
@@ -40,8 +40,8 @@ parameter **MUST** be a comma-separated (U+002C COMMA, ",") list of
 extension names.
 
 For example: a response that includes the header `Content-Type:
-application/vnd.api+json; supported-ext=bulk,patch` indicates that the
-server supports both the "bulk" and "patch" extensions.
+application/vnd.api+json; supported-ext=bulk,jsonpatch` indicates that the
+server supports both the "bulk" and "jsonpatch" extensions.
 
 If an extension is used to form a particular request or response document,
 then it **MUST** be specified by including its name in the `ext` media type
@@ -49,8 +49,9 @@ parameter with the `Content-Type` header. The `ext` media type parameter
 **MUST NOT** include more than one extension name.
 
 For example: a response that includes the header `Content-Type:
-application/vnd.api+json; ext=patch; supported-ext=bulk,patch` indicates
-that the document is formatted according to the "patch" extension.
+application/vnd.api+json; ext=jsonpatch; supported-ext=bulk,jsonpatch`
+indicates that the document is formatted according to the "jsonpatch"
+extension.
 
 Clients **MAY** request a particular media type extension by including its
 name in the `ext` media type parameter with the `Accept` header. Servers

--- a/format/index.md
+++ b/format/index.md
@@ -1008,7 +1008,7 @@ details **MAY** also be returned, as discussed below.
 
 ### Updating Resources <a href="#crud-updating" id="crud-updating" class="headerlink"></a>
 
-A resource's attributes and relationships can be updated by sending a `PUT`
+A resource's attributes and relationships can be updated by sending a `PATCH`
 request to the URL that represents the resource.
 
 The URL for a resource can be obtained:
@@ -1016,13 +1016,13 @@ The URL for a resource can be obtained:
 * from the `self` link in the resource object
 * for a *data object*, the original URL that was used to `GET` the document
 
-The `PUT` request **MUST** include a single resource object as primary data.
+The `PATCH` request **MUST** include a single resource object as primary data.
 The resource object **MUST** contain a `type` member.
 
 For example:
 
 ```text
-PUT /articles/1
+PATCH /articles/1
 Content-Type: application/vnd.api+json
 Accept: application/vnd.api+json
 
@@ -1038,7 +1038,7 @@ Accept: application/vnd.api+json
 #### Updating a Resource's Attributes <a href="#crud-updating-resource-attributes" id="crud-updating-resource-attributes" class="headerlink"></a>
 
 Any or all of a resource's attributes **MAY** be included in the resource
-object included in a `PUT` request.
+object included in a `PATCH` request.
 
 If a request does not include all of the fields for a resource, the server
 **MUST** interpret the missing fields as if they were included together with
@@ -1051,11 +1051,11 @@ choosing to interpret them as containing their current values, and the
 dominant real-world practice is to interpret such a request as a request for
 a partial update.
 
-For example, the following `PUT` request is interpreted as a request to
+For example, the following `PATCH` request is interpreted as a request to
 update only the `title` and `text` attributes of an article:
 
 ```text
-PUT /articles/1
+PATCH /articles/1
 Content-Type: application/vnd.api+json
 Accept: application/vnd.api+json
 
@@ -1072,16 +1072,16 @@ Accept: application/vnd.api+json
 #### Updating a Resource's To-One Relationships <a href="#crud-updating-resource-to-one-relationships" id="crud-updating-resource-to-one-relationships" class="headerlink"></a>
 
 If a to-one relationship is provided in the `links` section of a resource
-object in a `PUT` request, it **MUST** be one of:
+object in a `PATCH` request, it **MUST** be one of:
 
 * an object with `type` and `id` members corresponding to the related resource
 * `null`, to remove the relationship
 
-For instance, the following `PUT` request will update the `title` attribute
+For instance, the following `PATCH` request will update the `title` attribute
 and `author` relationship of an article:
 
 ```text
-PUT /articles/1
+PATCH /articles/1
 Content-Type: application/vnd.api+json
 Accept: application/vnd.api+json
 
@@ -1108,11 +1108,11 @@ object, it **MUST** be an object containing:
   `id` members for heterogeneous to-many relationships; to clear the
   relationship, set the `data` member to `[]`
 
-For instance, the following `PUT` request performs a complete replacement of
+For instance, the following `PATCH` request performs a complete replacement of
 the `tags` for an article:
 
 ```text
-PUT /articles/1
+PATCH /articles/1
 Content-Type: application/vnd.api+json
 Accept: application/vnd.api+json
 
@@ -1168,11 +1168,11 @@ references a related resource that does not exist.
 
 ##### 409 Conflict <a href="#crud-updating-responses-409" id="crud-updating-responses-409" class="headerlink"></a>
 
-A server **MAY** return `409 Conflict` when processing a `PUT` request to
+A server **MAY** return `409 Conflict` when processing a `PATCH` request to
 update a resource if that update would violate other server-enforced
 constraints (such as a uniqueness constraint on a field other than `id`).
 
-A server **MUST** return `409 Conflict` when processing a `PUT` request in
+A server **MUST** return `409 Conflict` when processing a `PATCH` request in
 which the resource's `type` and `id` do not match the server's endpoint.
 
 ##### Other Responses <a href="#crud-updating-responses-other" id="crud-updating-responses-other" class="headerlink"></a>
@@ -1205,10 +1205,10 @@ relationship is deleted (as a garbage collection measure).
 
 #### Updating To-One Relationships <a href="#crud-updating-to-one-relationships" id="crud-updating-to-one-relationships" class="headerlink"></a>
 
-A server **MUST** respond to `PUT` requests to a *to-one relationship URL* as
+A server **MUST** respond to `PATCH` requests to a *to-one relationship URL* as
 described below.
 
-The `PUT` request **MUST** include a top-level member named `data` containing
+The `PATCH` request **MUST** include a top-level member named `data` containing
 one of:
 
 * an object with `type` and `id` members corresponding to the related resource
@@ -1217,7 +1217,7 @@ one of:
 For example, the following request updates the author of an article:
 
 ```text
-PUT /articles/1/links/author
+PATCH /articles/1/links/author
 Content-Type: application/vnd.api+json
 Accept: application/vnd.api+json
 
@@ -1229,7 +1229,7 @@ Accept: application/vnd.api+json
 And the following request clears the author of the same article:
 
 ```text
-PUT /articles/1/links/author
+PATCH /articles/1/links/author
 Content-Type: application/vnd.api+json
 Accept: application/vnd.api+json
 
@@ -1243,14 +1243,14 @@ a `204 No Content` response.
 
 #### Updating To-Many Relationships <a href="#crud-updating-to-many-relationships" id="crud-updating-to-many-relationships" class="headerlink"></a>
 
-A server **MUST** respond to `PUT`, `POST`, and `DELETE` requests to a *to-many
+A server **MUST** respond to `PATCH`, `POST`, and `DELETE` requests to a *to-many
 relationship URL* as described below.
 
 For all request types, the body **MUST** contain a `data` member whose value
 is an object that contains `type` and `id` members, or an array of objects
 that each contain `type` and `id` members.
 
-If a client makes a `PUT` request to a *to-many relationship URL*, the
+If a client makes a `PATCH` request to a *to-many relationship URL*, the
 server **MUST** either completely replace every member of the relationship,
 return an appropriate error response if some resources can not be found or
 accessed, or return a `403 Forbidden` response if complete replacement is
@@ -1259,7 +1259,7 @@ not allowed by the server.
 For example, the following request replaces every tag for an article:
 
 ```text
-PUT /articles/1/links/tags
+PATCH /articles/1/links/tags
 Content-Type: application/vnd.api+json
 Accept: application/vnd.api+json
 


### PR DESCRIPTION
This resolves one of the most contentious issues in JSON API: the use of PUT to partially update, rather than replace, resources. This usage of PUT arguably crossed lines with the HTTP spec, so we are moving to updates wholly via PATCH.

To disambiguate the base spec's use of PATCH from the Patch extension, the Patch extension has been renamed to the "JSON Patch extension". This clarifies the usage of the JSON Patch format in the extension.

[Resolves #291]
