### PR TITLE
Explain complex attributes, again

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,8 @@ navigation:
   url: /extensions/
 - title: Recommendations
   url: /recommendations/
+- title: Examples
+  url: /examples/
 - title: Implementations
   url: /implementations/
 - title: FAQ

--- a/examples/index.md
+++ b/examples/index.md
@@ -5,3 +5,45 @@ title: Examples
 
 This page contains additional examples of how to apply various parts of the specification.
 
+### Complex Attributes <a href="#complex-attributes" id="complex-attributes" class="headerlink"></a>
+
+The following resource object represents an invoice and contains three [complex
+attributes](/format/#document-structure-resource-object-complex-attributes):
+`notes`, `total`, and `customer-references`.
+
+```json
+{
+  "type": "invoices",
+  "id": "1234",
+  "date": "2015-02-14",
+  "due": "2015-03-14",
+  "notes": ["Lorem ipsum dolor sit amet", "Consectetuer adipiscing elit"],
+  "total": {
+    "currency": "EUR",
+    "line-items": 3000.00,
+    "discounts": 150.00,
+    "tax": {
+      "tax-type": "VAT",
+      "taxable-amount": 2850.00,
+      "tax-amount": 570.00
+    },
+    "amount-payable": 3420.00
+  },
+  "customer-references": [{
+    "ref-type": "purchase-order",
+    "text": "AB3210"
+  }, {
+    "ref-type": "other",
+    "text": "Department XYZ"
+  }],
+  "links": {
+    "customer": {
+      "related": "http://example.com/invoices/1234/customer"
+    },
+    "line-items": {
+      "related": "http://example.com/invoices/1234/line-items"
+    }
+  }
+}
+```
+

--- a/examples/index.md
+++ b/examples/index.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Examples
+---
+
+This page contains additional examples of how to apply various parts of the specification.
+

--- a/format/index.md
+++ b/format/index.md
@@ -189,10 +189,12 @@ be represented under the "links object".
 
 #### Complex Attributes <a href="#document-structure-resource-object-complex-attributes" id="document-structure-resource-object-complex-attributes"></a>
 
-"[Complex attributes]" are [attributes] whose value is an object or array with
-any level of nesting. An object that constitutes or is contained in a complex
-attribute **MUST** reserve the `id`, `type`, `links`, and `meta` members for future
-use.
+"[Complex attributes]" are [attributes] whose value is an object or array
+([example](/examples/#complex-attributes)).
+
+JSON API permits embedding arbitrary data structures as complex attributes in
+resource objects. However, any object in a complex attribute **MUST** reserve
+the `id`, `type`, `links`, and `meta` members for future use.
 
 #### Fields <a href="#document-structure-resource-object-fields" id="document-structure-resource-object-fields" class="headerlink"></a>
 


### PR DESCRIPTION
The current explanation on complex attributes doesn't seem to be getting the point through. Once again, there was an issue opened asking how to do it.

Let's see if this revision does the trick.

A usage example was previously rejected from the base spec, so this time it's placed on the repurposed _Examples_ page, introduced in PR #503.
