### PR TITLE
In examples move Ruby JsonApiClient under Clients

### DIFF
--- a/examples/index.md
+++ b/examples/index.md
@@ -33,6 +33,8 @@ implementations. There is a [custom adapter](https://github.com/daliwali/ember-j
 
 * [jsonapi-consumer](https://github.com/jsmestad/jsonapi-consumer) a ruby library for consuming JSONAPI payloads. 
 
+* [JsonApiClient](https://github.com/chingor13/json_api_client) attempts to give you a query building framework that is easy to understand (similar to ActiveRecord scopes)
+
 ## Server <a href="#server" id="server" class="headerlink"></a>
 
 ### PHP <a href="#server-php" id="server-php" class="headerlink"></a>
@@ -49,8 +51,6 @@ implementations. There is a [custom adapter](https://github.com/daliwali/ember-j
 * [ActiveModel::Serializers](https://github.com/rails-api/active_model_serializers)
 is one of the original exemplar implementations, but is slightly out of date at
 the moment.
-
-* [JsonApiClient](https://github.com/chingor13/json_api_client) attempts to give you a query building framework that is easy to understand (similar to ActiveRecord scopes)
 
 * [The rabl wiki](https://github.com/nesquena/rabl/wiki/Conforming-to-jsonapi.org-format)
 has a page describing how to emit conformant JSON.


### PR DESCRIPTION
It appears that the Ruby library `JsonApiClient` was erroneously listed under Server, when it should been under Client. Or am I mistaked?
