### PR TITLE
change references from standard to specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ JSON API
 
 Documentation for the [application/vnd.api+json media
 type](http://www.iana.org/assignments/media-types/application/vnd.api+json),
-a standard for APIs that use JSON. This repository is the
+a specification for APIs that use JSON. This repository is the
 source code for [http://jsonapi.org](http://jsonapi.org).
 
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -31,7 +31,7 @@
       <header>
         <div class="content">
           <h1>JSON API</h1>
-          <h2>A standard for building APIs in JSON.</h2>
+          <h2>A specification for building APIs in JSON.</h2>
 
           <div class="quicklinks">
             {% for link in site.quicklinks %}

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "A standard for building APIs in JSON"
+title: "A specification for building APIs in JSON"
 show_masthead: true
 ---
 


### PR DESCRIPTION
JSON-API is not yet a standard--we should use the terminology
"specification" until it becomes one.
