### PR TITLE
Introduce 'canonical' and clarify 'resource'

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -222,12 +222,16 @@ The name of the relationship declared in the key **SHALL NOT** be `"self"`.
 
 The value of a relationship **MUST** be one of the following:
 
-* A string, which represents a URL for the related resource(s) (a "related
-  resource URL"). When fetched, it returns the related resource object(s) as the
-  response's primary data. For example, an `article`'s `comments` could specify a
-  URL that returns a list of comment resource objects when retrieved through a
-  `GET` request. A related resource URL **SHOULD** remain constant even when the
-  relationship it represents mutates.
+* A URL for the related resource(s) (a "related resource URL"). When fetched, it
+  returns the related resource object(s) as the response's primary data. For
+  example, an `article`'s `comments` relationship could specify a URL that
+  returns a list of comment resource objects when retrieved through a `GET`
+  request.
+
+  A related resource URL **MUST** remain constant even when the relationship (the
+  set of identities of the referenced resources) mutates. That is, the response
+  from a related resource URL always reflects the current state of the
+  relationship.
 
 * An object (a "link object").
 
@@ -239,6 +243,11 @@ one of the following:
   relationship. For example, it would allow a client to remove an `author` from
   an `article` without deleting the `people` resource itself.
 * A `resource` member, whose value is a related resource URL (as defined above).
+* A `canonical` member, whose value is a canonical URL for the related
+  resource(s). A canonical URL **MUST** be permanently tied to the identity of
+  the target resources. That is, a previously retrieved canonical URL
+  continues to point to the same resources even if the original relationship
+  mutates.
 * Linkage to other resource objects ("object linkage") included in a compound
   document. This allows a client to link together all of the resource objects
   included in a compound document without having to `GET` one of the
@@ -257,6 +266,11 @@ pagination links, as described below.
 
 If a link object refers to resource objects included in the same compound
 document, it **MUST** include object linkage to those resource objects.
+
+> Note: If present, a *related resource URL* must be a valid URL, even if the
+relationship isn't currently associated with any target resources. If a
+relationship is empty, the server can indicate this in the link object by
+including an `id: null` or `id: []` member depending on relationship cardinality.
 
 Besides the members described above (`self`, `resource`, `type`, `id`, `meta`,
 and the keys for pagination), a link object **MUST NOT** contain any additional

--- a/format/index.md
+++ b/format/index.md
@@ -290,37 +290,7 @@ For example, the following article is associated with an `author` and `comments`
     "author": {
       "self": "http://example.com/articles/1/links/author",
       "resource": "http://example.com/articles/1/author",
-      "type": "people",
-      "id": "9"
-    },
-    "comments": {
-      "resource": "http://example.com/articles/1/comments"
-    }
-  }
-}
-// ...
-```
-
-The `author` relationship includes a URL for the relationship itself (which
-allows the client to change the related author without deleting the `people`
-object), a URL to fetch the resource objects, and linkage information for
-the current compound document.
-
-The `comments` relationship is simpler: it just provides a URL to fetch the
-comments. The following resource object, which provides the `comments`
-relationship as a string value rather than an object, is equivalent:
-
-```javascript
-// ...
-{
-  "type": "articles",
-  "id": "1",
-  "title": "Rails is Omakase",
-  "links": {
-    "self": "http://example.com/articles/1",
-    "author": {
-      "self": "http://example.com/articles/1/links/author",
-      "resource": "http://example.com/articles/1/author",
+      "canonical": "http://example.com/people/9",
       "type": "people",
       "id": "9"
     },
@@ -329,6 +299,14 @@ relationship as a string value rather than an object, is equivalent:
 }
 // ...
 ```
+
+The `author` relationship includes a URL for the relationship itself (which
+allows the client to change the related author without deleting the `people`
+object), URLs to fetch the resource objects, and linkage information for
+the current compound document.
+
+The `comments` relationship is simpler: it just provides a related resource URL
+to fetch the comments, so the URL can be provided as a string value.
 
 ### Compound Documents <a href="#document-structure-compound-documents" id="document-structure-compound-documents" class="headerlink"></a>
 
@@ -352,6 +330,7 @@ A complete example document with multiple included relationships:
       "author": {
         "self": "http://example.com/articles/1/links/author",
         "resource": "http://example.com/articles/1/author",
+        "canonical": "http://example.com/people/9",
         "type": "people",
         "id": "9"
       },


### PR DESCRIPTION
[Please review before 1.0]

Resolves: #379

Currently, the `resource` member in link objects may be tied either to the relationship or to the identity of the target resource(s). This ambiguity sets the stage for all kinds of elusive bugs and race conditions. It would be prudent to resolve this conclusively before 1.0.

This PR addresses the issue in the following way:
- The role of `resource` is clarified by limiting it to "relationshippy" URLs only.
- A new member named `"canonical"` is allowed in link objects to hold a canonical URL.

An alternative naming scheme for `resource` and `canonical` would be `href-related` / `href-canonical`, which is more descriptive but involves changing the established key `resource`.

Additionally, a Note is added that points out the following, which otherwise may not be obvious:
- a related resource URL cannot be replaced with `null` to indicate "empty" (#386)
- an empty relationship can be signaled by including `id: null` or `id: []` (#386, #399).
