### PR TITLE
Clarifying note for 404 on relationships

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -701,6 +701,10 @@ Content-Type: application/vnd.api+json
 A server **MUST** return `404 Not Found` when processing a request to fetch
 a relationship URL that does not exist.
 
+> Note: This can happen when the parent resource of the relationship 
+does not exist. For example, when `/articles/1` does not exist, request to
+`/articles/1/links/tags` returns `404 Not Found`.
+
 > Note: If a relationship URL exists but the relationship is empty, then
 `200 OK` **MUST** be returned, as described above.
 


### PR DESCRIPTION
Maybe I am missing something -- what are other cases when the URL could be non-existing? IMHO, it would be helpful to list them.
