### PR TITLE
Change of 409 responses to comply with RFC 7231

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -1070,6 +1070,9 @@ create a resource with a client-generated ID that already exists.
 A server **MUST** return `409 Conflict` when processing a `POST` request in
 which the resource's `type` does not match the server's endpoint.
 
+A server **SHOULD** include error details and provide enough information to 
+recognize the source of the conflict.
+
 ##### Other Responses <a href="#crud-creating-responses-other" id="crud-creating-responses-other" class="headerlink"></a>
 
 Servers **MAY** use other HTTP error codes to represent errors. Clients
@@ -1230,6 +1233,9 @@ constraints (such as a uniqueness constraint on a property other than `id`).
 
 A server **MUST** return `409 Conflict` when processing a `PATCH` request in
 which the resource's `type` and `id` do not match the server's endpoint.
+
+A server **SHOULD** include error details and provide enough information to 
+recognize the source of the conflict.
 
 ##### Other Responses <a href="#crud-updating-responses-other" id="crud-updating-responses-other" class="headerlink"></a>
 


### PR DESCRIPTION
Following RFC 7231 for the HTTP/1.1 protocol the server "SHOULD generate a payload that includes enough information for a user to recognize the source of the conflict" when sending a 409 status code:
https://tools.ietf.org/html/rfc7231#section-6.5.8
