### PR TITLE
Remove relationship url option

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -261,27 +261,21 @@ can be specified by including a member in a resource's links object.
 
 The name of the relationship declared in the key **SHALL NOT** be `"self"`.
 
-The value of a relationship **MUST** be one of the following:
-
-* A URL for the related resource(s) (a "related resource URL"). When fetched, it
-  returns the related resource object(s) as the response's primary data. For
-  example, an `article`'s `comments` relationship could specify a URL that
-  returns a list of comment resource objects when retrieved through a `GET`
-  request. A related resource URL **MUST** remain constant even when the
-  relationship (the set of referenced resources) mutates. That is, the response
-  from a related resource URL always reflects the current state of the
-  relationship.
-
-* An object (a "link object").
-
-If a relationship is provided as a link object, it **MUST** contain at least
-one of the following:
+The value of a relationship **MUST** be a "link object", and **MUST** contain at
+least one of the following:
 
 * A `"self"` member, whose value is a URL for the relationship itself (a
   "relationship URL"). This URL allows the client to directly manipulate the
   relationship. For example, it would allow a client to remove an `author` from
   an `article` without deleting the `people` resource itself.
-* A `"related"` member, whose value is a related resource URL (as defined above).
+* A `"related"` member, whose value is a URL for the related resource(s)
+  (a "related resource URL"). When fetched, it returns the related resource
+  object(s) as the response's primary data. For example, an `article`'s
+  `comments` relationship could specify a URL that returns a list of comment
+  resource objects when retrieved through a `GET` request. A related resource
+  URL **MUST** remain constant even when the relationship (the set of
+  referenced resources) mutates. That is, the response from a related resource
+  URL always reflects the current state of the relationship.
 * A `"linkage"` member, whose value represents "resource linkage".
 * A `"meta"` member that contains non-standard meta-information about the
   relationship.

--- a/format/index.md
+++ b/format/index.md
@@ -302,7 +302,7 @@ relationship URLs.
 > Note: If present, a *related resource URL* must be a valid URL, even if the
 relationship isn't currently associated with any target resources.
 
-For example, the following article is associated with an `author` and `comments`:
+For example, the following article is associated with an `author`:
 
 ```javascript
 // ...
@@ -316,9 +316,6 @@ For example, the following article is associated with an `author` and `comments`
       "self": "http://example.com/articles/1/links/author",
       "related": "http://example.com/articles/1/author",
       "linkage": { "type": "people", "id": "9" }
-    },
-    "comments": {
-      "related": "http://example.com/articles/1/comments"
     }
   }
 }
@@ -328,10 +325,6 @@ For example, the following article is associated with an `author` and `comments`
 The `author` relationship includes a URL for the relationship itself (which
 allows the client to change the related author directly), a related resource URL
 to fetch the resource objects, and linkage information.
-
-The `comments` relationship is simpler: it just provides a related resource URL
-to fetch the comments. The URL can therefore be specified directly as the
-attribute value.
 
 ### Compound Documents <a href="#document-structure-compound-documents" id="document-structure-compound-documents" class="headerlink"></a>
 

--- a/format/index.md
+++ b/format/index.md
@@ -261,7 +261,7 @@ can be specified by including a member in a resource's links object.
 
 The name of the relationship declared in the key **SHALL NOT** be `"self"`.
 
-The value of a relationship **MUST** be a "link object", and **MUST** contain at
+The value of a relationship **MUST** be an object (a "link object"), and **MUST** contain at
 least one of the following:
 
 * A `"self"` member, whose value is a URL for the relationship itself (a
@@ -317,7 +317,9 @@ For example, the following article is associated with an `author` and `comments`
       "related": "http://example.com/articles/1/author",
       "linkage": { "type": "people", "id": "9" }
     },
-    "comments": "http://example.com/articles/1/comments"
+    "comments": {
+      "related": "http://example.com/articles/1/comments"
+    }
   }
 }
 // ...


### PR DESCRIPTION
The option for a url for a relationship is equivalent to a "link object" with a "related" member.

There is no need to have both options as it just increased the complexity of implementation.
