### PR TITLE
Include request accepted in the possible response.

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -1016,6 +1016,10 @@ Content-Type: application/vnd.api+json
 }
 ```
 
+##### 202 Accepted <a href="#creating-resources-responses-202" id="creating-resources-responses-202" class="headerlink"></a>
+
+A server **MUST** return `202 Accepted` when the request needs background processing.
+
 ##### 204 No Content <a href="#crud-creating-responses-204" id="crud-creating-responses-204" class="headerlink"></a>
 
 If a `POST` request *did* include a [Client-Generated
@@ -1178,6 +1182,10 @@ attribute or a computed `sha`), it **MUST** return a `200 OK` response.
 
 The response document for a `200 OK` **MUST** include a representation of
 the updated resource(s) as if a `GET` request was made to the request URL.
+
+##### 202 Accepted <a href="#updating-resources-responses-202" id="updating-resources-responses-202" class="headerlink"></a>
+
+A server **MUST** return `202 Accepted` when the request needs background processing.
 
 ##### 403 Forbidden <a href="#crud-updating-relationship-responses-403" id="crud-updating-relationship-responses-403" class="headerlink"></a>
 

--- a/format/index.md
+++ b/format/index.md
@@ -583,6 +583,31 @@ Content-Type: application/vnd.api+json
 }
 ```
 
+##### 202 Accepted <a href="#fetching-resources-responses-202" id="fetching-resources-responses-202" class="headerlink"></a>
+
+A server **MUST** return `202 Accepted` when the resource needs some background processing before the server can respond with the resource.
+
+A server **MUST** include the link to get the resource once the processing is completed in the location header.
+
+A server **MUST** response with null provided as the response document's primary data.
+
+The location header **MAY** be same as self link.
+
+For example, a GET request to comments statistics could return:
+
+```text
+HTTP/1.1 202 OK
+Content-Type: application/vnd.api+json
+location: http://example.com/article/1/stats/comment
+
+{
+  "links": {
+    "self": "http://example.com/article/1/stats/comment"
+  },
+  "data": null
+}
+```
+
 ##### 404 Not Found <a href="#fetching-resources-responses-404" id="fetching-resources-responses-404" class="headerlink"></a>
 
 A server **MUST** return `404 Not Found` when processing a request to fetch


### PR DESCRIPTION
Inspired from the git-hub API for the statistics there are many API's that respond with the stats immediately if the cache is available else the server response with a 202 ACCEPTED response for the request being accepted and processes the request in background. Once there is a cache available the same request can return the response with the required resource.
