### PR TITLE
Clarify relationship formatting

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -295,11 +295,10 @@ document, it **MUST** include resource linkage to those resource objects.
 Resource linkage **MUST** be represented as one of the following:
 
 * `null` for empty to-one relationships.
-* an object containing `"type"` and `"id"` members for non-empty to-one
-  relationships.
+* a "linkage object", which is an object containing `"type"` and `"id"` members,
+  for non-empty to-one relationships.
 * an empty array (`[]`) for empty to-many relationships.
-* an array of objects each containing `"type"` and `"id"` members for non-empty
-  to-many relationships.
+* an array of linkage objects for non-empty to-many relationships.
 
 > Note: Resource linkage in a compound document allows a client to link
 together all of the included resource objects without having to `GET` any
@@ -1210,7 +1209,7 @@ described below.
 The `PATCH` request **MUST** include a top-level member named `data` containing
 one of:
 
-* an object with `type` and `id` members corresponding to the related resource.
+* a linkage object (defined above) corresponding to the new related resource.
 * `null`, to remove the relationship.
 
 For example, the following request updates the author of an article:
@@ -1246,8 +1245,7 @@ A server **MUST** respond to `PATCH`, `POST`, and `DELETE` requests to a
 *to-many relationship URL* as described below.
 
 For all request types, the body **MUST** contain a `data` member whose value
-is an object that contains `type` and `id` members, or an array of objects
-that each contain `type` and `id` members.
+is a linkage object or an array of linkage objects.
 
 If a client makes a `PATCH` request to a *to-many relationship URL*, the
 server **MUST** either completely replace every member of the relationship,

--- a/format/index.md
+++ b/format/index.md
@@ -912,9 +912,9 @@ Accept: application/vnd.api+json
 }
 ```
 
-If the resource object being sent contains any relationships in its `"links"`
-key, those relationships **MUST** each have a `"linkage"` key that includes the
-linkage the new resource is to have.
+If a relationship is provided in the `links` section of the resource object, its
+value **MUST** be a link object with a `linkage` member. The value of this key
+represents the linkage the new resource is to have.
 
 #### Client-Generated IDs <a href="#crud-creating-client-ids" id="crud-creating-client-ids" class="headerlink"></a>
 

--- a/format/index.md
+++ b/format/index.md
@@ -903,10 +903,19 @@ Accept: application/vnd.api+json
   "data": {
     "type": "photos",
     "title": "Ember Hamster",
-    "src": "http://example.com/images/productivity.png"
+    "src": "http://example.com/images/productivity.png",
+    "links": {
+      "photographer": {
+        "linkage": { "type": "people", "id": "9" }
+      }
+    }
   }
 }
 ```
+
+If the resource object being sent contains any relationships in its `"links"`
+key, those relationships **MUST** each have a `"linkage"` key that includes the
+linkage the new resource is to have.
 
 #### Client-Generated IDs <a href="#crud-creating-client-ids" id="crud-creating-client-ids" class="headerlink"></a>
 

--- a/format/index.md
+++ b/format/index.md
@@ -1245,7 +1245,7 @@ A server **MUST** respond to `PATCH`, `POST`, and `DELETE` requests to a
 *to-many relationship URL* as described below.
 
 For all request types, the body **MUST** contain a `data` member whose value
-is a linkage object or an array of linkage objects.
+is an empty array or an array of linkage objects.
 
 If a client makes a `PATCH` request to a *to-many relationship URL*, the
 server **MUST** either completely replace every member of the relationship,

--- a/format/index.md
+++ b/format/index.md
@@ -295,10 +295,12 @@ document, it **MUST** include resource linkage to those resource objects.
 Resource linkage **MUST** be represented as one of the following:
 
 * `null` for empty to-one relationships.
-* a "linkage object", which is an object containing `"type"` and `"id"` members,
-  for non-empty to-one relationships.
+* a "linkage object" (defined below) for non-empty to-one relationships.
 * an empty array (`[]`) for empty to-many relationships.
 * an array of linkage objects for non-empty to-many relationships.
+
+A "linkage object" is an object that identifies an individual related resource.
+It **MUST** contain `type` and `id` members.
 
 > Note: Resource linkage in a compound document allows a client to link
 together all of the included resource objects without having to `GET` any

--- a/format/index.md
+++ b/format/index.md
@@ -1074,13 +1074,11 @@ Accept: application/vnd.api+json
 }
 ```
 
-#### Updating a Resource's To-One Relationships <a href="#crud-updating-resource-to-one-relationships" id="crud-updating-resource-to-one-relationships" class="headerlink"></a>
+#### Updating a Resource's Relationships <a href="#crud-updating-resource-relationships" id="crud-updating-resource-relationships" class="headerlink"></a>
 
-If a to-one relationship is provided in the `links` section of a resource
-object in a `PATCH` request, its value **MUST** be either:
-
-* an object with `type` and `id` members corresponding to the related resource
-* `null`, to remove the relationship
+If a relationship is provided in the `links` section of a resource object in a
+`PATCH` request, its value **MUST** be a link object with a `linkage` member.
+The relationship's value will be replaced with the value specified in this member.
 
 For instance, the following `PATCH` request will update the `title` attribute
 and `author` relationship of an article:
@@ -1096,22 +1094,15 @@ Accept: application/vnd.api+json
     "id": "1",
     "title": "Rails is a Melting Pot",
     "links": {
-      "author": { "type": "people", "id": "1" }
+      "author": {
+        "linkage": { "type": "people", "id": "1" }
+      }
     }
   }
 }
 ```
 
-#### Updating a Resource's To-Many Relationships <a href="#crud-updating-resource-to-many-relationships" id="crud-updating-resource-to-many-relationships" class="headerlink"></a>
-
-If a to-many relationship is included in the `links` section of a resource
-object, it **MUST** be either:
-
-* an array of objects each containing `type` and `id` members to replace all
-  members of the relationship.
-* an empty array (`[]`) to clear the relationship.
-
-For instance, the following `PATCH` request performs a complete replacement of
+Likewise, the following `PATCH` request performs a complete replacement of
 the `tags` for an article:
 
 ```text
@@ -1125,10 +1116,12 @@ Accept: application/vnd.api+json
     "id": "1",
     "title": "Rails is a Melting Pot",
     "links": {
-      "tags": [
-        { "type": "tags", "id": "2" },
-        { "type": "tags", "id": "3" }
-      ]
+      "tags": {
+        "linkage": [
+          { "type": "tags", "id": "2" },
+          { "type": "tags", "id": "3" }
+        ]
+      }
     }
   }
 }

--- a/format/index.md
+++ b/format/index.md
@@ -48,13 +48,13 @@ then it **MUST** be specified by including its name in the `ext` media type
 parameter with the `Content-Type` header. The value of the `ext` media type
 parameter **MUST** be formatted as a comma-separated (U+002C COMMA, ",")
 list of extension names and **MUST** be limited to a subset of the
-extensions supported by the server, which are listed in `supported-ext` 
+extensions supported by the server, which are listed in `supported-ext`
 of every response.
 
 For example: a response that includes the header `Content-Type:
 application/vnd.api+json; ext=ext1,ext2; supported-ext=ext1,ext2,ext3`
 indicates that the response document is formatted according to the
-extensions "ext1" and "ext2". Another example: a request that includes 
+extensions "ext1" and "ext2". Another example: a request that includes
 the header `Content-Type: application/vnd.api+json; ext=ext1,ext2`
 indicates that the request document is formatted according to the
 extensions "ext1" and "ext2".
@@ -1132,9 +1132,9 @@ relationship. In such a case, the server **MUST** reject the entire update,
 and return a `403 Forbidden` response.
 
 > Note: Since full replacement may be a very dangerous operation, a server
-may choose to disallow it. A server may reject full replacement if it has
-not provided the client with the full list of associated objects, and does
-not want to allow deletion of records the client has not seen.
+may choose to disallow it. For example, a server may reject full replacement if
+it has not provided the client with the full list of associated objects, and
+does not want to allow deletion of records the client has not seen.
 
 #### Responses <a href="#crud-updating-responses" id="crud-updating-responses" class="headerlink"></a>
 


### PR DESCRIPTION
**Update** I've edited this description to capture the current state of the PR. It does three things:
1. When relationship information is being sent to the server as part of a PATCH or POST done on a _full resource_ (as opposed to patching/posting to the relationship directly), the format for sending this information is the same as its representation in GET requests. (I.e. there's a `links` key with a proper link object.)
2. This link object containing the new relationship information MUST have a linkage key. This clarifies that relationships can only be set by providing "linkage", not by providing `related` urls.
3. It simplifies some of the definitions for PATCHing/DELETEing relationships directly, by introducing the concept of a linkage object. It doesn't go so far as to use link objects to represent single relationships retrieved at/sent to relationship URLs. That discussion is happening here and in #482. If that's desired, I can update the PR further.
