### PR TITLE
Resolve formal contradiction between `fields` and `include`

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -887,9 +887,10 @@ section of the compound document.
 
 The value of the `include` parameter **MUST** be a comma-separated (U+002C
 COMMA, ",") list of relationship paths. A relationship path is a dot-separated
-(U+002E FULL-STOP, ".") list of relationship names. Each relationship name
-**MUST** be identical to the key in the `"relationships"` member of its parent
-resource object.
+(U+002E FULL-STOP, ".") list of relationship names.
+
+If a server is unable to identify a relationship path or does not support
+inclusion of resources from a path, it **MUST** respond with 400 Bad Request.
 
 > Note: For example, a relationship path could be `comments.author`, where
 `comments` is a relationship listed under a `articles` resource object, and


### PR DESCRIPTION
In #476, @hhware pointed out that there's a contradiction between:
1. the requirement that a relationship name in the `include` parameter "MUST be identical to the key in the links section of its parent resource object" and 
2. the possibility that the key for the relationship might not exist in the parent resource object, because it's been excluded by `fields`.

We devised two ways to fix this. 
1. Require that linkage pointing to the included related resources must not be excluded by `fields`. This was expressed originally in #548 and then in the simplified #579.
2. Remove the formal contradiction, but explicitly allow the linkage pointing to the `included` resources to be removed by fields. This approach was represented in #549 and I'm offering a simplified PR for it here.

Whether to go with this PR or #579 depends on the semantics we want for `include`, which we should finish debating first in #497. I just wanted to open this PR to have a concise representation of option 2, as #549 snuck in considerations (like [restrictions on `TYPE`](as a counterpart to #579)) that are beyond the scope of this issue.
