### PR TITLE
Added fix for sidebar overflowing small viewports

### DIFF
--- a/javascripts/all.js
+++ b/javascripts/all.js
@@ -17,18 +17,30 @@ $(document).ready(function() {
 function fixElement(element, offset) {
     if(element.length == 0) return;
 
+    var $window = $(window);
+    var elementBottom = element.height() + offset;
     var affixWaypoint = element.offset().top - offset;
+    var shouldFix = $window.height() > elementBottom;
 
-    $(window).scroll(function(event) {
-        var scrollPosition = $(window).scrollTop();
+    function updatePosition() {
+        var scrollPosition = $window.scrollTop();
 
-        if(scrollPosition >= affixWaypoint) {
+        if(shouldFix && scrollPosition >= affixWaypoint) {
             element.css('position', 'fixed');
             element.css('top', offset + 'px');
         } else {
             element.css('position', 'relative');
             element.css('top', '0');
         }
+    }
+
+    $(window).resize(function(event) {
+        shouldFix = $window.height() > elementBottom;
+        updatePosition();
+    });
+
+    $(window).scroll(function(event) {
+        updatePosition();
     });
 }
 


### PR DESCRIPTION
This works around the issue in #772. When the window is too small to contain the sidebar, it is not fixed and stays at the top of the page.

It’s not the prettiest solution I must admit, but it does the job of preventing the overflow on small viewports.
