### PR TITLE
Require 400 for invalid include path

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -895,6 +895,10 @@ resource object.
 `comments` is a relationship listed under a `articles` resource object, and
 `author` is a relationship listed under a `comments` resource object.
 
+If any segment in any relationship path listed in the `include` parameter
+contains a relationship name that is not a [valid member name](#document-structure-member-names),
+the server **MUST** respond with `400 Bad Request`.
+
 For instance, comments could be requested with an article:
 
 ```http


### PR DESCRIPTION
If we don't say this explicitly, a server might simply ignore invalid include paths. That would be bad because, if we expand the set of valid include paths down the line (e.g. with `-comments.author` style paths), we want the client to know whether those paths were honored or not.
