### PR TITLE
Add support for tables in markdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,8 @@ exclude:
   - ./public
   - ./stylesheets/*.scss
 markdown: redcarpet
+redcarpet:
+  extensions: ["tables"]
 pygments: false
 port: 9876
 

--- a/examples/index.md
+++ b/examples/index.md
@@ -288,12 +288,12 @@ forms due to localization.
 
 For the example below, imagine the API docs specifed the following mapping:
 
-> | Code | Problem                                                   |
-> |------|-----------------------------------------------------------|
-> |  123 | Value too short                                           |
-> |  225 | Password lacks a letter, number, or punctuation character |
-> |  226 | Passwords do not match                                    |
-> |  227 | Password cannot be one of last five passwords             |
+| Code | Problem                                                   |
+|------|-----------------------------------------------------------|
+|  123 | Value too short                                           |
+|  225 | Password lacks a letter, number, or punctuation character |
+|  226 | Passwords do not match                                    |
+|  227 | Password cannot be one of last five passwords             |
 
 Multiple errors on `"password"` attribute, with error `code`:
 


### PR DESCRIPTION
To accommodate the table in the error examples
