### PR TITLE
Combining extensions #452

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -45,18 +45,20 @@ server supports both the "bulk" and "jsonpatch" extensions.
 
 If an extension is used to form a particular request or response document,
 then it **MUST** be specified by including its name in the `ext` media type
-parameter with the `Content-Type` header. The `ext` media type parameter
-**MUST NOT** include more than one extension name.
+parameter with the `Content-Type` header. 
+The value of the `ext` media type parameter **MUST** be formatted 
+in the same way as the value of `supported-ext` media type parameter 
+and **MUST** be limited to a subset of extensions listed in `supported-ext`.
 
 For example: a response that includes the header `Content-Type:
-application/vnd.api+json; ext=jsonpatch; supported-ext=bulk,jsonpatch`
-indicates that the document is formatted according to the "jsonpatch"
-extension.
+application/vnd.api+json; ext=ext1,ext2; supported-ext=ext1,ext2,ext3`
+indicates that the document is formatted according to the 
+extensions "ext1" and "ext2".
 
 Clients **MAY** request a particular media type extension by including its
-name in the `ext` media type parameter with the `Accept` header. Servers
-that do not support a requested extension **MUST** return a `406 Not
-Acceptable` status code.
+name in the `ext` media type parameter with the `Accept` header. 
+Servers that do not support requested extensions or requested combination of 
+extensions **MUST** return a `406 Not Acceptable` status code.
 
 If the media type in the `Accept` header is supported by a server but the
 media type in the `Content-Type` header is unsupported, the server
@@ -65,6 +67,12 @@ media type in the `Content-Type` header is unsupported, the server
 Servers **MUST NOT** provide extended functionality that is incompatible with the
 base specification to clients that do not request the extension in the `ext`
 parameter of the `Content-Type` or the `Accept` header.
+
+> Note: Since extensions can contradict one another or have interactions that 
+can be resolved in many equally plausible ways, it is responsibility of the
+server to decide which extensions are compatible, and it is a responsibility
+of the designer of each implementation of this specification to describe 
+extension interoperability rules which are applicable to that implementation.
 
 ## Document Structure <a href="#document-structure" id="document-structure" class="headerlink"></a>
 


### PR DESCRIPTION
Here are the changed discussed in #452.

I wonder whether it is worth making recommendation about the order of elements in `ext` and `supported-ext` or just leave it completely open. IMHO, the order could only make any practical difference if that particular header is used in `Vary`, should it just be a concern of the implementation?
