### PR TITLE
Allow missing `Accept` header

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -510,10 +510,10 @@ The top-level links object **MAY** contain the following members:
 Data, including resources and relationships, can be fetched by sending a
 `GET` request to an endpoint.
 
-JSON API requests **MUST** include an `Accept` header specifying the JSON
-API media type. This header value **MUST** also include media type
-extensions relevant to the request. Servers **MUST** return a `406 Not
-Acceptable` status code if this header is missing or specifies an
+Clients **MUST** indicate that they can accept the JSON API media type, per
+the semantics of the HTTP `Accept` header. If present, this header value **MUST**
+also include any media type extensions relevant to the request. Servers **MUST**
+return a `406 Not Acceptable` status code if this header specifies an
 unsupported media type.
 
 > Note: Servers may support multiple media types at any endpoint. For example,


### PR DESCRIPTION
The current text says:

> Servers **MUST** return a `406 Not Acceptable` status code if [the `Accept`] header is missing

But this is a violation of the HTTP spec, which [says](https://tools.ietf.org/html/rfc7231#section-5.3.2) that a missing `Accept` header "implies that the user agent will accept any media type in response". Therefore, `406` can never be an appropriate response here. 

So that left two options: keep the requirement for an `Accept` header—even when specifying it wouldn't be necessary for HTTP content-negotiation—and return a `400` when it's missing; or, just allow a missing `Accept` header and treat it according to HTTP's semantics (i.e. as implying `*/*`). Since I don't think we want to mess with HTTP, the second option seemed better.

So this PR both removes the "is missing" part from the 406 conditions and updates the first sentence to say that the `Accept` header isn't required per se; what's required is that the client indicates (per HTTP) that it can accept the JSON-API media type.
