### PR TITLE
Allowed format/characters for member names

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -510,33 +510,32 @@ The top-level links object **MAY** contain the following members:
 
 All member names used in the document **MUST** be handled case sensitive by clients and servers, and they **MUST** meet all of the following conditions:
 - Member names **MUST** contain at least one character.
-- Member names **MUST** start and end with one of the following ASCII characters: a-z, A-Z, 0-9, or any NON-ASCII character.
-- Member names **MUST** contain only non-reserved ASCII characters or NON-ASCII characters.
+- Member names **MUST** contain only allowed characters as listed below.
+- Member names **MUST** start and end with an overall allowed character as listed below.
 
-To standardize the naming and to enable an easy mapping of member names to URLs, member names **SHOULD** also meet the following (more restrictive) conditions:
-- Member names **SHOULD** start with one of the following ASCII characters: a-z
-- Member names **SHOULD** consist only of the following URL safe ASCII characters: a-z, 0-9, hyphen minus (U+002D HYPHEN-MINUS, "-")
+To enable an easy mapping of member names to URLs, it's **RECOMMENDED** to limit the allowed characters to non-reserved, URL safe characters, following [RFC 3986](http://tools.ietf.org/html/rfc3986#page-13).
 
-#### Allowed and recommended ASCII characters <a href="#document-structure-member-names-allowed-recommended-ascii-characters" id="document-structure-member-names-allowed-recommended-ascii-characters"></a>
-- a-z
-- 0-9 (not recommended as first character)
-- U+002D HYPHEN-MINUS, "-" (not allowed as first character)
+#### Overall allowed characters <a href="#document-structure-member-names-overall-allowed-characters" id="document-structure-member-names-overall-allowed-characters"></a>
+- U+0061 to U+007A, "a-z"
+- U+0041 to U+005A, "A-Z"
+- U+0030 to U+0039, "0-9"
+- any UNICODE character except U+0000 to U+007F _(not recommended, not URL safe)_
 
-#### Other allowed ASCII characters <a href="#document-structure-member-names-other-allowed-ascii-characters" id="document-structure-member-names-other-allowed-ascii-characters"></a>
-- A-Z
-- U+0020 SPACE, " " (not allowed as first character, not URL safe)
-- U+005F LOW LINE, "_" (not allowed as first character)
-- U+005E CIRCUMFLEX ACCENT, "^" (not allowed as first character, not URL safe)
-- U+0060 GRAVE ACCENT, "`" (not allowed as first character, not URL safe)
+#### Other allowed characters (but not at start/end of the member name) <a href="#document-structure-member-names-other-allowed-characters" id="document-structure-member-names-other-allowed-characters"></a>
+- U+002D HYPHEN-MINUS, "-"
+- U+005F LOW LINE, "_"
+- U+0020 SPACE, " " _(not recommended, not URL safe)_
+- U+005E CIRCUMFLEX ACCENT, "^" _(not recommended, not URL safe)_
+- U+0060 GRAVE ACCENT, "`" _(not recommended, not URL safe)_
 
-#### Reserved ASCII characters (currently in use) <a href="#document-structure-member-names-reserved-ascii-characters-in-use" id="document-structure-member-names-reserved-ascii-characters-in-use"></a>
-- U+002B PLUS SIGN, "+" (used for ordering)
-- U+002C COMMA, "," (used separator for multiple relationship paths)
-- U+002E PERIOD, "." (used as relationship path separators)
-- U+005B LEFT SQUARE BRACKET, "[" (use in sparse fieldsets)
-- U+005D RIGHT SQUARE BRACKET, "]" (used in sparse fieldsets)
+#### Reserved characters (currently in use) <a href="#document-structure-member-names-reserved-ascii-characters-in-use" id="document-structure-member-names-reserved-ascii-characters-in-use"></a>
+- U+002B PLUS SIGN, "+" _(used for ordering)_
+- U+002C COMMA, "," _(used separator for multiple relationship paths)_
+- U+002E PERIOD, "." _(used as relationship path separators)_
+- U+005B LEFT SQUARE BRACKET, "[" _(use in sparse fieldsets)_
+- U+005D RIGHT SQUARE BRACKET, "]" _(used in sparse fieldsets)_
 
-#### Reserved ASCII characters (punctation, currency and math symbols) for later use <a href="#document-structure-member-names-reserved-ascii-characters-later-use" id="document-structure-member-names-reserved-ascii-characters-later-use"></a>
+#### Reserved characters (punctation, currency and math symbols) for later use <a href="#document-structure-member-names-reserved-ascii-characters-later-use" id="document-structure-member-names-reserved-ascii-characters-later-use"></a>
 - U+0021 EXCLAMATION MARK, "!"	 	
 - U+0022 QUOTATION MARK, '"'
 - U+0023 NUMBER SIGN, "#"

--- a/format/index.md
+++ b/format/index.md
@@ -30,6 +30,7 @@ for exchanging data.
   - [Compound Documents](#document-structure-compound-documents)
   - [Meta information](#document-structure-meta)
   - [Top-level Links](#document-structure-top-level-links)
+  - [Member names](#document-structure-member-names)
 - [Fetching Data](#fetching)
   - [Fetching Resources](#fetching-resources)
   - [Fetching Relationships](#fetching-relationships)
@@ -504,6 +505,62 @@ The top-level links object **MAY** contain the following members:
 * `"related"` - a related resource URL (as defined above) when the primary
   data represents a resource relationship.
 * Pagination links for the primary data (as described below).
+
+### Member names <a href="#document-structure-member-names" id="document-structure-member-names"></a>
+
+All member names used in the document **MUST** be handled case sensitive by clients and servers, and they **MUST** meet all of the following conditions:
+- Member names **MUST** contain at least one character.
+- Member names **MUST** start and end with one of the following ASCII characters: a-z, A-Z, 0-9, or any NON-ASCII character.
+- Member names **MUST** contain only non-reserved ASCII characters or NON-ASCII characters.
+
+To standardize the naming and avoid potential problems with the implementation of JSON API, member names **SHOULD** also meet the following (more restrictive) conditions:
+- Members **SHOULD NOT** start with a digit ("0-9").
+- Members **SHOULD NOT** contain NON-ASCII characters.
+- Members **SHOULD NOT** contain ASCII control characters.
+- Members **SHOULD NOT** use the "same" name in different spellings (e.g. "name" and "NAME").
+- Members **SHOULD** use an underscore (U+005F LOW LINE, "_") as word separator.
+
+#### Allowed ASCII characters <a href="#document-structure-member-names-allowed-ascii-characters" id="document-structure-member-names-allowed-ascii-characters"></a>
+- a-z
+- A-Z
+- 0-9
+- U+0020 SPACE, " " (except as first character)
+- U+002D HYPHEN-MINUS, "-" (except as first character)
+- U+005F LOW LINE, "_" (except as first character)
+- U+005E CIRCUMFLEX ACCENT, "^" (except as first character)
+- U+0060 GRAVE ACCENT, "`" (except as first character)
+
+#### Reserved ASCII characters (currently in use) <a href="#document-structure-member-names-reserved-ascii-characters-in-use" id="document-structure-member-names-reserved-ascii-characters-in-use"></a>
+- U+002B PLUS SIGN, "+" (used for ordering)
+- U+002C COMMA, "," (used separator for multiple relationship paths)
+- U+002E PERIOD, "." (used as relationship path separators)
+- U+005B LEFT SQUARE BRACKET, "[" (use in sparse fieldsets)
+- U+005D RIGHT SQUARE BRACKET, "]" (used in sparse fieldsets)
+
+#### Reserved ASCII characters (punctation, currency and math symbols) for later use <a href="#document-structure-member-names-reserved-ascii-characters-later-use" id="document-structure-member-names-reserved-ascii-characters-later-use"></a>
+- U+0021 EXCLAMATION MARK, "!"	 	
+- U+0022 QUOTATION MARK, '"'
+- U+0023 NUMBER SIGN, "#"
+- U+0024 DOLLAR SIGN, "$"
+- U+0025 PERCENT SIGN, "%"
+- U+0026 AMPERSAND, "&"
+- U+0027 APOSTROPHE, "'"
+- U+0028 LEFT PARENTHESIS, "("
+- U+0029 RIGHT PARENTHESIS, ")"
+- U+002A ASTERISK, "*"
+- U+002F SOLIDUS, "/"
+- U+003A COLON, ":"
+- U+003B SEMICOLON, ";"
+- U+003C LESS-THAN SIGN, "<"
+- U+003D EQUALS SIGN, "="
+- U+003E GREATER-THAN SIGN, ">"
+- U+003F QUESTION MARK, "?"
+- U+0040 COMMERCIAL AT, "@"
+- U+005C REVERSE SOLIDUS, "\"
+- U+007B LEFT CURLY BRACKET, "{"
+- U+007C VERTICAL LINE, "|"
+- U+007D RIGHT CURLY BRACKET, "}"
+- U+007E TILDE, "~"
 
 ## Fetching Data <a href="#fetching" id="fetching" class="headerlink"></a>
 

--- a/format/index.md
+++ b/format/index.md
@@ -513,22 +513,21 @@ All member names used in the document **MUST** be handled case sensitive by clie
 - Member names **MUST** start and end with one of the following ASCII characters: a-z, A-Z, 0-9, or any NON-ASCII character.
 - Member names **MUST** contain only non-reserved ASCII characters or NON-ASCII characters.
 
-To standardize the naming and avoid potential problems with the implementation of JSON API, member names **SHOULD** also meet the following (more restrictive) conditions:
-- Members **SHOULD NOT** start with a digit ("0-9").
-- Members **SHOULD NOT** contain NON-ASCII characters.
-- Members **SHOULD NOT** contain ASCII control characters.
-- Members **SHOULD NOT** use the "same" name in different spellings (e.g. "name" and "NAME").
-- Members **SHOULD** use an underscore (U+005F LOW LINE, "_") as word separator.
+To standardize the naming and to enable an easy mapping of member names to URLs, member names **SHOULD** also meet the following (more restrictive) conditions:
+- Member names **SHOULD** start with one of the following ASCII characters: a-z
+- Member names **SHOULD** consist only of the following URL safe ASCII characters: a-z, 0-9, hyphen minus (U+002D HYPHEN-MINUS, "-")
 
-#### Allowed ASCII characters <a href="#document-structure-member-names-allowed-ascii-characters" id="document-structure-member-names-allowed-ascii-characters"></a>
+#### Allowed and recommended ASCII characters <a href="#document-structure-member-names-allowed-recommended-ascii-characters" id="document-structure-member-names-allowed-recommended-ascii-characters"></a>
 - a-z
+- 0-9 (not recommended as first character)
+- U+002D HYPHEN-MINUS, "-" (not allowed as first character)
+
+#### Other allowed ASCII characters <a href="#document-structure-member-names-other-allowed-ascii-characters" id="document-structure-member-names-other-allowed-ascii-characters"></a>
 - A-Z
-- 0-9
-- U+0020 SPACE, " " (except as first character)
-- U+002D HYPHEN-MINUS, "-" (except as first character)
-- U+005F LOW LINE, "_" (except as first character)
-- U+005E CIRCUMFLEX ACCENT, "^" (except as first character)
-- U+0060 GRAVE ACCENT, "`" (except as first character)
+- U+0020 SPACE, " " (not allowed as first character, not URL safe)
+- U+005F LOW LINE, "_" (not allowed as first character)
+- U+005E CIRCUMFLEX ACCENT, "^" (not allowed as first character, not URL safe)
+- U+0060 GRAVE ACCENT, "`" (not allowed as first character, not URL safe)
 
 #### Reserved ASCII characters (currently in use) <a href="#document-structure-member-names-reserved-ascii-characters-in-use" id="document-structure-member-names-reserved-ascii-characters-in-use"></a>
 - U+002B PLUS SIGN, "+" (used for ordering)

--- a/recommendations/index.md
+++ b/recommendations/index.md
@@ -9,11 +9,14 @@ are beyond the scope of the base JSON API specification.
 
 ## Recommendations for Naming <a href="#naming" id="naming" class="headerlink"></a>
 
-The allowed characters for naming members are defined in the spec, but it's recommended to only use the lower-case ASCII characters a-z and 0-9, and to start the name with a-z. Furthormore the hypen minus (U+002D HYPHEN-MINUS, "-") should be used as a word separator.
+The allowed and recommended characters for an URL safe naming of members are defined in the format spec. In addition, to standardize member names, the following restrictions are recommended:
+- Member names **SHOULD** be all lower-case.
+- Member names **SHOULD NOT** start with a digit (U+0030 to U+0039, "0-9")
+- Member names cointaining multiple words **SHOULD** use a hyphen minus (U+002D HYPHEN-MINUS, "-") as word separator.
 
-All these recommended characters are URL safe following [RFC 3986](http://tools.ietf.org/html/rfc3986), so member names can be mapped to URLs without translation (see below for details).
-
-These recommendations help to standardize the naming of members and to avoid potential problems.
+Together with the recommendations in the format spec this results in:
+- Member names **SHOULD** start and end with the characters "a-z" (U+0061 to U+007A)
+- Member names **SHOULD** contain only the characters "a-z" (U+0061 to U+007A), "0-9" (U+0030 to U+0039) and "-" (U+002D HYPHEN-MINUS)
 
 ## Recommendations for URL Design <a href="#urls" id="urls" class="headerlink"></a>
 

--- a/recommendations/index.md
+++ b/recommendations/index.md
@@ -9,14 +9,9 @@ are beyond the scope of the base JSON API specification.
 
 ## Recommendations for Naming <a href="#naming" id="naming" class="headerlink"></a>
 
-The allowed and recommended characters for an URL safe naming of members are defined in the format spec. In addition, to standardize member names, the following restrictions are recommended:
-- Member names **SHOULD** be all lower-case.
-- Member names **SHOULD NOT** start with a digit (U+0030 to U+0039, "0-9")
-- Member names cointaining multiple words **SHOULD** use a hyphen minus (U+002D HYPHEN-MINUS, "-") as word separator.
-
-Together with the recommendations in the format spec this results in:
+The allowed and recommended characters for an URL safe naming of members are defined in the format spec. To also standardize member names, the following (more restrictive) rules are recommended:
 - Member names **SHOULD** start and end with the characters "a-z" (U+0061 to U+007A)
-- Member names **SHOULD** contain only the characters "a-z" (U+0061 to U+007A), "0-9" (U+0030 to U+0039) and "-" (U+002D HYPHEN-MINUS)
+- Member names **SHOULD** contain only the characters "a-z" (U+0061 to U+007A), "0-9" (U+0030 to U+0039), and the hyphen minus (U+002D HYPHEN-MINUS, "-") as seperator between multiple words.
 
 ## Recommendations for URL Design <a href="#urls" id="urls" class="headerlink"></a>
 

--- a/recommendations/index.md
+++ b/recommendations/index.md
@@ -9,9 +9,8 @@ are beyond the scope of the base JSON API specification.
 
 ## Recommendations for Naming <a href="#naming" id="naming" class="headerlink"></a>
 
-It is recommended that resource types, attribute names, and association
-names be "dasherized"; i.e. consist of only lower case alphanumeric
-characters and dashes (U+002D HYPHEN-MINUS, "-").
+It is recommended that resource type names, attribute names, and association
+names with multiple words be separated. It's recommended to use an underscore (U+005F LOW LINE, "_") as separator, because other separator characters (like a hyphen minus or space) could cause problems in some implementation languages, when reading/processing the JSON API document.
 
 It is also recommended that resource types be pluralized. Dasherized and
 pluralized resource types can be used as URL segments without translation,

--- a/recommendations/index.md
+++ b/recommendations/index.md
@@ -9,12 +9,11 @@ are beyond the scope of the base JSON API specification.
 
 ## Recommendations for Naming <a href="#naming" id="naming" class="headerlink"></a>
 
-It is recommended that resource type names, attribute names, and association
-names with multiple words be separated. It's recommended to use an underscore (U+005F LOW LINE, "_") as separator, because other separator characters (like a hyphen minus or space) could cause problems in some implementation languages, when reading/processing the JSON API document.
+The allowed characters for naming members are defined in the spec, but it's recommended to only use the lower-case ASCII characters a-z and 0-9, and to start the name with a-z. Furthormore the hypen minus (U+002D HYPHEN-MINUS, "-") should be used as a word separator.
 
-It is also recommended that resource types be pluralized. Separated and
-pluralized resource types can be used as URL segments without translation,
-as discussed below.
+All these recommended characters are URL safe following [RFC 3986](http://tools.ietf.org/html/rfc3986), so member names can be mapped to URLs without translation (see below for details).
+
+These recommendations help to standardize the naming of members and to avoid potential problems.
 
 ## Recommendations for URL Design <a href="#urls" id="urls" class="headerlink"></a>
 

--- a/recommendations/index.md
+++ b/recommendations/index.md
@@ -12,7 +12,7 @@ are beyond the scope of the base JSON API specification.
 It is recommended that resource type names, attribute names, and association
 names with multiple words be separated. It's recommended to use an underscore (U+005F LOW LINE, "_") as separator, because other separator characters (like a hyphen minus or space) could cause problems in some implementation languages, when reading/processing the JSON API document.
 
-It is also recommended that resource types be pluralized. Dasherized and
+It is also recommended that resource types be pluralized. Separated and
 pluralized resource types can be used as URL segments without translation,
 as discussed below.
 


### PR DESCRIPTION
This patch contains the changes discussed in #567, to reach the following goals:
- Define basic MUSTs for naming members that were missing in the spec (including support for NON-ASCII characters)
- Give API designers the freedom to use another naming scheme if required
- Define recommendations to standardize the naming

This suggestion includes several considerations
- Existing naming of reserved members
- URL mapping / URL safe characters ([RFC 3986](http://tools.ietf.org/html/rfc3986))
- Readability and usability, common spelling
- Reduction of potential implementation problems with some languages
- Not breaking the previous naming recommendations
