### PR TITLE
Relax restriction on repeated, included resources

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -399,7 +399,7 @@ A complete example document with multiple included relationships:
 }
 ```
 
-A compound document **MUST NOT** include more than one resource object for
+A compound document **SHOULD NOT** include more than one resource object for
 each `type` and `id` pair.
 
 > Note: In a single document, you can think of the `type` and `id` as a
@@ -929,7 +929,7 @@ a properly generated and formatted *UUID* as described in RFC 4122
 > NOTE: In some use-cases, such as importing data from another source, it
 may be possible to use something other than a UUID that is still guaranteed
 to be globally unique. Do not use anything other than a UUID unless you are
-100% confident that the strategy you are using indeed generates globally 
+100% confident that the strategy you are using indeed generates globally
 unique indentifiers.
 
 For example:


### PR DESCRIPTION
Back in #278, everyone agreed that this should be a **SHOULD NOT** rather than a **MUST NOT**. 

@ahacking pointed out that:

> If the duplicate resource rule is relaxed, no book keeping history is required and streaming results of any size/length over and arbitrary time period is possible...It is hard to reason that repeating a resource could actually cause trouble in practice, also given a long enough running process this could actually be used to refresh resources and be beneficial.

My guess is that this got rather mindlessly converted into a **MUST** during the _remove all the **SHOULD**s crusade_ that was part of rc3's simplification effort. If I'm wrong on that, though, and there was a more nuanced reason for making this a **MUST**, let me know!
