### PR TITLE
Inconsistency in updating relationships?

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -1434,9 +1434,6 @@ Although relationships can be modified along with resources (as described
 above), JSON API also supports updating of relationships independently at
 *relationship URLs*.
 
-If a *relationship's `links` object* contains a *relationship URL*, then the
-server **MUST** respond to requests to that URL to update the relationship.
-
 > Note: Relationships are updated without exposing the underlying server
 semantics, such as foreign keys. Furthermore, relationships can be updated
 without necessarily affecting the related resources. For example, if an article


### PR DESCRIPTION
Section Updating Relationships says:

> If a _relationship's `links` object_ contains a _relationship URL_, then the
> server **MUST** respond to requests to that URL to update the relationship.

Section Updating To-One Relationships says:

> A server **MUST** respond to `PATCH` requests to a _to-one relationship URL_ as
> described below.

Likewise, Section Updating To-Many Relationships says:

> A server **MUST** respond to `PATCH`, `POST`, and `DELETE` requests to a
> _to-many relationship URL_ as described below.

I believe that the former clause is redundant, in addition to being inconsistent with the latter two clauses. Am I missing something?
