### PR TITLE
Clarify top-level self's description

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -442,7 +442,7 @@ Any members **MAY** be specified within `meta` objects.
 
 The top-level links object **MAY** contain the following members:
 
-* `"self"` - a link for fetching the data in the response document.
+* `"self"` - the URL that generated the current response document.
 * `"related"` - a related resource URL (as defined above) when the primary
   data represents a resource relationship.
 * Pagination links for the primary data (as described below).


### PR DESCRIPTION
As I discovered in the process of opening #500, reading the spec, and then convincing myself that #500 wasn't necessary, the current definition of the top-level `self` link is a little vague. This PR aims to fix that.
