### PR TITLE
Ordering of primary data

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -825,6 +825,13 @@ The above example should return the newest articles first. Any articles
 created on the same date will then be sorted by their title in ascending
 alphabetical order.
 
+If sorting is supported by the server and requested by the client via 
+query parameter `sort`, the server **MUST** return elements of the 
+top-level `data` array of the response ordered according to the criteria 
+specified. 
+The server **MAY** apply default sorting rules to top-level `data` 
+if request parameter `sort` is not specified. 
+
 ### Pagination <a href="#fetching-pagination" id="fetching-pagination" class="headerlink"></a>
 
 A server **MAY** choose to limit the number of resources returned in a response


### PR DESCRIPTION
IMHO, not enough attention is given in the spec to the way of specifying of order of results in the response, especially given that the specification of sorting in the request is quite detailed. I believe it is just assumed that the way to specify order of results is to order elements in the top-level data, but AFAIK it is not mentioned explicitly anywhere. The only reference to ordering I was able to find is in the Recommendations: "because order is significant" . I suggest to mention this explicitly in the base spec.
