### PR TITLE
Extensions Overhaul

### DIFF
--- a/extensions/index.md
+++ b/extensions/index.md
@@ -6,15 +6,17 @@ show_sidebar: true
 
 JSON API can be extended in several ways:
 
-* The `supported-ext` and `ext` media type parameters can be used to negotiate
-  support for extensions,
-  [as discussed in the base specification](/format#extending).
-  Official and custom extensions to the specification are discussed below.
+* [Meta information](/format/#document-structure-meta) can be included throughout
+  request and response documents, to communicate extra data or enable additional
+  behaviors. Meta information is non-standard, and so should be used only for
+  customizations that only apply to a single API or a small set of APIs.
 
-* Meta information can be included in several places in a document,
-  [as discussed in the base specification](/format/#document-structure-meta).
+* API creators can also author [extensions](/format#extending) if they need to
+  make more radical changes to the base specification than is possible using
+  `meta`. Extensions also allow individuals to define a format for supporting
+  a new capability that can then be published and shared for use by others.
+  Two such published extensions are the official extensions listed below.
 
-* A profile can be specified in the top-level `meta` object, as discussed below.
 
 ## Official Extensions <a href="#official-extensions" id="official-extensions" class="headerlink"></a>
 
@@ -29,86 +31,3 @@ JSON API currently supports the following official extensions:
   [[RFC5789](http://tools.ietf.org/html/rfc5789)] and the JSON Patch format
   [[RFC6902](http://tools.ietf.org/html/rfc6902)]. The JSON Patch extension is
   referenced with the extension name `jsonpatch`.
-
-## Custom Extensions <a href="#custom-extensions" id="custom-extensions" class="headerlink"></a>
-
-The JSON API media type can be extended for your organization by writing your
-own custom extension. This extension should also be specified using the `ext`
-and `supported-ext` media type parameters.
-
-It is strongly recommended that custom extensions be prefixed with a unique
-identifier for your organization to avoid namespace collision. For example,
-`my-org/embedded-resources`.
-
-## Profiles <a href="#profiles" id="profiles" class="headerlink"></a>
-
-JSON API can be extended with the profile link relation, defined in [RFC
-6906](http://tools.ietf.org/html/rfc6906). See also [this blog post by Mark
-Nottingham](http://www.mnot.net/blog/2012/04/17/profiles).
-
-According to the RFC, profiles are:
-
-```text
-defined not to alter the semantics of the resource representation itself, but
-to allow clients to learn about additional semantics (constraints, conventions,
-extensions) that are associated with the resource representation, in addition
-to those defined by the media type and possibly other mechanisms.
-```
-
-A profile link **SHOULD** be specified in the top-level `meta` object, keyed
-by `profile`.
-
-For example, let's say that you want your API to support a offset / limit
-based pagination scheme that you'd like to describe to your users. You would
-make some sort of profile page on your site, such as
-`http://api.example.com/profile`, and then include it in the `meta` key of
-your responses:
-
-```text
-GET http://api.example.com/posts
-
-{
-  "meta": {
-    "profile": "http://api.example.com/profile",
-    "page": {
-      "offset": 1,
-      "limit": 10,
-      "total": 35
-    }
-  },
-  "links": {
-    "self": "http://api.example.com/posts",
-    "next": "http://api.example.com/posts?page[offset]=11",
-    "last": "http://api.example.com/posts?page[offset]=31"
-  },
-  "data": [
-    // First 10 posts
-  ]
-}
-```
-
-That document will de-reference to explain your link relations:
-
-```http
-GET http://api.example.com/profile HTTP/1.1
-```
-
-```text
-HTTP/1.1 200 OK
-Content-Type: text/plain
-
-The Example.com API Profile
-===========================
-
-The Example.com API uses simple offset and limit-based pagination. Paginated
-resources will include the standard JSON API `next`, `prev`, `first`, and
-`last` pagination links in the top-level `links` object when they are not
-`null`.
-
-In addition, a `page` member will be added to the top-level `meta` object
-that includes the following members: `offset`, `limit`, and `total`. The
-`total` member represents the total count of resources in the paginated
-collection. You can use the `offset` and `limit` members to construct your
-own custom pagination links with the query parameters `page[offset]` and
-`page[limit]`.
-```

--- a/faq/index.md
+++ b/faq/index.md
@@ -6,8 +6,8 @@ title: Frequently Asked Questions
 ## Why is JSON API not versioned? <a href="#why-is-json-api-not-versioned" id="why-is-json-api-not-versioned" class="headerlink"></a>
 
 Once JSON API is stable, it will always be backwards compatible using a _never
-remove, only add_ strategy.
-[#46](https://github.com/json-api/json-api/issues/46)
+remove, only add_ strategy. All future additions will fit the constraints of
+[profile extensions](/format#extending-extension-types-profile-extensions).
 
 ## Why not use the HAL specification? <a href="#why-not-use-the-hal-specification" id="why-not-use-the-hal-specification" class="headerlink"></a>
 

--- a/format/index.md
+++ b/format/index.md
@@ -13,7 +13,8 @@ fetched or modified, and how a server should respond to those requests.
 
 JSON API is designed to minimize both the number of requests and the amount of
 data transmitted between clients and servers. This efficiency is achieved
-without compromising readability, flexibility, or discoverability.
+without compromising readability, flexibility, or discoverability. JSON API can
+also be easily [extended](#extending).
 
 JSON API requires use of the JSON API media type
 ([`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json))
@@ -25,65 +26,6 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in RFC 2119
 [[RFC2119](http://tools.ietf.org/html/rfc2119)].
-
-## Extending <a href="#extending" id="extending" class="headerlink"></a>
-
-The base JSON API specification **MAY** be extended to support additional
-capabilities.
-
-An extension **MAY** make changes to and deviate from the requirements of the
-base specification apart from this section, which remains binding.
-
-Servers that support one or more extensions to JSON API **MUST** return
-those extensions in every response in the `supported-ext` media type
-parameter of the `Content-Type` header. The value of the `supported-ext`
-parameter **MUST** be a comma-separated (U+002C COMMA, ",") list of
-extension names.
-
-For example: a response that includes the header `Content-Type:
-application/vnd.api+json; supported-ext="bulk,jsonpatch"` indicates that the
-server supports both the "bulk" and "jsonpatch" extensions.
-
-If an extension is used to form a particular request or response document,
-then it **MUST** be specified by including its name in the `ext` media type
-parameter with the `Content-Type` header. The value of the `ext` media type
-parameter **MUST** be formatted as a comma-separated (U+002C COMMA, ",")
-list of extension names and **MUST** be limited to a subset of the
-extensions supported by the server, which are listed in `supported-ext`
-of every response.
-
-For example: a response that includes the header `Content-Type:
-application/vnd.api+json; ext="ext1,ext2"; supported-ext="ext1,ext2,ext3"`
-indicates that the response document is formatted according to the
-extensions "ext1" and "ext2". Another example: a request that includes
-the header `Content-Type: application/vnd.api+json; ext="ext1,ext2"`
-indicates that the request document is formatted according to the
-extensions "ext1" and "ext2".
-
-Clients **MAY** request a particular media type extension by including its
-name in the `ext` media type parameter with the `Accept` header. Servers
-that do not support a requested extension or combination of extensions
-**MUST** return a `406 Not Acceptable` status code.
-
-If the media type in the `Accept` header is supported by a server but the
-media type in the `Content-Type` header is unsupported, the server
-**MUST** return a `415 Unsupported Media Type` status code.
-
-Servers **MUST NOT** provide extended functionality that is incompatible
-with the base specification to clients that do not request the extension in
-the `ext` parameter of the `Content-Type` or the `Accept` header.
-
-> Note: Since extensions can contradict one another or have interactions
-that can be resolved in many equally plausible ways, it is the
-responsibility of the server to decide which extensions are compatible, and
-it is the responsibility of the designer of each implementation of this
-specification to describe extension interoperability rules which are
-applicable to that implementation.
-
-When the value of the `ext` or `supported-ext` media type parameter contains
-more than one extension name, the value **MUST** be surrounded with quotation
-marks (U+0022 QUOTATION MARK, """), in accordance with the HTTP specification.
-
 
 ## Document Structure <a href="#document-structure" id="document-structure" class="headerlink"></a>
 
@@ -1585,6 +1527,65 @@ successful.
 Servers **MAY** use other HTTP error codes to represent errors. Clients
 **MUST** interpret those errors in accordance with HTTP semantics. Error
 details **MAY** also be returned, as discussed below.
+
+
+## Extending <a href="#extending" id="extending" class="headerlink"></a>
+
+The base JSON API specification **MAY** be extended to support additional
+capabilities.
+
+An extension **MAY** make changes to and deviate from the requirements of the
+base specification apart from this section, which remains binding.
+
+Servers that support one or more extensions to JSON API **MUST** return
+those extensions in every response in the `supported-ext` media type
+parameter of the `Content-Type` header. The value of the `supported-ext`
+parameter **MUST** be a comma-separated (U+002C COMMA, ",") list of
+extension names.
+
+For example: a response that includes the header `Content-Type:
+application/vnd.api+json; supported-ext="bulk,jsonpatch"` indicates that the
+server supports both the "bulk" and "jsonpatch" extensions.
+
+If an extension is used to form a particular request or response document,
+then it **MUST** be specified by including its name in the `ext` media type
+parameter with the `Content-Type` header. The value of the `ext` media type
+parameter **MUST** be formatted as a comma-separated (U+002C COMMA, ",")
+list of extension names and **MUST** be limited to a subset of the
+extensions supported by the server, which are listed in `supported-ext`
+of every response.
+
+For example: a response that includes the header `Content-Type:
+application/vnd.api+json; ext="ext1,ext2"; supported-ext="ext1,ext2,ext3"`
+indicates that the response document is formatted according to the
+extensions "ext1" and "ext2". Another example: a request that includes
+the header `Content-Type: application/vnd.api+json; ext="ext1,ext2"`
+indicates that the request document is formatted according to the
+extensions "ext1" and "ext2".
+
+Clients **MAY** request a particular media type extension by including its
+name in the `ext` media type parameter with the `Accept` header. Servers
+that do not support a requested extension or combination of extensions
+**MUST** return a `406 Not Acceptable` status code.
+
+If the media type in the `Accept` header is supported by a server but the
+media type in the `Content-Type` header is unsupported, the server
+**MUST** return a `415 Unsupported Media Type` status code.
+
+Servers **MUST NOT** provide extended functionality that is incompatible
+with the base specification to clients that do not request the extension in
+the `ext` parameter of the `Content-Type` or the `Accept` header.
+
+> Note: Since extensions can contradict one another or have interactions
+that can be resolved in many equally plausible ways, it is the
+responsibility of the server to decide which extensions are compatible, and
+it is the responsibility of the designer of each implementation of this
+specification to describe extension interoperability rules which are
+applicable to that implementation.
+
+When the value of the `ext` or `supported-ext` media type parameter contains
+more than one extension name, the value **MUST** be surrounded with quotation
+marks (U+0022 QUOTATION MARK, """), in accordance with the HTTP specification.
 
 ## Errors <a href="#errors" id="errors" class="headerlink"></a>
 

--- a/format/index.md
+++ b/format/index.md
@@ -515,13 +515,20 @@ the following members:
 
 ### Member Names <a href="#document-structure-member-names" id="document-structure-member-names" class="headerlink"></a>
 
-All member names used in a JSON API document **MUST** be treated as case sensitive
-by clients and servers, and they **MUST** meet all of the following conditions:
+All member names used in a JSON API document **MUST** be treated as case
+sensitive by clients and servers.
 
-- Member names **MUST** contain at least one character.
+Member names added to a document by an [extension](#extending) **MUST** be
+prefixed with either an underscore (U+005F LOW LINE, "_") or an "at sign"
+(U+0040 COMMERCIAL AT, "@").
+
+Additionally:
+
+- Member names **MUST** contain at least one character in addition to their
+  prefix character (if any).
 - Member names **MUST** contain only the allowed characters listed below.
-- Member names **MUST** start and end with a "globally allowed character",
-  as defined below.
+- Excluding their prefix character (if any), member names **MUST** start and end
+  with a "globally allowed character", as defined below.
 
 To enable an easy mapping of member names to URLs, it is **RECOMMENDED** that
 member names use only non-reserved, URL safe characters specified in [RFC 3986](http://tools.ietf.org/html/rfc3986#page-13).
@@ -535,11 +542,13 @@ The following "globally allowed characters" **MAY** be used anywhere in a member
 - U+0030 to U+0039, "0-9"
 - any UNICODE character except U+0000 to U+007F _(not recommended, not URL safe)_
 
-Additionally, the following characters are allowed in member names, except as the
-first or last character:
+Additionally, the following characters **MAY** be used in member names, except as
+the last character and, excluding their possible use as a prefix character, as the
+first character:
 
 - U+002D HYPHEN-MINUS, "-"
 - U+005F LOW LINE, "_"
+- U+0040 COMMERCIAL AT, "@"
 - U+0020 SPACE, " " _(not recommended, not URL safe)_
 - U+005E CIRCUMFLEX ACCENT, "^" _(not recommended, not URL safe)_
 - U+0060 GRAVE ACCENT, "`" _(not recommended, not URL safe)_
@@ -570,12 +579,20 @@ The following characters **MUST NOT** be used in member names:
 - U+003D EQUALS SIGN, "="
 - U+003E GREATER-THAN SIGN, ">"
 - U+003F QUESTION MARK, "?"
-- U+0040 COMMERCIAL AT, "@"
 - U+005C REVERSE SOLIDUS, "\"
 - U+007B LEFT CURLY BRACKET, "{"
 - U+007C VERTICAL LINE, "|"
 - U+007D RIGHT CURLY BRACKET, "}"
 - U+007E TILDE, "~"
+
+### Query Parameter Names
+
+If a URI in a `links` object contains any query parameters other than those
+defined or reserved for users by this specification, the names of these
+additional query parameters **MUST** begin with an underscore (U+005F LOW LINE, "_")
+or an "at sign" (U+0040 COMMERCIAL AT, "@").
+
+This is the only restriction that JSON API imposes on URIs.
 
 ## Fetching Data <a href="#fetching" id="fetching" class="headerlink"></a>
 


### PR DESCRIPTION
Ok guys. Here's the PR that I've been alluding to for #614. It's a lot of new stuff, but I think it's really important to get extensions right for 1.0. 

Our current system let's any extension do anything, which means we're giving up the opportunity to signal that whole classes of extensions are composable and to encourage people to design composable extensions. Making extensions composable is useful for generic clients, client and server libraries, and the prospect of extension reuse/developing an extension ecosystem. 

We're also allowing extensions that contradict the base spec (as opposed to just adding to it), which opens the door to a lot of confusion, and to the possibility that the media type will become pretty meaningless.

Finally, the current system has both the `ext`/`supported-ext` approach _and_ the profile option, which is just plain bizarre.

This PR is an attempt to unify and add rigor to the extension mechanisms to get the best of all worlds. The thinking behind most of these changes is already covered in depth in #614, but I'll try to summarize it here:
1. Dividing the extensions into profile extensions and comprehensive extensions comes from [this comment](https://github.com/json-api/json-api/issues/614#issuecomment-103717409). The idea is to guarantee composability where possible, while also having a more powerful type of extension that can make non-composable changes.
2. But restricting even the comprehensive extensions to honoring the base spec is aimed at making sure they're truly additive. I discussed this idea [here](https://github.com/json-api/json-api/issues/614#issuecomment-103726921).
3. The requirement that profile extensions used prefixed member names is based on the fact that we need _some_ way to make them forward compatible, and doing it this way: 1) [let's us](https://github.com/json-api/json-api/issues/614#issuecomment-103733776) define JSON-LD as a profile extension and 2) offers an approach that can be carried over to query parameters to consistently and visually delineate userland members from spec-defined ones.
4. The new advertising mechanism with options is based on the fact that `supported-ext` sucked in at least four ways:
   - It makes the protocol chattier than necessary, since the list of extensions has to be sent on every response, even after negotiation's done.
   - It's an abuse of the media type, since `supported-ext` doesn't actually tell you anything about the content. Meanwhile, `OPTIONS` is designed precisely for things like this.
   - The `supported-ext` list can't signal which _combinations_ of the listed extensions are supported. The OPTIONS format doesn't right now either (since I just wanted to get this in), but it could easily be extended to later.
   - The `supported-ext` header can't signal whether the listed extensions apply to other endpoints too (since not every extension will apply to every endpoint). But, again, the `OPTIONS` response could be extended in the future to specify which extensions apply beyond the current resource, to save future requests.

Note that I haven't written the last chunk of the negotiation section yet, but I just wanted to get this in asap so you guys could see it.
