### PR TITLE
Change example dates to ISO8601

### DIFF
--- a/examples/index.md
+++ b/examples/index.md
@@ -26,8 +26,8 @@ Content-Type: application/vnd.api+json
     "attributes": {
       "title": "JSON API paints my bikeshed!",
       "body": "The shortest article. Ever.",
-      "created": 1432306588,
-      "updated": 1432306589
+      "created": "2015-05-22T14:56:29.000Z",
+      "updated": "2015-05-22T14:56:28.000Z"
     },
     "relationships": {
       "author": {


### PR DESCRIPTION
When people are studying the specification, they tend to primarily focus on the examples because they are the quickest way to begin understanding the format. Although JSON API makes no recommendation about the format of the dates, using the Unix epoch format (seconds since 1970) in the examples can appear to be a recommendation.

These timestamps are not an ideal format for dates and times in JSON APIs. The numbers are ambiguous, especially considering that Javascript will parse _miliseconds_ since 1970 correctly when initializing a date, but will show the wrong date for seconds.

Here is some [StackOverflow discussion on the topic](http://stackoverflow.com/questions/10286204/the-right-json-date-format).

Even though the spec does not cover date formats, I'm proposing a change to this example so that if people do interpret the examples as a recommendation for date formatting, at least they will end up with a reasonable standard.
