### PR TITLE
Adds table of contents to Format document.

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -18,6 +18,33 @@ JSON API requires use of the JSON API media type
 ([`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json))
 for exchanging data.
 
+**Table of Contents**
+
+- [Status](#status)
+- [Introduction](#introduction)
+- [Conventions](#conventions)
+- [Extending](#extending)
+- [Document Structure](#document-structure)
+  - [Top Level](#document-structure-top-level)
+  - [Resource Objects](#document-structure-resource-objects)
+  - [Compound Documents](#document-structure-compound-documents)
+  - [Meta information](#document-structure-meta)
+  - [Top-level Links](#document-structure-top-level-links)
+- [Fetching Data](#fetching)
+  - [Fetching Resources](#fetching-resources)
+  - [Fetching Relationships](#fetching-relationships)
+  - [Inclusion of Related Resources](#fetching-includes)
+  - [Sparse Fieldsets](#fetching-sparse-fieldsets)
+  - [Sorting](#fetching-sorting)
+  - [Pagination](#fetching-pagination)
+  - [Filtering](#fetching-filtering)
+- [Creating, Updating and Deleting Resources](#crud)
+  - [Creating Resources](#crud-creating)
+  - [Updating Resources](#crud-updating)
+  - [Updating Relationships](#crud-updating-relationships)
+  - [Deleting Resources](#crud-deleting)
+- [Errors](#errors)
+
 ## Conventions <a href="#conventions" id="conventions" class="headerlink"></a>
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",


### PR DESCRIPTION
There seems to be no simple way to automatically generate a table of contents when rendering Markdown as HTML via GitHub Pages, so I generated this manually.
