### PR TITLE
Note that fields[TYPE] brackets must be percent encoded

### DIFF
--- a/examples/index.md
+++ b/examples/index.md
@@ -55,6 +55,10 @@ Request with `fields` parameter:
 GET /articles?include=author&fields[articles]=title,body,author&fields[people]=name
 ```
 
+> Note: The above example URI shows unencoded `[` and `]` characters simply
+for readability. In practice, these characters must be percent-encoded, as
+noted in the base specification.
+
 Here we want `articles` objects to have fields `title`, `body` and `author` only and `people` objects to have `name` field only.
 
 ```http
@@ -117,3 +121,8 @@ Content-Type: application/vnd.api+json
   ]
 }
 ```
+
+> Note: The above example URI shows unencoded `[` and `]` characters simply
+for readability. In practice, these characters must be percent-encoded, as
+noted in the base specification.
+

--- a/format/index.md
+++ b/format/index.md
@@ -993,6 +993,10 @@ GET /articles?include=author&fields[articles]=title,body&fields[people]=name HTT
 Accept: application/vnd.api+json
 ```
 
+> Note: The above example URI shows unencoded `[` and `]` characters simply for
+readability. In practice, these characters must be percent-encoded, per the
+requirements [in RFC 3986](http://tools.ietf.org/html/rfc3986#section-3.4).
+
 > Note: This section applies to any endpoint that responds with resources as
 primary or included data, regardless of the request type. For instance, a
 server could support sparse fieldsets along with a `POST` request to create


### PR DESCRIPTION
This is simply making explicit a requirement from the URI spec that was
already implicitly in effect, so it’s not a BC break.

Addresses #647
