### PR TITLE
Non-normative note about responses without message-body.

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -77,9 +77,10 @@ called out below.
 ### Top Level <a href="#document-structure-top-level" id="document-structure-top-level" class="headerlink"></a>
 
 A JSON object **MUST** be at the root of every JSON API response containing
-data. This object defines a document's "top level". The `204 No Content`
-response cannot contain a message body, and so does not include a data
-document.
+data. This object defines a document's "top level".
+
+> Note: Responses that can not contain a message-body, such as `204 No Content`,
+do not include a document with data.
 
 The document's "primary data" is a representation of the resource, collection
 of resources, or resource relationship primarily targeted by a request.


### PR DESCRIPTION
The statement about 204s should be both non-normative and more 
inclusive. Other responses, such as 404, may not contain a message-body 
either.

The relevant normative line is:

> A JSON object **MUST** be at the root of every JSON API response 
> containing data.
