### PR TITLE
Bulk responses

### DIFF
--- a/extensions/bulk/index.md
+++ b/extensions/bulk/index.md
@@ -98,3 +98,33 @@ Accept: application/vnd.api+json; ext=bulk
   "data": { "type": "articles", "id": ["1", "2"] }
 }
 ```
+
+## Responses <a href="#responses" id="responses" class="headerlink"></a>
+
+For successful Bulk requests, a server **MUST** return 
+the corresponding success HTTP status code of the performed operation.
+
+When a server encounters one or more problems while processing a Bulk
+operation, it **SHOULD** specify the most appropriate HTTP error code in the
+response. Clients **MUST** interpret those errors in accordance with HTTP
+semantics.
+
+A server **MAY** choose to stop processing Bulk operations as soon as the
+first problem is encountered, or it **MAY** continue processing operations and
+encounter multiple problems. For instance, a server might process multiple
+resource updates and then return multiple validation problems in a single
+response.
+
+When a server encounters multiple problems from a single request, the most
+generally applicable HTTP error code should be specified in the response. For
+instance, `400 Bad Request` might be appropriate for multiple 4xx errors or `500
+Internal Server Error` might be appropriate for multiple 5xx errors.
+
+A server **MAY** return error objects that correspond to each operation. The
+body of the response **MUST** contain an array of JSON objects, which
+**MUST** be in sequential order and correspond to the operations in the
+request document. Each response object **SHOULD** contain only error objects
+keyed by `"errors"`, since no operations can be completed successfully when
+any errors occur. Error codes for each specific operation **SHOULD** be
+returned in the `"status"` member of each error object.
+


### PR DESCRIPTION
Extension "jsonpatch" describes responses in detail, but similar section is missing from the description of the extension "bulk". The suggested change is copied almost word-to-word from the former to the latter, which is not elegant, but is there a better place for this?
