### PR TITLE
Introduce "resource identifier objects"

### DIFF
--- a/extensions/bulk/index.md
+++ b/extensions/bulk/index.md
@@ -28,7 +28,7 @@ server **MUST NOT** be changed by a request if any individual operation fails.
 Multiple resources can be created by sending a `POST` request to a URL that
 represents a collection of resources. The request **MUST** include an array
 of resource objects as primary data. Each resource object **MUST** contain
-at least a `type` member.
+at least a `"type"` member.
 
 For instance, multiple photos might be created with the following request:
 
@@ -60,7 +60,7 @@ Accept: application/vnd.api+json; ext=bulk
 Multiple resources can be updated by sending a `PATCH` request to a URL that
 represents a collection of resources to which they all belong. The request
 **MUST** include an array of resource objects as primary data. Each resource
-object **MUST** contain at least `type` and `id` members.
+object **MUST** contain at least `"type"` and `"id"` members.
 
 For example:
 

--- a/extensions/bulk/index.md
+++ b/extensions/bulk/index.md
@@ -91,8 +91,8 @@ Accept: application/vnd.api+json; ext=bulk
 Multiple resources can be deleted by sending a `DELETE` request to a URL that
 represents a collection of resources to which they all belong.
 
-The body of the request **MUST** contain a `data` member whose value is an
-an array of objects that each contain a `type` and `id`.
+The body of the request **MUST** contain a `"data"` member whose value is an
+an array of resource identifier objects.
 
 For example:
 

--- a/extensions/jsonpatch/index.md
+++ b/extensions/jsonpatch/index.md
@@ -97,9 +97,9 @@ target a particular relationship's URL.
 
 #### Updating To-One Relationships <a href="#patch-updating-to-one-relationships" id="patch-updating-to-one-relationships" class="headerlink"></a>
 
-To update a to-one relationship, perform a `"replace"` operation with a URL and
-`"path"` that targets the relationship. The `"value"` **MUST** be a linkage object
-or `null`, to remove the relationship.
+To update a to-one relationship, perform a `"replace"` operation with a URL
+and `"path"` that targets the relationship. The `"value"` **MUST** be a
+resource identifier object or `null`, to remove the relationship.
 
 For instance, the following request should update the `author` of an article:
 
@@ -132,8 +132,8 @@ A server **MUST** respond to Patch operations that target a *to-many
 relationship URL* as described below.
 
 For all operations, the `"value"` **MUST** contain an object that contains
-an array of linkage objects or an empty array, to remove all elements
-of the relationship.
+an array of resource identifier objects or an empty array, to remove all
+elements of the relationship.
 
 If a client requests a `"replace"` operation to a *to-many relationship URL*, the
 server **MUST** either completely replace every member of the relationship,

--- a/format/index.md
+++ b/format/index.md
@@ -255,7 +255,7 @@ consistently throughout an implementation.
 
 #### Resource IDs <a href="#document-structure-resource-ids" id="document-structure-resource-ids" class="headerlink"></a>
 
-Each resource object **MUST** contain an `id` member, whose value **MUST**
+Each resource object **MUST** contain an `"id"` member, whose value **MUST**
 be a string.
 
 #### Relationships <a href="#document-structure-links" id="document-structure-resource-objects-relationships" class="headerlink"></a>
@@ -286,7 +286,7 @@ which **MUST** contain at least one of the following:
   relationship.
 
 A relationship object that represents a to-many relationship **MAY** also contain
-pagination links under the `links` member, as described below.
+pagination links under the `"links"` member, as described below.
 
 If a relationship object refers to resource objects included in the same compound
 document, it **MUST** include resource linkage to those resource objects.

--- a/index.md
+++ b/index.md
@@ -36,14 +36,14 @@ Here's an example response from a blog that implements JSON API:
           "self": "http://example.com/posts/1/relationships/author",
           "related": "http://example.com/posts/1/author"
         },
-        "linkage": { "type": "people", "id": "9" }
+        "data": { "type": "people", "id": "9" }
       },
       "comments": {
         "links": {
           "self": "http://example.com/posts/1/relationships/comments",
           "related": "http://example.com/posts/1/comments"
         },
-        "linkage": [
+        "data": [
           { "type": "comments", "id": "5" },
           { "type": "comments", "id": "12" }
         ]


### PR DESCRIPTION
Instead of referring to "linkage objects" that identify resources with
`type` and `id`, this concept is generalized with a new definition:
"resource identifier objects".

Using this term throughout the spec provides simplification and
consistency, as it can be used not only for relationships but also
for bulk deletes.

Furthermore, with the introduction of the relationships object, we no
longer need to force the term "linkage" into the document structure.
Within a relationships object, this member has been replaced simply with
`"data"`, which represents the relationship data. This has a nice
parallel for relationship URLs in which relationship data _is_ the
primary data.

Credit to @ethanresnick for the term "resource identifier object".

See #618 and #625 for more history and discussion.
