### PR TITLE
Styles: typography improvements

### DIFF
--- a/stylesheets/all.sass
+++ b/stylesheets/all.sass
@@ -26,7 +26,7 @@ $border-radius-main: 4px
 body
   font-family: "Helvetica Neue", "Helvetica", "Open Sans", sans-serif
   font-size: 15px
-  line-height: 1.5
+  line-height: 1.6
   -webkit-font-smoothing: antialiased
 
 
@@ -68,7 +68,8 @@ h5
   font-size: inherit
 
 p
-  margin: 0 0 10px 0
+  line-height: 1.7333
+  margin: 0 0 13px 0
 
 a
   color: $color-main
@@ -84,6 +85,7 @@ blockquote
 p > code, li > code
   padding: 1px 4px
   background: rgba(0, 0, 0, 0.06)
+  white-space: nowrap
 
 
 /** Navigation */


### PR DESCRIPTION
Tweaks:
1. Use more generous leading. This is helpful given how long our line lengths are by conventional typographic standards. It also helps considering the (padded) gray background behind inline code snippets, which need a bit of breathing room.
2. Don't line break within inline code snippets. This makes them a bit easier to read, by making sure, e.g. that "400" and "Bad Request" stay on the same line in `400 Bad Request`.

Note: this doesn't recompile the sass to update the `all.css` and `all.css.map` files, since I assume compilation is handled by a build step somewhere.
