### PR TITLE
Unify rules about reserved object members

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -75,10 +75,7 @@ certain aspects are only applicable to one or the other. These differences are
 called out below.
 
 Unless otherwise noted, objects defined by this specification **MUST NOT**
-contain any additional members whose keys start with an alphanumeric character.
-
-Any object **MAY** contain additional members whose keys start with a
-non-alphanumeric character.
+contain any additional members.
 
 ### Top Level <a href="#document-structure-top-level" id="document-structure-top-level" class="headerlink"></a>
 
@@ -143,9 +140,8 @@ In addition, a resource object **MAY** contain any of these top-level members:
 * `"meta"`: non-standard meta-information about a resource that can not be
   represented as an attribute or relationship.
 
-A resource object **MAY** contain additional top-level members whose keys begin
-with an alphanumeric character. These members represent "attributes" and may
-contain any valid JSON value.
+A resource object **MAY** contain additional top-level members. These members
+represent "attributes" and may contain any valid JSON value.
 
 If the value of an attribute is a JSON object or array, the member is called a
 *complex attribute*. The value is allowed to be any valid JSON structure.

--- a/format/index.md
+++ b/format/index.md
@@ -118,10 +118,6 @@ A document's top level **MAY** also have the following members:
 If any of these members appears in the top-level of a response, their values
 **MUST** comply with this specification.
 
-The top level of a document **MUST NOT** contain any additional members whose
-names start with alphanumeric characters. Additional members whose names start
-with non-alphanumeric characters are allowed.
-
 ### Resource Objects <a href="#document-structure-resource-objects" id="document-structure-resource-objects" class="headerlink"></a>
 
 "Resource objects" appear in a JSON API document to represent resources.
@@ -283,11 +279,6 @@ without having to `GET` one of the relationship URLs.
 > Note: If present, a *related resource URL* must be a valid URL, even if the
 relationship isn't currently associated with any target resources.
 
-Besides the members described above (`self`, `resource`, `type`, `id`, `meta`,
-and the keys for pagination), a link object **MUST NOT** contain any additional
-members whose names start with alphanumeric characters. Additional members whose
-names start with non-alphanumeric characters are allowed.
-
 For example, the following article is associated with an `author` and `comments`:
 
 ```javascript
@@ -448,9 +439,22 @@ The top-level links object **MAY** contain the following members:
   data represents a resource relationship.
 * Pagination links for the primary data (as described below).
 
-The top-level links object **MUST NOT** contain any additional members whose
-names start with alphanumeric characters. Additional members whose names
-start with non-alphanumeric characters are allowed.
+### Additional Object Members <a href="#document-structure-additional-members" id="document-structure-additional-members" class="headerlink"></a>
+
+This specification describes various JSON objects with a specific purpose and
+format. Each description enumerates a set of *reserved members* that carry a
+special meaning for the object. Additional members are allowed subject to the
+following conditions.
+
+Any additional members are allowed in these objects:
+* resource objects (as *attributes*)
+* `meta` objects
+* error objects.
+
+Other objects **MUST NOT** contain any additional members whose keys start with
+an alphanumeric character. Additional members whose keys start with a
+non-alphanumeric character are allowed. This also applies to the object that
+constitutes the document's top level.
 
 ## Fetching Data <a href="#fetching" id="fetching" class="headerlink"></a>
 
@@ -1427,4 +1431,3 @@ An error object **MAY** have the following members:
   to the resource path(s) expressed in the error object's `"links"` member
   [e.g. `["/first-name", "/last-name"]` to reference a couple attributes].
 
-Additional members **MAY** be specified within error objects.

--- a/format/index.md
+++ b/format/index.md
@@ -143,8 +143,9 @@ In addition, a resource object **MAY** contain any of these top-level members:
 * `"meta"`: non-standard meta-information about a resource that can not be
   represented as an attribute or relationship.
 
-Any other top-level member in a resource object represents an "attribute".
-An attribute may contain any valid JSON value.
+A resource object **MAY** contain additional top-level members whose keys begin
+with an alphanumeric character. These members represent "attributes" and may
+contain any valid JSON value.
 
 If the value of an attribute is a JSON object or array, the member is called a
 *complex attribute*. The value is allowed to be any valid JSON structure.
@@ -435,6 +436,8 @@ For example:
   }
 }
 ```
+
+Any members **MAY** be specified within `meta` objects.
 
 ### Top-level Links <a href="#document-structure-top-level-links" id="document-structure-top-level-links" class="headerlink"></a>
 

--- a/format/index.md
+++ b/format/index.md
@@ -74,6 +74,12 @@ Although the same media type is used for both request and response documents,
 certain aspects are only applicable to one or the other. These differences are
 called out below.
 
+Unless otherwise noted, objects defined by this specification **MUST NOT**
+contain any additional members whose keys start with an alphanumeric character.
+
+Any object **MAY** contain additional members whose keys start with a
+non-alphanumeric character.
+
 ### Top Level <a href="#document-structure-top-level" id="document-structure-top-level" class="headerlink"></a>
 
 A JSON object **MUST** be at the root of every JSON API response containing
@@ -438,23 +444,6 @@ The top-level links object **MAY** contain the following members:
 * `"related"` - a related resource URL (as defined above) when the primary
   data represents a resource relationship.
 * Pagination links for the primary data (as described below).
-
-### Additional Object Members <a href="#document-structure-additional-members" id="document-structure-additional-members" class="headerlink"></a>
-
-This specification describes various JSON objects with a specific purpose and
-format. Each description enumerates a set of *reserved members* that carry a
-special meaning for the object. Additional members are allowed subject to the
-following conditions.
-
-Any additional members are allowed in these objects:
-* resource objects (as *attributes*)
-* `meta` objects
-* error objects.
-
-Other objects **MUST NOT** contain any additional members whose keys start with
-an alphanumeric character. Additional members whose keys start with a
-non-alphanumeric character are allowed. This also applies to the object that
-constitutes the document's top level.
 
 ## Fetching Data <a href="#fetching" id="fetching" class="headerlink"></a>
 
@@ -1431,3 +1420,4 @@ An error object **MAY** have the following members:
   to the resource path(s) expressed in the error object's `"links"` member
   [e.g. `["/first-name", "/last-name"]` to reference a couple attributes].
 
+Additional members **MAY** be specified within error objects.


### PR DESCRIPTION
Simplifies the spec ~~and resolves #415~~.

This is possible because the restrictions all follow the "alphanumeric" rule.

I may occasionally write some weird quasi-English, so if the wording can be improved, please edit away.
