### PR TITLE
add example of pagination links

### DIFF
--- a/examples/index.md
+++ b/examples/index.md
@@ -154,6 +154,7 @@ Content-Type: application/vnd.api+json
     }
   ],
   "links": {
+    "self": "http://example.com/articles?page[number]=3&page[size]=1",
     "first": "http://example.com/articles?page[number]=1&page[size]=1",
     "prev": "http://example.com/articles?page[number]=2&page[size]=1",
     "next": "http://example.com/articles?page[number]=4&page[size]=1",

--- a/examples/index.md
+++ b/examples/index.md
@@ -126,3 +126,38 @@ Content-Type: application/vnd.api+json
 for readability. In practice, these characters must be percent-encoded, as
 noted in the base specification.
 
+## Pagination Links
+
+Example of how to add [pagination links](http://jsonapi.org/format/#fetching-pagination).
+
+Basic request:
+
+```http
+GET /articles?page=3&per_page=1
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.api+json
+
+{
+  "data": [
+    {
+      "type": "articles",
+      "id": "1",
+      "attributes": {
+        "title": "JSON API paints my bikeshed!",
+        "body": "The shortest article. Ever.",
+        "created": "2015-05-22T14:56:29.000Z",
+        "updated": "2015-05-22T14:56:28.000Z"
+      }
+    }
+  ],
+  "links": {
+    "first": "?page=1&per_page=1",
+    "prev": "?page=2&per_page=1",
+    "next": "?page=4&per_page=1",
+    "last": "?page=13&per_page=1"
+  }
+}
+```

--- a/examples/index.md
+++ b/examples/index.md
@@ -154,10 +154,10 @@ Content-Type: application/vnd.api+json
     }
   ],
   "links": {
-    "first": "?page=1&per_page=1",
-    "prev": "?page=2&per_page=1",
-    "next": "?page=4&per_page=1",
-    "last": "?page=13&per_page=1"
+    "first": "http://example.com/articles?page=1&per_page=1",
+    "prev": "http://example.com/articles?page=2&per_page=1",
+    "next": "http://example.com/articles?page=4&per_page=1",
+    "last": "http://example.com/articles?page=13&per_page=1"
   }
 }
 ```

--- a/examples/index.md
+++ b/examples/index.md
@@ -144,7 +144,7 @@ Content-Type: application/vnd.api+json
   "data": [
     {
       "type": "articles",
-      "id": "1",
+      "id": "3",
       "attributes": {
         "title": "JSON API paints my bikeshed!",
         "body": "The shortest article. Ever.",

--- a/examples/index.md
+++ b/examples/index.md
@@ -128,12 +128,12 @@ noted in the base specification.
 
 ## Pagination Links
 
-Example of how to add [pagination links](http://jsonapi.org/format/#fetching-pagination).
+Example of a page-based strategy on how to add [pagination links](http://jsonapi.org/format/#fetching-pagination).
 
 Basic request:
 
 ```http
-GET /articles?page=3&per_page=1
+GET /articles?page[number]=3&page[size]=1
 ```
 
 ```http
@@ -154,10 +154,10 @@ Content-Type: application/vnd.api+json
     }
   ],
   "links": {
-    "first": "http://example.com/articles?page=1&per_page=1",
-    "prev": "http://example.com/articles?page=2&per_page=1",
-    "next": "http://example.com/articles?page=4&per_page=1",
-    "last": "http://example.com/articles?page=13&per_page=1"
+    "first": "http://example.com/articles?page[number]=1&page[size]=1",
+    "prev": "http://example.com/articles?page[number]=2&page[size]=1",
+    "next": "http://example.com/articles?page[number]=4&page[size]=1",
+    "last": "http://example.com/articles?page[number]=13&page[size]=1"
   }
 }
 ```


### PR DESCRIPTION
We are adding a new feature on [AMS](https://github.com/rails-api/active_model_serializers) and to make sure we're getting it right, I think it is important to validate and add examples on `json-api`.

That is the [PR to support pagination links](https://github.com/rails-api/active_model_serializers/pull/1041) on AMS

What do you thing about that?
