### PR TITLE
Don't allow additional members in error objects by default

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -1511,6 +1511,8 @@ An error object **MAY** have the following members:
   associated resource(s) in the request document. Each path **MUST** be relative
   to the resource path(s) expressed in the error object's `"links"` member
   [e.g. `["/first-name", "/last-name"]` to reference a couple attributes].
+* `"meta"` - to contain non-standard meta-information about the error.
+
 
 [attributes]: #document-structure-resource-object-attributes
 [links]: #document-structure-resource-links

--- a/format/index.md
+++ b/format/index.md
@@ -1512,8 +1512,6 @@ An error object **MAY** have the following members:
   to the resource path(s) expressed in the error object's `"links"` member
   [e.g. `["/first-name", "/last-name"]` to reference a couple attributes].
 
-Additional members **MAY** be specified within error objects.
-
 [attributes]: #document-structure-resource-object-attributes
 [links]: #document-structure-resource-links
 [fields]: #document-structure-resource-object-fields


### PR DESCRIPTION
This is a PR for #604 
