### PR TITLE
Make the sidebar scroll independently on too-small viewports

### DIFF
--- a/javascripts/all.js
+++ b/javascripts/all.js
@@ -23,11 +23,21 @@ function fixElement(element, offset) {
         var scrollPosition = $(window).scrollTop();
 
         if(scrollPosition >= affixWaypoint) {
-            element.css('position', 'fixed');
-            element.css('top', offset + 'px');
+            element.css({
+                position: 'fixed',
+                top: offset + 'px',
+                bottom: '0',
+                overflow: 'scroll',
+                paddingBottom: offset + 'px'
+            });
         } else {
-            element.css('position', 'relative');
-            element.css('top', '0');
+            element.css({
+                position: 'relative',
+                top: '',
+                bottom: '',
+                overflow: '',
+                paddingBottom: ''
+            });
         }
     });
 }


### PR DESCRIPTION
This should fix #831/#855. It's an alternative to the fix in #785. @tkellen, @dgeb, @steveklabnik please merge whichever version you prefer. @wvteijlingen is welcome to chime in too!

This PR makes the sidebar scroll independently when it overflows (as requested in #855), while the other PR makes it not `position: fixed` if it can't fit.  
