### PR TITLE
Try to fix listing in naming section

### DIFF
--- a/recommendations/index.md
+++ b/recommendations/index.md
@@ -11,6 +11,7 @@ are beyond the scope of the base JSON API specification.
 ## Naming <a href="#naming" id="naming" class="headerlink"></a>
 
 The allowed and recommended characters for an URL safe naming of members are defined in the format spec. To also standardize member names, the following (more restrictive) rules are recommended:
+
 - Member names **SHOULD** start and end with the characters "a-z" (U+0061 to U+007A)
 - Member names **SHOULD** contain only the characters "a-z" (U+0061 to U+007A), "0-9" (U+0030 to U+0039), and the hyphen minus (U+002D HYPHEN-MINUS, "-") as seperator between multiple words.
 


### PR DESCRIPTION
Added a line break before the list, as suggested in #634
