### PR TITLE
JSON API reaches final review phase.

### DIFF
--- a/_includes/status.md
+++ b/_includes/status.md
@@ -1,4 +1,5 @@
 ## Status <a href="#status" id="status" class="headerlink"></a>
 
-**This document is a work in progress** and will change as implementation work
-progresses. See the [Status](/status) page for more information.
+**This document is a work in progress** and is in a final review phase
+before the specification reaches 1.0 on May 28, 2015. See the
+[Status](/status) page for more information.

--- a/index.md
+++ b/index.md
@@ -115,6 +115,8 @@ Official extensions are available for [Bulk](/extensions/bulk/) and
 
 ## Update history <a href="#update-history" id="update-history" class="headerlink"></a>
 
+- _2015-05-28: 1.0 final to be released._
+- 2015-05-21: Release candidate 4 released.
 - 2015-03-16: Release candidate 3 released.
 - 2015-02-18: Release candidate 2 released.
 - 2014-07-05: Release candidate 1 released.

--- a/status/index.md
+++ b/status/index.md
@@ -3,10 +3,17 @@ layout: page
 title: "JSON API: Specification Status"
 ---
 
-JSON API is at a third release candidate state. This means that it is not yet
-stable, however, libraries intended to work with 1.0 should implement this
-version of the specification. We may make very small tweaks, but everything is
-basically in place.
+JSON API is at a fourth release candidate state.
+
+This is the final release candidate before the specification will be tagged
+1.0 on May 28, 2015.
+
+In the final week before 1.0, do not expect any changes to the specified
+document structure. This release candidate exists solely to provide time for
+the specification to be carefully reviewed for inconsistencies and defects.
+
+Libraries intended to work with 1.0 should implement this version of the
+specification as soon as possible.
 
 Work on this specification is being done at its [GitHub
 repository](https://github.com/json-api/json-api). Please feel free to help


### PR DESCRIPTION
Due to the massive number of changes to the specification in the past
two weeks, we are providing an extra week for final review before
tagging 1.0.

This release candidate, technically RC4, exists solely to provide time
for the specification to be carefully reviewed for inconsistencies and
defects. Do not expect any changes to the specified document structure.

Thanks to the supportive (and prolific) group of contributors who have
helped us reach this milestone. Let's ensure that the final spec is
as good as can be!

---

_This should be merged by the end of today._
