### PR TITLE
More consistent resource linkage.

### DIFF
--- a/index.md
+++ b/index.md
@@ -33,14 +33,15 @@ Here's an example response from a blog that implements JSON API:
       "author": {
         "self": "http://example.com/posts/1/links/author",
         "related": "http://example.com/posts/1/author",
-        "type": "people",
-        "id": "9"
+        "linkage": { "type": "people", "id": "9" }
       },
       "comments": {
         "self": "http://example.com/posts/1/links/comments",
         "related": "http://example.com/posts/1/comments",
-        "type": "comments",
-        "id": ["5", "12"]
+        "linkage": [
+          { "type": "comments", "id": "5" },
+          { "type": "comments", "id": "12" }
+        ]
       }
     }
   }],


### PR DESCRIPTION
I put together this PR as the result of a discussion in #437. As [I mentioned](https://github.com/json-api/json-api/pull/437#issuecomment-78045651), this was one approach that I considered while working on RC2, but was concerned with the verbosity.

However, after discussing with a couple implementors who are in favor of these simplifications, I'd like to put this out there for general consideration. Even though this is the 11th hour for the spec, it's probably worthwhile to consider a simplifying approach.

The gist is that resource linkage is consistently represented in this approach, regardless of whether relationships are homogeneous or heterogeneous. Linkage is contained within a `linkage` member in the links object, eliminating the dichotomy of using either `type` / `id`  (for homogeneous relationships) vs. `data` (for heteregeneous relationships).

Here's the home page resource object currently:

```
  "data": [{
    "type": "posts",
    "id": "1",
    "title": "JSON API paints my bikeshed!",
    "links": {
      "self": "http://example.com/posts/1",
      "author": {
        "self": "http://example.com/posts/1/links/author",
        "related": "http://example.com/posts/1/author",
        "type": "people",
        "id": "9"
      },
      "comments": {
        "self": "http://example.com/posts/1/links/comments",
        "related": "http://example.com/posts/1/comments",
        "type": "comments",
        "id": ["5", "12"]
      }
    }
  }]
```

And here it is after this change:

```
  "data": [{
    "type": "posts",
    "id": "1",
    "title": "JSON API paints my bikeshed!",
    "links": {
      "self": "http://example.com/posts/1",
      "author": {
        "self": "http://example.com/posts/1/links/author",
        "related": "http://example.com/posts/1/author",
        "linkage": {"type": "people", "id": "9"}
      },
      "comments": {
        "self": "http://example.com/posts/1/links/comments",
        "related": "http://example.com/posts/1/comments",
        "linkage": [
           {"type": "comments", "id": "5"},
           {"type": "comments", "id": "12"}
        ]
      }
    }
  }]
```

I find this structure to be more consistent with resource objects themselves, which all must contain a `type` and `id`. This approach also simplifies endpoints for updating relationships.

But of course, as I've said, it is more verbose.
