### PR TITLE
Media type negotiation cleanup

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -28,26 +28,31 @@ interpreted as described in RFC 2119
 
 ## Content Negotiation <a href="#content-negotiation" id="content-negotiation" class="headerlink"></a>
 
-Clients **MUST** send all JSON API data in request documents with
-the header `Content-Type: application/vnd.api+json`.
+Clients **MUST** send all JSON API data in request documents with the header
+`Content-Type: application/vnd.api+json`, without any media type parameters.
 
-Clients **MUST** ignore all parameters for the `application/vnd.api+json`
+If a client violates this requirement, servers **MUST** respond with a
+`415 Unsupported Media Type` status code.
+
+Clients that include the JSON API media type in their `Accept` header, **MUST**
+specify the media type there at least once without any media type parameters.
+
+If a client violates this requirement, and its `Accept` header doesn't contain
+any other media types that the server can produce, the server **MUST** respond
+with a `406 Not Acceptable` status code.
+
+Servers **MUST** send all JSON API data in response documents with the header
+`Content-Type: application/vnd.api+json`, without any media type parameters.
+
+Servers **MUST NOT** send responses with the `application/vnd.api+json` media
+type if the client has not indicated, using its `Accept` header, that it can
+understand this format.
+
+Clients **MUST** ignore any parameters for the `application/vnd.api+json`
 media type received in the `Content-Type` header of response documents.
 
-Servers **MUST** send all JSON API data in response documents with
-the header `Content-Type: application/vnd.api+json`.
-
-Servers **MUST** return a `406 Not Acceptable` status code if the
-`application/vnd.api+json` media type is modified by the `ext` parameter in
-the `Accept` header of a request. Otherwise, servers **MUST** return a `415
-Unsupported Media Type` status code if the `application/vnd.api+json` media
-type is modified by the `ext` parameter in the `Content-Type` header of a
-request. Servers **MUST** ignore all other parameters for the
-`application/vnd.api+json` media type in `Accept` and `Content-Type`
-headers.
-
-> Note: These requirements may allow future versions of this specification
-to support an extension mechanism based upon the `ext` media type parameter.
+> Note: These requirements exist to allow future versions of this specification
+to use media type parameters for extension negotiation and versioning.
 
 ## Document Structure <a href="#document-structure" id="document-structure" class="headerlink"></a>
 
@@ -592,16 +597,6 @@ The following characters **MUST NOT** be used in member names:
 Data, including resources and relationships, can be fetched by sending a
 `GET` request to an endpoint.
 
-Clients **MUST** indicate that they can accept the JSON API media type, per
-the semantics of the HTTP `Accept` header. If present, this header value **MUST**
-also include any media type extensions relevant to the request. Servers **MUST**
-return a `406 Not Acceptable` status code if this header specifies an
-unsupported media type.
-
-> Note: Servers may support multiple media types at any endpoint. For example,
-a server may choose to support `text/html` in order to simplify viewing content
-via a web browser.
-
 Responses can be further refined with the optional features described below.
 
 ### Fetching Resources <a href="#fetching-resources" id="fetching-resources" class="headerlink"></a>
@@ -1070,10 +1065,6 @@ strategies.
 
 A server **MAY** allow resources of a given type to be created. It **MAY**
 also allow existing resources to be modified or deleted.
-
-Any requests that contain content **MUST** include a `Content-Type` header
-whose value is `application/vnd.api+json`. This header value **MUST** also
-include media type extensions relevant to the request.
 
 A request **MUST** completely succeed or fail (in a single "transaction"). No
 partial updates are allowed.

--- a/format/index.md
+++ b/format/index.md
@@ -48,6 +48,13 @@ Servers **MUST NOT** send responses with the `application/vnd.api+json` media
 type if the client has not indicated, using its `Accept` header, that it can
 understand this format.
 
+> Note: If a client's `Accept` header indicates that it accepts standard JSON
+but not the JSON API media type, the server may choose serve it a JSON API
+document identified as `application/json`. If the server does so, is not
+considered to be sending "JSON API data" for the purposes of the requirement
+above, but rather simple JSON data, and the client cannot rely on any of the
+rules laid out in this specification.
+
 Clients **MUST** ignore any parameters for the `application/vnd.api+json`
 media type received in the `Content-Type` header of response documents.
 

--- a/format/index.md
+++ b/format/index.md
@@ -26,7 +26,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 interpreted as described in RFC 2119
 [[RFC2119](http://tools.ietf.org/html/rfc2119)].
 
-## Media Type Negotiation <a href="#media-type-negotiation" id="media-type-negotiation" class="headerlink"></a>
+## Content Negotiation <a href="#content-negotiation" id="content-negotiation" class="headerlink"></a>
 
 Clients **MUST** send all JSON API data in request documents with
 the header `Content-Type: application/vnd.api+json`.


### PR DESCRIPTION
This does a few things:
1. It doesn't let the server silently ignore media type parameters other than `ext`. Instead, it requires the server to explicitly return an error. We could add all sorts of parameters down the line, and post 1.0–clients that use these parameters may need to know whether they've been honored or not; silent ignoring could be quite unacceptable. By contrast, if we add any parameters down the line that can be simply ignored by old servers, then the post 1.0–client that gets the explicit error can simply retry its request without the parameter. (Of course, none of this effects 1.0 clients, since they're not allowed to include any parameters And, if they do, it's probably a bug, so an explicit error is more helpful for them too.)
2. It applies the same treatment to `ext` as it does to every other media type parameter—namely, it requires the server to send the error mentioned in (1). This is better than using 406/415 here now, which will make it harder, when we add extensions in the future, for clients to distinguish between extensions not being supported at all vs. a particular extension not being supported. Also, there's no guarantee that we'll stick only to the `ext` parameter for required extension negotiation. (My proposal in #650, for example, will, when I finish the last section, have an `ext` and a `required-profile` parameter.)
3. It accounts for the fact that the Accept header can take multiple values, e.g. `Accept: application/vnd.api+json;ext=bulk, application/vnd.api+json`, and that the header is only problematic if _every_ JSON-API option it lists contains parameters. If only some of the options contain parameters (as in the prior example), then the requests should succeed—and, in fact, future clients may want to format their `Accept` header like this to work with older servers.
4. **Update** It also moves the remaining stray note about content negotiation that was in the "Fetching Data" section into this single top section. And it renames the section to "Content Negotiation", which is what everyone else calls this process, so we should too. 
5. **Update**: Finally, it reworks the requirements that were in "Fetching Data" to be more consistent with my understanding of our intentions. See my inline comments
