### PR TITLE
Support an optional charset parameter in `Content-Type` on requests

### DIFF
--- a/_format/1.0/normative-statements.json
+++ b/_format/1.0/normative-statements.json
@@ -2631,7 +2631,7 @@ layout: null
       "id": "error-object-key",
       "type": "normative-statements",
       "attributes": {
-        "level": "SHOULD",
+        "level": "MUST",
         "description": "Error objects **MUST** be returned as an array keyed by `errors` in the top level of a JSON API document."
       },
       "relationships": {

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -26,7 +26,7 @@ interpreted as described in RFC 2119
 
 ### Client Responsibilities <a href="#content-negotiation-clients" id="content-negotiation-clients" class="headerlink"></a>
 
-Clients **MUST** send all JSON API data in request documents with the header
+Clients **MUST** send all JSON API data with the header
 `Content-Type: application/vnd.api+json` without any media type parameters.
 
 Clients that include the JSON API media type in their `Accept` header **MUST**
@@ -42,7 +42,9 @@ Servers **MUST** send all JSON API data in response documents with the header
 
 Servers **MUST** respond with a `415 Unsupported Media Type` status code if
 a request specifies the header `Content-Type: application/vnd.api+json`
-with any media type parameters.
+with any media type parameters other than the `charset` parameter. Servers
+**SHOULD** accept requests that include the `charset` parameter but **SHOULD**
+ignore its value.
 
 Servers **MUST** respond with a `406 Not Acceptable` status code if a
 request's `Accept` header contains the JSON API media type and all instances

--- a/_format/1.1/normative-statements.json
+++ b/_format/1.1/normative-statements.json
@@ -2631,7 +2631,7 @@ layout: null
       "id": "error-object-key",
       "type": "normative-statements",
       "attributes": {
-        "level": "SHOULD",
+        "level": "MUST",
         "description": "Error objects **MUST** be returned as an array keyed by `errors` in the top level of a JSON API document."
       },
       "relationships": {

--- a/_format/1.1/normative-statements.json
+++ b/_format/1.1/normative-statements.json
@@ -21,6 +21,7 @@ layout: null
           "data": [
             { "id": "request-content-type", "type": "normative-statements" },
             { "id": "request-accept", "type": "normative-statements" },
+            { "id": "request-ignore-charset", "type": "normative-statements" },
             { "id": "response-ignore-parameters", "type": "normative-statements" },
             { "id": "response-content-type", "type": "normative-statements"},
             { "id": "response-unsupported-media-type", "type": "normative-statements"},
@@ -306,6 +307,19 @@ layout: null
       "attributes": {
         "level": "MUST",
         "description": "Clients that include the JSON API media type in their `Accept` header **MUST** specify the media type there at least once without any media type parameters."
+      },
+      "relationships": {
+        "section": {
+          "data": { "id": "content-negotiation", "type": "sections" }
+        }
+      }
+    },
+    {
+      "id": "request-ignore-charset",
+      "type": "normative-statements",
+      "attributes": {
+        "level": "SHOULD",
+        "description": "Servers **SHOULD** accept requests that include the `charset` parameter but **SHOULD** ignore its value."
       },
       "relationships": {
         "section": {


### PR DESCRIPTION
A fix for #837.
