### PR TITLE
JSON API version MAY

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -531,7 +531,7 @@ array of values, whereas a `self` link does not).
 
 A JSON API document **MAY** include information about its implementation
 under a top level `jsonapi` member. If present, its value **MUST** be an
-object (a "jsonapi object") that **MUST** contain a `version` member whose
+object (a "jsonapi object") that **MAY** contain a `version` member whose
 value is a string indicating the highest JSON API version supported. This
 object **MAY** also contain a `meta` member, whose value is a [meta] object
 that contains non-standard meta-information.
@@ -544,8 +544,8 @@ that contains non-standard meta-information.
 }
 ```
 
-If this member is not present, clients should assume the server implements
-version 1.0 of the specification.
+If the `version` member is not present, clients should make assume the server
+implements version 1.0 of the specification.
 
 > Note: Because JSON API is committed to making additive changes only, the
 version string primarily indicates which new features a server may support.


### PR DESCRIPTION
It's optional for a server to provide the JSON API version it's using in its response document, in that its optional for it to include a `jsonapi` member at all. Yet, the current construction means that if the server does include a `jsonapi` member, then it must include a version. That seems a little odd, since, even now, the server could be including the `jsonapi` member for non-version-related reasons, like to take advantage of the `meta` container there. Also, if we add more keys in `jsonapi` servers could again want to add that object (with those new keys) without being compelled to add a version, which I think we're trying to keep optional.

This PR accomplishes that by giving the version key a MAY even if the `jsonapi` object is present.
