### PR TITLE
Add JsonApiNet to implementation list for .NET

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -88,9 +88,11 @@ has a page describing how to emit conformant JSON.
 
 ### .NET <a href="#server-libraries-net" id="server-libraries-net" class="headerlink"></a>
 
+* [JsonApiNet](https://github.com/l8nite/JsonApiNet) lets you quickly deserialize JSON API documents into C# entities. Supports compound documents, complex type mapping from attributes, attribute mapping, and more. [See the README](https://github.com/l8nite/JsonApiNet/blob/master/README.md) for full details.
+
 * [JSONAPI.NET](https://github.com/SphtKr/JSONAPI.NET) is a .NET library that integrates with ASP.NET WebAPI, Json.NET, and (optionally) Entity Framework to help you quickly create JSON API compliant web services.
 
-* [Migrap.AspNet.Mvc.Jsonapi](https://github.com/migrap/Migrap.AspNet.Mvc.Jsonapi) is an ASP.NET 5 (vNext) library that allows for existing code to build JSON API responses through output formatters. 
+* [Migrap.AspNet.Mvc.Jsonapi](https://github.com/migrap/Migrap.AspNet.Mvc.Jsonapi) is an ASP.NET 5 (vNext) library that allows for existing code to build JSON API responses through output formatters.
 
 ### JAVA <a href="#server-libraries-java" id="server-libraries-java" class="headerlink"></a>
 


### PR DESCRIPTION
I wrote a library for easy deserialization of JSON API documents into C# classes with support for entity remapping, included resources, complex type parsing, etc. It is intended to be used in client applications written in C#.

https://github.com/l8nite/JsonApiNet 

This PR adds the library to the list of implementations for .NET
