### PR TITLE
Update index.md with katharsis-servlet as a Java implementation

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -93,6 +93,7 @@ has a page describing how to emit conformant JSON.
 ### JAVA <a href="#server-libraries-java" id="server-libraries-java" class="headerlink"></a>
 
 * [katharsis](http://katharsis.io) has comprehensive coverage of standard allowing to create JSON:API compatible resources with dynamic relation based routing. Library is highly modular and compatible with all JAX-RS based frameworks.
+* [katharsis-servlet](https://github.com/woonsan/katharsis-servlet) is a generic servlet/filter adapter for [katharsis](http://katharsis.io) core module. This module can be used in traditional servlet or filter based Java web applications, or even non-Servlet-API-based web applications such as Portal/Portlet, Wicket, etc.
 
 ## Examples <a href="#examples" id="examples" class="headerlink"></a>
 


### PR DESCRIPTION
Hi,

I've cut a release of katharsis-servlet which is an adapter module for katharsis-core, so I think it might be good to add this module info as an implementation in the page.
This adapter module provides a generic adapter for traditional servlet/filter based Java web applications. This module is based on katharsis-core like katharsis-rs is, but katharsis-servlet provides servlet/filter bridges while katharsis-rs provides JAX-RS container filter bridge.

Please let me know if you have any questions.

Regards,

Woonsan
