### PR TITLE
Optimize allowed characters for version 1.0

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -551,8 +551,6 @@ first or last character:
 - U+002D HYPHEN-MINUS, "-"
 - U+005F LOW LINE, "_"
 - U+0020 SPACE, " " _(not recommended, not URL safe)_
-- U+005E CIRCUMFLEX ACCENT, "^" _(not recommended, not URL safe)_
-- U+0060 GRAVE ACCENT, "`" _(not recommended, not URL safe)_
 
 #### Reserved Characters <a href="#document-structure-member-names-reserved-characters" id="document-structure-member-names-reserved-characters" class="headerlink"></a>
 
@@ -582,6 +580,8 @@ The following characters **MUST NOT** be used in member names:
 - U+003F QUESTION MARK, "?"
 - U+0040 COMMERCIAL AT, "@"
 - U+005C REVERSE SOLIDUS, "\"
+- U+005E CIRCUMFLEX ACCENT, "^"
+- U+0060 GRAVE ACCENT, "`"
 - U+007B LEFT CURLY BRACKET, "{"
 - U+007C VERTICAL LINE, "|"
 - U+007D RIGHT CURLY BRACKET, "}"


### PR DESCRIPTION
As the extensions have been removed from version 1.0 of the spec and it's not clear how they will be realized, I suggest to also reserve the two currently allowed ASCII accent characters for later use.

They don't seem to be important (as these characters are normally used only in combination with other characters and then would form a UNICODE character, which is still allowed), and it will always be possible to allow them in a future version (but not to disallow them later).
