### PR TITLE
Clarify definition of 'resource object'

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -123,13 +123,15 @@ with non-alphanumeric characters are allowed.
 
 ### Resource Objects <a href="#document-structure-resource-objects" id="document-structure-resource-objects" class="headerlink"></a>
 
-"Resource objects" appear in a JSON API document to represent primary data
-and included resources.
+"Resource objects" appear in a JSON API document to represent resources.
 
 A resource object **MUST** contain at least the following top-level members:
 
 * `"id"`
 * `"type"`
+
+Exception: The `id` member is not required when the resource object originates at
+the client and represents a new resource to be created on the server.
 
 In addition, a resource object **MAY** contain any of these top-level members:
 

--- a/format/index.md
+++ b/format/index.md
@@ -1029,7 +1029,7 @@ The URL for a resource can be obtained:
 * for a *data object*, the original URL that was used to `GET` the document
 
 The `PATCH` request **MUST** include a single resource object as primary data.
-The resource object **MUST** contain a `type` member.
+The resource object **MUST** contain `type` and `id` members.
 
 For example:
 


### PR DESCRIPTION
With the latest changes, _resource object_ no longer seems to be used in the umbrella meaning (resources + relationships), so it's finally possible to give it a more focused definition without introducing other changes.

It also felt appropriate to explicitly waive the ID requirement for POST here, since it was only implied in the _Creating Resources_ section.
