### PR TITLE
Add shwoodard/jsonapi golang lib for serializing and deserializing

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -81,6 +81,7 @@ has a page describing how to emit conformant JSON.
 ### Go <a href="#server-libraries-go" id="server-libraries-go" class="headerlink"></a>
 
 * [api2go](https://github.com/univedo/api2go) is a small library to make it easier to provide a JSON API with your Golang project.
+* [jsonapi](https://github.com/shwoodard/jsonapi) serializes and deserializes jsonapi formatted payloads using struct tags to annotate the structs that you already have in your Golang project. [Godoc](http://godoc.org/github.com/shwoodard/jsonapi)
 
 ### .NET <a href="#server-libraries-net" id="server-libraries-net" class="headerlink"></a>
 


### PR DESCRIPTION
Add goland jsonapi lib to list of implementations.  `shwoodard/jsonapi` uses struct tags rather than interfaces to construct and destruct [jsonapi.org](http://jsonapi.org) payloads.  The idea for adding a second library to the mix is to minimize the amount of code needed to read and produce jsonapi formatted json payloads.

See,

https://github.com/shwoodard/jsonapi
http://godoc.org/github.com/shwoodard/jsonapi
