### PR TITLE
POSTing resources with invalid type

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -1034,7 +1034,7 @@ A server **MUST** return `409 Conflict` when processing a `POST` request to
 create a resource with a client-generated ID that already exists.
 
 A server **MUST** return `409 Conflict` when processing a `POST` request in
-which the resource's `type` does is not among the type(s) that constitute the
+which the resource's `type` is not among the type(s) that constitute the
 collection represented by the endpoint.
 
 ##### Other Responses <a href="#crud-creating-responses-other" id="crud-creating-responses-other" class="headerlink"></a>

--- a/format/index.md
+++ b/format/index.md
@@ -1034,7 +1034,8 @@ A server **MUST** return `409 Conflict` when processing a `POST` request to
 create a resource with a client-generated ID that already exists.
 
 A server **MUST** return `409 Conflict` when processing a `POST` request in
-which the resource's `type` does not match the server's endpoint.
+which the resource's `type` does is not among the type(s) that constitute the
+collection represented by the endpoint.
 
 ##### Other Responses <a href="#crud-creating-responses-other" id="crud-creating-responses-other" class="headerlink"></a>
 


### PR DESCRIPTION
Start of a PR for #492.

We need to figure out: 

If we're going to explicitly mention the `409` response in the bulk extension, which is what #492 was originally about, we should probably mention the other status codes/responses too. But right now the bulk extension doesn't define any responses at all. So, how do you guys want to handle that?
