### PR TITLE
Don't require `Accept` validation before `Content-Type` validation

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -91,9 +91,8 @@ name in the `ext` media type parameter with the `Accept` header. Servers
 that do not support a requested extension or combination of extensions
 **MUST** return a `406 Not Acceptable` status code.
 
-If the media type in the `Accept` header is supported by a server but the
-media type in the `Content-Type` header is unsupported, the server
-**MUST** return a `415 Unsupported Media Type` status code.
+If the media type in the client's `Content-Type` header is unsupported, the
+server **MUST** return a `415 Unsupported Media Type` status code.
 
 Servers **MUST NOT** provide extended functionality that is incompatible
 with the base specification to clients that do not request the extension in


### PR DESCRIPTION
The current text implicitly requires a server to check the validity of the `Accept` header (and respond 406 if it's invalid) before checking the validity of the `Content-Type` header. This PR allows the server to check the headers in either order, which will be more convenient for implementors. (This was quite an arbitrary restriction anyway; if anything, it would make sense to check the format of incoming data, i.e. `Content-Type`, first.)

I think the only reason that the text currently reads as it does is to prevent the kind of incompatibility discussed in #608, in which the spec can be simultaneously mandating two different response codes (which it would indeed be doing under my revised text if _both_ the `Accept` and the `Content-Type` headers are invalid). But, as discussed in #608, this type of contradiction can already happen in other places, so we need a generic way to handle it. And it seems unlikely that the approach used here—namely specifying an implicit processing order—is the one we want to use, as doing that for every possible cause of multiple errors would unduly constrain implementations.
