### PR TITLE
include list of archived versions for further reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,10 @@ This standard is currently under development. To assist:
 
 The website is automatically built by [GitHub Pages](http://pages.github.com)
 when changes are pushed to the `gh-pages` branch.
+
+Archive
+-------
+
+older versions of the JSON-API documentations
+
+* RC3 - http://jsonapi-rc3.herokuapp.com/


### PR DESCRIPTION
had a situation where I have to reference the old documentation (yes it was just RC3 but yet it was implemented  in production on our app => I needed to give reference link to client and there was no resource) 
