### PR TITLE
Typo fix in Errors section

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -1727,7 +1727,7 @@ to standard query parameters without conflicting with existing implementations.
 
 A server **MAY** choose to stop processing as soon as a problem is encountered,
 or it **MAY** continue processing and encounter multiple problems. For instance,
-a server might process multiple attribute and then return multiple validation
+a server might process multiple attributes and then return multiple validation
 problems in a single response.
 
 When a server encounters multiple problems for a single request, the most


### PR DESCRIPTION
"multiple attribute" -> "multiple attributes"
