### PR TITLE
Handling of unsupported sorting requests

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -794,6 +794,9 @@ query parameter. The value for `sort` **MUST** represent sort fields.
 GET /people?sort=+age
 ```
 
+If the server does not support sorting as specified in the query parameter 
+`sort`, it **MUST** return `400 Bad Request`.
+
 An endpoint **MAY** support multiple sort fields by allowing comma-separated
 (U+002C COMMA, ",") sort fields. Sort fields **SHOULD** be applied in the
 order specified.


### PR DESCRIPTION
IMHO, it would be appropriate to require servers which do not support sorting requested via `sort` (either no sorting, or only particular fields do not work) to respond with an error rather than allow them to ignore the `sort` query string parameter.

I would like to request to consider this for 1.0.
