### PR TITLE
Reserved members of complex attributes

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -191,7 +191,7 @@ be represented under the "links object".
 
 "[Complex attributes]" are [attributes] whose value is an object or array with
 any level of nesting. An object that constitutes or is contained in a complex
-attribute must reserve the `id`, `type`, `links`, and `meta` members for future
+attribute **MUST** reserve the `id`, `type`, `links`, and `meta` members for future
 use.
 
 #### Fields <a href="#document-structure-resource-object-fields" id="document-structure-resource-object-fields" class="headerlink"></a>


### PR DESCRIPTION
I suggest to turn it to a RFC verb. IMHO, it should be **MUST** instead, but it could be argued that **SHOULD** could be more appropriate.
