### PR TITLE
Fix error object definition

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -84,7 +84,7 @@ document.
 The document's "primary data" is a representation of the resource, collection
 of resources, or resource relationship primarily targeted by a request.
 
-A document **MUST** contain either primary data or an array of error objects.
+A document **MUST** contain either primary data or an array of [error objects](#errors).
 
 Primary data **MUST** appear under a top-level key named `"data"`. Primary
 data **MUST** be either a single resource object, an array of resource
@@ -1372,8 +1372,7 @@ details **MAY** also be returned, as discussed below.
 
 ## Errors <a href="#errors" id="errors" class="headerlink"></a>
 
-Error objects are specialized resource objects that **MAY** be returned in a
-response to provide additional information about problems encountered while
+Error objects provide additional information about problems encountered while
 performing an operation. Error objects **MUST** be returned as an array
 keyed by `"errors"` in the top level of a JSON API document, and **SHOULD
 NOT** be returned with any primary data.


### PR DESCRIPTION
Error objects are _not_ "specialized resource objects". That would imply that they have the same base semantics as resource objects (just with some additions) when, in fact, `"links"` means something totally different in error objects, `"id"` and `"type"` don't appear to be required.

This PR just lets them stand as their own type of object, rather than as subtypes of standard resource objects.

@dgeb 
