### PR TITLE
Remove extension mechanism from base spec.

### DIFF
--- a/extensions/bulk/index.md
+++ b/extensions/bulk/index.md
@@ -5,8 +5,9 @@ title: "Bulk Extension"
 
 ## Status <a href="#status" id="status" class="headerlink"></a>
 
-**This extension is a work in progress** and will change as implementation work
-progresses.
+**Extensions are an experimental feature** and should be considered a work
+in progress. There is no official support for extensions in the base JSON
+API specification.
 
 ## Introduction <a href="#introduction" id="introduction" class="headerlink"></a>
 

--- a/extensions/index.md
+++ b/extensions/index.md
@@ -4,17 +4,83 @@ title: Extensions
 show_sidebar: true
 ---
 
+## Status
+
+**Extensions are an experimental feature** and should be considered a work
+in progress. There is no official support for extensions in the base JSON
+API specification.
+
+## Extending JSON API <a href="#extending-json-api" id="extending-json-api" class="headerlink"></a>
+
 JSON API can be extended in several ways:
 
-* The `supported-ext` and `ext` media type parameters can be used to negotiate
-  support for extensions,
-  [as discussed in the base specification](/format#extending).
-  Official and custom extensions to the specification are discussed below.
+* [Official](#official-extensions) and [custom](#custom-extensions) extensions
+  are in development. The `supported-ext` and `ext` media type parameters can
+  be used to [negotiate support for extensions](#extension-negotiation).
 
 * Meta information can be included in several places in a document,
   [as discussed in the base specification](/format/#document-structure-meta).
 
-* A profile can be specified in the top-level `meta` object, as discussed below.
+* A profile can be specified in the top-level `"meta"` object, as discussed
+  below.
+
+## Extension Negotiation <a href="#extension-negotiation" id="extension-negotiation" class="headerlink"></a>
+
+The JSON API specification **MAY** be extended to support additional
+capabilities.
+
+An extension **MAY** make changes to and deviate from the requirements of the
+base specification apart from this section, which remains binding.
+
+Servers that support one or more extensions to JSON API **MUST** return
+those extensions in every response in the `supported-ext` media type
+parameter of the `Content-Type` header. The value of the `supported-ext`
+parameter **MUST** be a comma-separated (U+002C COMMA, ",") list of
+extension names.
+
+For example: a response that includes the header `Content-Type:
+application/vnd.api+json; supported-ext="bulk,jsonpatch"` indicates that the
+server supports both the "bulk" and "jsonpatch" extensions.
+
+If an extension is used to form a particular request or response document,
+then it **MUST** be specified by including its name in the `ext` media type
+parameter with the `Content-Type` header. The value of the `ext` media type
+parameter **MUST** be formatted as a comma-separated (U+002C COMMA, ",")
+list of extension names and **MUST** be limited to a subset of the
+extensions supported by the server, which are listed in `supported-ext`
+of every response.
+
+For example: a response that includes the header `Content-Type:
+application/vnd.api+json; ext="ext1,ext2"; supported-ext="ext1,ext2,ext3"`
+indicates that the response document is formatted according to the
+extensions "ext1" and "ext2". Another example: a request that includes
+the header `Content-Type: application/vnd.api+json; ext="ext1,ext2"`
+indicates that the request document is formatted according to the
+extensions "ext1" and "ext2".
+
+Clients **MAY** request a particular media type extension by including its
+name in the `ext` media type parameter with the `Accept` header. Servers
+that do not support a requested extension or combination of extensions
+**MUST** return a `406 Not Acceptable` status code.
+
+If the media type in the `Accept` header is supported by a server but the
+media type in the `Content-Type` header is unsupported, the server
+**MUST** return a `415 Unsupported Media Type` status code.
+
+Servers **MUST NOT** provide extended functionality that is incompatible
+with the base specification to clients that do not request the extension in
+the `ext` parameter of the `Content-Type` or the `Accept` header.
+
+> Note: Since extensions can contradict one another or have interactions
+that can be resolved in many equally plausible ways, it is the
+responsibility of the server to decide which extensions are compatible, and
+it is the responsibility of the designer of each implementation of this
+specification to describe extension interoperability rules which are
+applicable to that implementation.
+
+When the value of the `ext` or `supported-ext` media type parameter contains
+more than one extension name, the value **MUST** be surrounded with quotation
+marks (U+0022 QUOTATION MARK, """), in accordance with the HTTP specification.
 
 ## Official Extensions <a href="#official-extensions" id="official-extensions" class="headerlink"></a>
 

--- a/extensions/jsonpatch/index.md
+++ b/extensions/jsonpatch/index.md
@@ -5,8 +5,9 @@ title: "JSON Patch Extension"
 
 ## Status <a href="#status" id="status" class="headerlink"></a>
 
-**This extension is a work in progress** and will change as implementation work
-progresses.
+**Extensions are an experimental feature** and should be considered a work
+in progress. There is no official support for extensions in the base JSON
+API specification.
 
 ## Introduction <a href="#introduction" id="introduction" class="headerlink"></a>
 

--- a/format/index.md
+++ b/format/index.md
@@ -26,65 +26,6 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 interpreted as described in RFC 2119
 [[RFC2119](http://tools.ietf.org/html/rfc2119)].
 
-## Extending <a href="#extending" id="extending" class="headerlink"></a>
-
-The base JSON API specification **MAY** be extended to support additional
-capabilities.
-
-An extension **MAY** make changes to and deviate from the requirements of the
-base specification apart from this section, which remains binding.
-
-Servers that support one or more extensions to JSON API **MUST** return
-those extensions in every response in the `supported-ext` media type
-parameter of the `Content-Type` header. The value of the `supported-ext`
-parameter **MUST** be a comma-separated (U+002C COMMA, ",") list of
-extension names.
-
-For example: a response that includes the header `Content-Type:
-application/vnd.api+json; supported-ext="bulk,jsonpatch"` indicates that the
-server supports both the "bulk" and "jsonpatch" extensions.
-
-If an extension is used to form a particular request or response document,
-then it **MUST** be specified by including its name in the `ext` media type
-parameter with the `Content-Type` header. The value of the `ext` media type
-parameter **MUST** be formatted as a comma-separated (U+002C COMMA, ",")
-list of extension names and **MUST** be limited to a subset of the
-extensions supported by the server, which are listed in `supported-ext`
-of every response.
-
-For example: a response that includes the header `Content-Type:
-application/vnd.api+json; ext="ext1,ext2"; supported-ext="ext1,ext2,ext3"`
-indicates that the response document is formatted according to the
-extensions "ext1" and "ext2". Another example: a request that includes
-the header `Content-Type: application/vnd.api+json; ext="ext1,ext2"`
-indicates that the request document is formatted according to the
-extensions "ext1" and "ext2".
-
-Clients **MAY** request a particular media type extension by including its
-name in the `ext` media type parameter with the `Accept` header. Servers
-that do not support a requested extension or combination of extensions
-**MUST** return a `406 Not Acceptable` status code.
-
-If the media type in the `Accept` header is supported by a server but the
-media type in the `Content-Type` header is unsupported, the server
-**MUST** return a `415 Unsupported Media Type` status code.
-
-Servers **MUST NOT** provide extended functionality that is incompatible
-with the base specification to clients that do not request the extension in
-the `ext` parameter of the `Content-Type` or the `Accept` header.
-
-> Note: Since extensions can contradict one another or have interactions
-that can be resolved in many equally plausible ways, it is the
-responsibility of the server to decide which extensions are compatible, and
-it is the responsibility of the designer of each implementation of this
-specification to describe extension interoperability rules which are
-applicable to that implementation.
-
-When the value of the `ext` or `supported-ext` media type parameter contains
-more than one extension name, the value **MUST** be surrounded with quotation
-marks (U+0022 QUOTATION MARK, """), in accordance with the HTTP specification.
-
-
 ## Document Structure <a href="#document-structure" id="document-structure" class="headerlink"></a>
 
 This section describes the structure of a JSON API document, which is identified
@@ -293,7 +234,7 @@ relationship URLs.
 If present, a *related resource URL* **MUST** be a valid URL, even if the
 relationship isn't currently associated with any target resources.
 
-> Note: The spec does not impart meaning to order of resource identifier 
+> Note: The spec does not impart meaning to order of resource identifier
 objects in linkage arrays of to-many relationships, although implementations
 may do that. Arrays of resource identifier objects may represent ordered
 or unordered relationships, and both types can be mixed in one response
@@ -1556,7 +1497,7 @@ Accept: application/vnd.api+json
 ```
 
 If a client makes a `POST` request to a *relationship URL*, the server
-**MUST** add the specified members to the relationship unless they are 
+**MUST** add the specified members to the relationship unless they are
 already present. If a given `type` and `id` is already in the relationship,
 the server **MUST NOT** add it again.
 

--- a/format/index.md
+++ b/format/index.md
@@ -26,6 +26,25 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 interpreted as described in RFC 2119
 [[RFC2119](http://tools.ietf.org/html/rfc2119)].
 
+## Media Type Negotiation <a href="#media-type-negotiation" id="media-type-negotiation" class="headerlink"></a>
+
+Clients **MUST** send all JSON API data in request documents with
+the header `Content-Type: application/vnd.api+json`.
+
+Clients **MUST** ignore all parameters for the `application/vnd.api+json`
+media type received in the `Content-Type` header of response documents.
+
+Servers **MUST** send all JSON API data in response documents with
+the header `Content-Type: application/vnd.api+json`.
+
+Servers **MUST** return a `406 Not Acceptable` status code if the
+`application/vnd.api+json` media type is modified by the `ext` parameter in
+the `Accept` header of a request. Otherwise, servers **MUST** return a `415
+Unsupported Media Type` status code if the `application/vnd.api+json` media
+type is modified by the `ext` parameter in the `Content-Type` header of a
+request. Servers **MUST** ignore all other parameters for the
+`application/vnd.api+json` in `Accept` and `Content-Type` headers.
+
 ## Document Structure <a href="#document-structure" id="document-structure" class="headerlink"></a>
 
 This section describes the structure of a JSON API document, which is identified

--- a/format/index.md
+++ b/format/index.md
@@ -45,6 +45,9 @@ type is modified by the `ext` parameter in the `Content-Type` header of a
 request. Servers **MUST** ignore all other parameters for the
 `application/vnd.api+json` in `Accept` and `Content-Type` headers.
 
+> Note: These requirements may allow future versions of this specification
+to support an extension mechanism based upon the `ext` media type parameter.
+
 ## Document Structure <a href="#document-structure" id="document-structure" class="headerlink"></a>
 
 This section describes the structure of a JSON API document, which is identified

--- a/index.md
+++ b/index.md
@@ -108,9 +108,9 @@ specification](/format).
 
 ## Extensions <a href="#extensions" id="extensions" class="headerlink"></a>
 
-JSON API can be [extended in several ways](/extensions).
+JSON API has [experimental support for extensions](/extensions).
 
-Official extensions are available for [Bulk](/extensions/bulk/) and
+Official extensions are being developed for [Bulk](/extensions/bulk/) and
 [JSON Patch](/extensions/jsonpatch/) operations.
 
 ## Update history <a href="#update-history" id="update-history" class="headerlink"></a>


### PR DESCRIPTION
Instead of rushing the extension mechanism into the 1.0 release, we are
marking it as experimental and removing it from the base spec.

This allows us to solidify the extension concepts for a future release.
