### PR TITLE
Fix invalid char class by moving the dash to the front of the char class.

### DIFF
--- a/schema
+++ b/schema
@@ -190,7 +190,7 @@
       "description": "Members of the attributes object (\"attributes\") represent information about the resource object in which it's defined.",
       "type": "object",
       "patternProperties": {
-        "^(?!relationships$|links$)\\w[\\w-_]*$": {
+        "^(?!relationships$|links$)\\w[-\\w_]*$": {
           "description": "Attributes may contain any valid JSON value."
         }
       },
@@ -201,7 +201,7 @@
       "description": "Members of the relationships object (\"relationships\") represent references from the resource object in which it's defined to other resource objects.",
       "type": "object",
       "patternProperties": {
-        "^\\w[\\w-_]*$": {
+        "^\\w[-\\w_]*$": {
           "properties": {
             "links": {
               "$ref": "#/definitions/links"


### PR DESCRIPTION
See http://stackoverflow.com/questions/13161903/regular-expression-empty-range-in-char-class-error

Moving the dash to the front of the char class fixes issues  #829
