### PR TITLE
400 for unknown, valid spec query parameters

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -1704,6 +1704,10 @@ least one non a-z character (U+0061 to U+007A). It is **RECOMMENDED** that a
 U+002D HYPHEN-MINUS, "-", U+005F LOW LINE, "_", or capital letter is used
 (e.g. camelCasing).
 
+If a server encounters a query parameter that does not follow the naming
+conventions above, and the server does not know how to proccess it as a query
+parameter from this specification, it **MUST** return `400 Bad Request`.
+
 > Note: This is to preserve the ability of JSON API to make additive additions
 to standard query parameters without conflicting with existing implementations.
 


### PR DESCRIPTION
If we add a new query parameter later that complies with the base spec naming rules (i.e. no hyphens, underscores, etc), servers that don't support that query parameter need to return 400 if they encounter it. (Though servers are free to ignore implementation-specific query parameter names if they want.) This PR ensures that.
