### PR TITLE
Proposal: discoverable actions

### DIFF
--- a/faq/index.md
+++ b/faq/index.md
@@ -39,7 +39,8 @@ interchange format itself.
 
 ### How to discover resource possible actions? <a href="#how-to-discover-resource-possible-actions" id="how-to-discover-resource-possible-actions" class="headerlink"></a>
 
-You should use the OPTIONS HTTP method to discover what can be done with a
+If resource-level member `"actions"` is not provided by the server,
+you should use the OPTIONS HTTP method to discover what can be done with a
 particular resource. The semantics of the methods returned by OPTIONS is defined
 by the JSON API standard.
 

--- a/format/index.md
+++ b/format/index.md
@@ -192,6 +192,8 @@ In addition, a resource object **MAY** contain any of these top-level members:
   relationships (described below).
 * `"meta"`: non-standard meta-information about a resource that can not be
   represented as an attribute or relationship.
+* `"actions"`: a list of actions, which the client can perform on 
+  the given resource.
 
 Here's how an article (i.e. a resource of type "articles") might appear in a document:
 
@@ -377,6 +379,51 @@ to fetch the resource objects, and linkage information.
 The `comments` relationship is simpler: it just provides a related resource URL
 to fetch the comments. The URL can therefore be specified directly as the
 attribute value.
+
+#### Actions <a href="#document-structure-resource-actions" id="document-structure-resource-actions" class="headerlink"></a>
+
+Member `"actions"` contains list of actions which the client can perform 
+on the given resource. If provided, it **MUST** account for authentication
+and authorization status of the current client and for other pertinent 
+circumstances in order to provide a list of actions which the given client 
+is actually allowed to perform on the given resource at the moment when 
+the response is being built by the server.
+
+Its value **MUST** be an array of action objects, each including at least 
+the following members:
+
+* `"label"`: a string, identifying the given action,
+* `"href"`: an endpoint for performing the given action.
+
+In addition, each action object **MAY** include the following members:
+
+* `"method"`: contains name of HTTP method corresponding to the given action.
+* `"meta"`: contains non-standard meta-information about the action.
+
+For example,
+
+```
+// ...
+{
+  "type": "articles",
+  "id": "1",
+  "title": "Rails is Omakase",
+  "actions": [{
+    "label": "FETCH",
+    "href": "http://example.com/articles/1",
+    "method": "GET"
+  },{
+    "label": "DISCARD",
+    "href": "http://example.com/articles/1",
+    "method": "DELETE"
+  },{
+    "label": "PUBLISH",
+    "href": "http://example.com/articles/1/publish",
+    "method": "POST"
+  }]
+}
+// ...
+```
 
 ### Compound Documents <a href="#document-structure-compound-documents" id="document-structure-compound-documents" class="headerlink"></a>
 


### PR DESCRIPTION
IMHO, the suggestion in the FAQ to use `OPTIONS` to communicate a list of actions available on a resource is impractical. There are only 5 HTTP verbs in common use, it is clearly not enough for a complex API. The solution is to provide custom endpoints (such as `POST /articles/1/postprocess`). Essentially, these endpoints provide additional actions for the "parent" endpoint (in this case `/article/1`), but they are not discoverable by performing `OPTIONS` on the parent. 

This proposal is an attempt to provide a standardized solution to this problem: a resource-level member `actions`, which would make JSON API more suitable for APIs supporting HATEOAS. I hope that the proposed format could cover majority of use cases. For methods with complex interfaces, and where the server wishes to provide more information than fits in stadanrd members, `meta` can be used.

I would like to request to consider this for 1.0. It is additive feature, but I hope it is not too controversial, and I also think that the argument for consideration for 1.0 from section Milestoning of https://github.com/json-api/json-api/pull/431#issuecomment-90378980 applies here.
