### PR TITLE
Remove reference to paginating non-primary resources

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -817,17 +817,11 @@ alphabetical order.
 
 ### Pagination <a href="#fetching-pagination" id="fetching-pagination" class="headerlink"></a>
 
-A server **MAY** choose to limit the number of resources returned in a response
-to a subset ("page") of the whole set available.
+A server **MAY** choose to limit the number of primary resources returned 
+in a response to a subset ("page") of the whole set available.
 
 A server **MAY** provide links to traverse a paginated data set ("pagination
-links").
-
-Pagination links **MUST** appear in the link object that corresponds to a
-collection. To paginate the primary data, supply pagination links in the
-top-level `links` object. To paginate an included collection returned in
-a compound document, supply pagination links in the corresponding link
-object.
+links") links in the top-level `links` object.
 
 The following keys **MUST** be used for pagination links:
 


### PR DESCRIPTION
Right now, the spec says: "To paginate an included collection returned in a compound document, supply pagination links in the corresponding link object." But: what corresponding link object is this talking about? The only link objects in the `"included"` section are for part of individual resources; they're not associated with any collections. 

Even if the "included" section were to be restructured such that there were clear collections, presumably one for each path asked to be included, I don't think we'd want to paginate those collections; it should be enough to just paginate the primary resources, and only include resources related to the primary resources that are part of the current "page" (which is what the spec would do if this PR were merged). Doing otherwise could get messy, with query parameters like `page[posts.author][size]`. Ick.
