### PR TITLE
Clarify link object requirements

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -277,12 +277,15 @@ The value of a relationship **MUST** be one of the following:
 If a relationship is provided as a link object, it **MUST** contain at least
 one of the following:
 
+* A `"related"` member, whose value is a related resource URL (as defined above).
+* A `"linkage"` member, whose value represents "resource linkage".
+
+The link object **MAY** also contain:
 * A `"self"` member, whose value is a URL for the relationship itself (a
   "relationship URL"). This URL allows the client to directly manipulate the
   relationship. For example, it would allow a client to remove an `author` from
   an `article` without deleting the `people` resource itself.
-* A `"related"` member, whose value is a related resource URL (as defined above).
-* A `"linkage"` member, whose value represents "resource linkage".
+
 * A `"meta"` member that contains non-standard meta-information about the
   relationship.
 


### PR DESCRIPTION
Under the current spec, this is technically valid:

```
{
  "links": {
    "author": {
      "meta": {}
    }
  }
}
```

But clearly that's not enough information for a client to figure out the link.

This PR clarifies that it's actually at least one of the `related`or `linkage` keys that's required, with `self` and `meta` then being optional extras.

We could also say that at least one of: `"related"`, `"linkage"`, or `"self"` is required, with only `"meta"` being completely optional. If we do that, then this would be valid:

```
{
  "links": {
    "author": {
      "self": "http://example.com/people/1/links/author"
    }
  }
}
```

Technically, that provides enough information for a client to figure out the linked resources, but I don't think we should allow this. Having implementors put either a `related` or `linkage` key doesn't seem like a big burden, and it saves the client a request (since in the `self`-only case it has to request that url just to get the linkage).
