### PR TITLE
Add JSONAPI::Serializers to Ruby implementations.

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -56,7 +56,7 @@ has a page describing how to emit conformant JSON.
 * [Oat](https://github.com/ismasan/oat#adapters) ships with a JSON API adapter.
 * [JSONAPI::Resources](https://github.com/cerebris/jsonapi-resources) provides a complete framework for developing a JSON API server. It is designed to work with Rails, and provides routes, controllers, and serializers.
 * [Yaks](https://github.com/plexus/yaks) Library for building hypermedia APIs, contains a JSON API output format.
-
+* [JSONAPI::Serializers](https://github.com/fotinakis/jsonapi-serializers) provides a pure Ruby, readonly serializer implementation.
 
 ### Python <a href="#server-python" id="server-libraries-python" class="headerlink"></a>
 


### PR DESCRIPTION
I've recently written a pure-Ruby, readonly serializer implementation that is up-to-date with the current version of the spec. Would love to get it added to the implementations listing!

https://github.com/fotinakis/jsonapi-serializers
