### PR TITLE
Fix headings going off-screen after following an anchor link

### DIFF
--- a/_format/1.0/index.md
+++ b/_format/1.0/index.md
@@ -2,7 +2,7 @@
 version: 1.0
 ---
 
-## Introduction <a href="#introduction" id="introduction" class="headerlink"></a>
+## <a href="#introduction" id="introduction" class="headerlink"></a> Introduction
 
 JSON API is a specification for how a client should request that resources be
 fetched or modified, and how a server should respond to those requests.
@@ -15,16 +15,16 @@ JSON API requires use of the JSON API media type
 ([`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json))
 for exchanging data.
 
-## Conventions <a href="#conventions" id="conventions" class="headerlink"></a>
+## <a href="#conventions" id="conventions" class="headerlink"></a> Conventions
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in RFC 2119
 [[RFC2119](http://tools.ietf.org/html/rfc2119)].
 
-## Content Negotiation <a href="#content-negotiation" id="content-negotiation" class="headerlink"></a>
+## <a href="#content-negotiation" id="content-negotiation" class="headerlink"></a> Content Negotiation
 
-### Client Responsibilities <a href="#content-negotiation-clients" id="content-negotiation-clients" class="headerlink"></a>
+### <a href="#content-negotiation-clients" id="content-negotiation-clients" class="headerlink"></a> Client Responsibilities
 
 Clients **MUST** send all JSON API data in request documents with the header
 `Content-Type: application/vnd.api+json` without any media type parameters.
@@ -35,7 +35,7 @@ specify the media type there at least once without any media type parameters.
 Clients **MUST** ignore any parameters for the `application/vnd.api+json`
 media type received in the `Content-Type` header of response documents.
 
-### Server Responsibilities <a href="#content-negotiation-servers" id="content-negotiation-servers" class="headerlink"></a>
+### <a href="#content-negotiation-servers" id="content-negotiation-servers" class="headerlink"></a> Server Responsibilities
 
 Servers **MUST** send all JSON API data in response documents with the header
 `Content-Type: application/vnd.api+json` without any media type parameters.
@@ -52,7 +52,7 @@ of that media type are modified with media type parameters.
 of this specification to use media type parameters for extension negotiation
 and versioning.
 
-## Document Structure <a href="#document-structure" id="document-structure" class="headerlink"></a>
+## <a href="#document-structure" id="document-structure" class="headerlink"></a> Document Structure
 
 This section describes the structure of a JSON API document, which is identified
 by the media type [`application/vnd.api+json`]
@@ -71,7 +71,7 @@ ignore members not recognized by this specification.
 > Note: These conditions allow this specification to evolve through additive
 changes.
 
-### Top Level <a href="#document-top-level" id="document-top-level" class="headerlink"></a>
+### <a href="#document-top-level" id="document-top-level" class="headerlink"></a> Top Level
 
 A JSON object **MUST** be at the root of every JSON API request and response
 containing data. This object defines a document's "top level".
@@ -145,7 +145,7 @@ references the same resource:
 A logical collection of resources **MUST** be represented as an array, even if
 it only contains one item or is empty.
 
-### Resource Objects <a href="#document-resource-objects" id="document-resource-objects" class="headerlink"></a>
+### <a href="#document-resource-objects" id="document-resource-objects" class="headerlink"></a> Resource Objects
 
 "Resource objects" appear in a JSON API document to represent resources.
 
@@ -189,7 +189,7 @@ Here's how an article (i.e. a resource of type "articles") might appear in a doc
 // ...
 ```
 
-#### Identification <a href="#document-resource-object-identification" id="document-resource-object-identification" class="headerlink"></a>
+#### <a href="#document-resource-object-identification" id="document-resource-object-identification" class="headerlink"></a> Identification
 
 Every [resource object][resource objects] **MUST** contain an `id` member and a `type` member.
 The values of the `id` and `type` members **MUST** be strings.
@@ -208,7 +208,7 @@ The values of `type` members **MUST** adhere to the same constraints as
 can be either plural or singular. However, the same value should be used
 consistently throughout an implementation.
 
-#### Fields <a href="#document-resource-object-fields" id="document-resource-object-fields" class="headerlink"></a>
+#### <a href="#document-resource-object-fields" id="document-resource-object-fields" class="headerlink"></a> Fields
 
 A resource object's [attributes] and its [relationships] are collectively called
 its "[fields]".
@@ -218,7 +218,7 @@ other and with `type` and `id`. In other words, a resource can not have an
 attribute and relationship with the same name, nor can it have an attribute
 or relationship named `type` or `id`.
 
-#### Attributes <a href="#document-resource-object-attributes" id="document-resource-object-attributes" class="headerlink"></a>
+#### <a href="#document-resource-object-attributes" id="document-resource-object-attributes" class="headerlink"></a> Attributes
 
 The value of the `attributes` key **MUST** be an object (an "attributes
 object"). Members of the attributes object ("attributes") represent information
@@ -237,7 +237,7 @@ alongside other information to be represented in a resource object, these keys
 
 > Note: See [fields] and [member names] for more restrictions on this container.
 
-#### Relationships <a href="#document-resource-object-relationships" id="document-resource-object-relationships" class="headerlink"></a>
+#### <a href="#document-resource-object-relationships" id="document-resource-object-relationships" class="headerlink"></a> Relationships
 
 The value of the `relationships` key **MUST** be an object (a "relationships
 object"). Members of the relationships object ("relationships") represent
@@ -263,7 +263,7 @@ A relationship object that represents a to-many relationship **MAY** also contai
 
 > Note: See [fields] and [member names] for more restrictions on this container.
 
-#### Related Resource Links <a href="#document-resource-object-related-resource-links" id="document-resource-object-related-resource-links" class="headerlink"></a>
+#### <a href="#document-resource-object-related-resource-links" id="document-resource-object-related-resource-links" class="headerlink"></a> Related Resource Links
 
 A "related resource link" provides access to [resource objects] [linked][links]
 in a [relationship][relationships]. When fetched, the related resource object(s)
@@ -278,7 +278,7 @@ relationship isn't currently associated with any target resources. Additionally,
 a related resource link **MUST NOT** change because its relationship's content
 changes.
 
-#### Resource Linkage <a href="#document-resource-object-linkage" id="document-resource-object-linkage" class="headerlink"></a>
+#### <a href="#document-resource-object-linkage" id="document-resource-object-linkage" class="headerlink"></a> Resource Linkage
 
 Resource linkage in a [compound document] allows a client to link together all
 of the included [resource objects] without having to `GET` any URLs via [links].
@@ -326,7 +326,7 @@ The `author` relationship includes a link for the relationship itself (which
 allows the client to change the related author directly), a related resource
 link to fetch the resource objects, and linkage information.
 
-#### Resource Links <a href="#document-resource-object-links" id="document-resource-object-links" class="headerlink"></a>
+#### <a href="#document-resource-object-links" id="document-resource-object-links" class="headerlink"></a> Resource Links
 
 The optional `links` member within each [resource object][resource objects] contains [links]
 related to the resource.
@@ -352,7 +352,7 @@ identifies the resource represented by the resource object.
 A server **MUST** respond to a `GET` request to the specified URL with a
 response that includes the resource as the primary data.
 
-### Resource Identifier Objects <a href="#document-resource-identifier-objects" id="document-resource-identifier-objects" class="headerlink"></a>
+### <a href="#document-resource-identifier-objects" id="document-resource-identifier-objects" class="headerlink"></a> Resource Identifier Objects
 
 A "resource identifier object" is an object that identifies an individual
 resource.
@@ -362,7 +362,7 @@ A "resource identifier object" **MUST** contain `type` and `id` members.
 A "resource identifier object" **MAY** also include a `meta` member, whose value is a [meta] object that
 contains non-standard meta-information.
 
-### Compound Documents <a href="#document-compound-documents" id="document-compound-documents" class="headerlink"></a>
+### <a href="#document-compound-documents" id="document-compound-documents" class="headerlink"></a> Compound Documents
 
 To reduce the number of HTTP requests, servers **MAY** allow responses that
 include related resources along with the requested primary resources. Such
@@ -470,7 +470,7 @@ the document.
 returned with each response, even when the same resource is referenced
 multiple times.
 
-### Meta Information <a href="#document-meta" id="document-meta" class="headerlink"></a>
+### <a href="#document-meta" id="document-meta" class="headerlink"></a> Meta Information
 
 Where specified, a `meta` member can be used to include non-standard
 meta-information. The value of each `meta` member **MUST** be an object (a
@@ -497,7 +497,7 @@ For example:
 }
 ```
 
-### Links <a href="#document-links" id="document-links" class="headerlink"></a>
+### <a href="#document-links" id="document-links" class="headerlink"></a> Links
 
 Where specified, a `links` member can be used to represent links. The value
 of each `links` member **MUST** be an object (a "links object").
@@ -538,7 +538,7 @@ objects in the future. It is also possible that the allowed values of
 additional members will be expanded (e.g. a `collection` link may support an
 array of values, whereas a `self` link does not).
 
-### JSON API Object <a href="#document-jsonapi-object" id="document-jsonapi-object" class="headerlink"></a>
+### <a href="#document-jsonapi-object" id="document-jsonapi-object" class="headerlink"></a> JSON API Object
 
 A JSON API document **MAY** include information about its implementation
 under a top level `jsonapi` member. If present, the value of the `jsonapi`
@@ -561,7 +561,7 @@ implements at least version 1.0 of the specification.
 > Note: Because JSON API is committed to making additive changes only, the
 version string primarily indicates which new features a server may support.
 
-### Member Names <a href="#document-member-names" id="document-member-names" class="headerlink"></a>
+### <a href="#document-member-names" id="document-member-names" class="headerlink"></a> Member Names
 
 All member names used in a JSON API document **MUST** be treated as case sensitive
 by clients and servers, and they **MUST** meet all of the following conditions:
@@ -574,7 +574,7 @@ by clients and servers, and they **MUST** meet all of the following conditions:
 To enable an easy mapping of member names to URLs, it is **RECOMMENDED** that
 member names use only non-reserved, URL safe characters specified in [RFC 3986](http://tools.ietf.org/html/rfc3986#page-13).
 
-#### Allowed Characters <a href="#document-member-names-allowed-characters" id="document-member-names-allowed-characters" class="headerlink"></a>
+#### <a href="#document-member-names-allowed-characters" id="document-member-names-allowed-characters" class="headerlink"></a> Allowed Characters
 
 The following "globally allowed characters" **MAY** be used anywhere in a member name:
 
@@ -590,7 +590,7 @@ first or last character:
 - U+005F LOW LINE, "_"
 - U+0020 SPACE, " " _(not recommended, not URL safe)_
 
-#### Reserved Characters <a href="#document-member-names-reserved-characters" id="document-member-names-reserved-characters" class="headerlink"></a>
+#### <a href="#document-member-names-reserved-characters" id="document-member-names-reserved-characters" class="headerlink"></a> Reserved Characters
 
 The following characters **MUST NOT** be used in member names:
 
@@ -625,14 +625,14 @@ The following characters **MUST NOT** be used in member names:
 - U+007D RIGHT CURLY BRACKET, "}"
 - U+007E TILDE, "~"
 
-## Fetching Data <a href="#fetching" id="fetching" class="headerlink"></a>
+## <a href="#fetching" id="fetching" class="headerlink"></a> Fetching Data
 
 Data, including resources and relationships, can be fetched by sending a
 `GET` request to an endpoint.
 
 Responses can be further refined with the optional features described below.
 
-### Fetching Resources <a href="#fetching-resources" id="fetching-resources" class="headerlink"></a>
+### <a href="#fetching-resources" id="fetching-resources" class="headerlink"></a> Fetching Resources
 
 A server **MUST** support fetching resource data for every URL provided as:
 
@@ -661,9 +661,9 @@ GET /articles/1/author HTTP/1.1
 Accept: application/vnd.api+json
 ```
 
-#### Responses <a href="#fetching-resources-responses" id="fetching-resources-responses" class="headerlink"></a>
+#### <a href="#fetching-resources-responses" id="fetching-resources-responses" class="headerlink"></a> Responses
 
-##### 200 OK <a href="#fetching-resources-responses-200" id="fetching-resources-responses-200" class="headerlink"></a>
+##### <a href="#fetching-resources-responses-200" id="fetching-resources-responses-200" class="headerlink"></a> 200 OK
 
 A server **MUST** respond to a successful request to fetch an individual
 resource or resource collection with a `200 OK` response.
@@ -766,13 +766,13 @@ Content-Type: application/vnd.api+json
 }
 ```
 
-##### 404 Not Found <a href="#fetching-resources-responses-404" id="fetching-resources-responses-404" class="headerlink"></a>
+##### <a href="#fetching-resources-responses-404" id="fetching-resources-responses-404" class="headerlink"></a> 404 Not Found
 
 A server **MUST** respond with `404 Not Found` when processing a request to
 fetch a single resource that does not exist, except when the request warrants a
 `200 OK` response with `null` as the primary data (as described above).
 
-##### Other Responses <a href="#fetching-resources-responses-other" id="fetching-resources-responses-other" class="headerlink"></a>
+##### <a href="#fetching-resources-responses-other" id="fetching-resources-responses-other" class="headerlink"></a> Other Responses
 
 A server **MAY** respond with other HTTP status codes.
 
@@ -782,7 +782,7 @@ A server **MUST** prepare responses, and a client **MUST** interpret
 responses, in accordance with
 [`HTTP semantics`](http://tools.ietf.org/html/rfc7231).
 
-### Fetching Relationships <a href="#fetching-relationships" id="fetching-relationships" class="headerlink"></a>
+### <a href="#fetching-relationships" id="fetching-relationships" class="headerlink"></a> Fetching Relationships
 
 A server **MUST** support fetching relationship data for every relationship URL
 provided as a `self` link as part of a relationship's `links` object.
@@ -801,9 +801,9 @@ GET /articles/1/relationships/author HTTP/1.1
 Accept: application/vnd.api+json
 ```
 
-#### Responses <a href="#fetching-relationships-responses" id="fetching-relationships-responses" class="headerlink"></a>
+#### <a href="#fetching-relationships-responses" id="fetching-relationships-responses" class="headerlink"></a> Responses
 
-##### 200 OK <a href="#fetching-relationships-responses-200" id="fetching-relationships-responses-200" class="headerlink"></a>
+##### <a href="#fetching-relationships-responses-200" id="fetching-relationships-responses-200" class="headerlink"></a> 200 OK
 
 A server **MUST** respond to a successful request to fetch a relationship
 with a `200 OK` response.
@@ -884,7 +884,7 @@ Content-Type: application/vnd.api+json
 }
 ```
 
-##### 404 Not Found <a href="#fetching-relationships-responses-404" id="fetching-relationships-responses-404" class="headerlink"></a>
+##### <a href="#fetching-relationships-responses-404" id="fetching-relationships-responses-404" class="headerlink"></a> 404 Not Found
 
 A server **MUST** return `404 Not Found` when processing a request to fetch
 a relationship link URL that does not exist.
@@ -896,7 +896,7 @@ does not exist. For example, when `/articles/1` does not exist, request to
 If a relationship link URL exists but the relationship is empty, then
 `200 OK` **MUST** be returned, as described above.
 
-##### Other Responses <a href="#fetching-relationships-responses-other" id="fetching-relationships-responses-other" class="headerlink"></a>
+##### <a href="#fetching-relationships-responses-other" id="fetching-relationships-responses-other" class="headerlink"></a> Other Responses
 
 A server **MAY** respond with other HTTP status codes.
 
@@ -906,7 +906,7 @@ A server **MUST** prepare responses, and a client **MUST** interpret
 responses, in accordance with
 [`HTTP semantics`](http://tools.ietf.org/html/rfc7231).
 
-### Inclusion of Related Resources <a href="#fetching-includes" id="fetching-includes" class="headerlink"></a>
+### <a href="#fetching-includes" id="fetching-includes" class="headerlink"></a> Inclusion of Related Resources
 
 An endpoint **MAY** return resources related to the primary data by default.
 
@@ -983,7 +983,7 @@ data, regardless of the request type. For instance, a server could support
 the inclusion of related resources along with a `POST` request to create a
 resource or relationship.
 
-### Sparse Fieldsets <a href="#fetching-sparse-fieldsets" id="fetching-sparse-fieldsets" class="headerlink"></a>
+### <a href="#fetching-sparse-fieldsets" id="fetching-sparse-fieldsets" class="headerlink"></a> Sparse Fieldsets
 
 A client **MAY** request that an endpoint return only specific [fields] in the
 response on a per-type basis by including a `fields[TYPE]` parameter.
@@ -1008,7 +1008,7 @@ primary or included data, regardless of the request type. For instance, a
 server could support sparse fieldsets along with a `POST` request to create
 a resource.
 
-### Sorting <a href="#fetching-sorting" id="fetching-sorting" class="headerlink"></a>
+### <a href="#fetching-sorting" id="fetching-sorting" class="headerlink"></a> Sorting
 
 A server **MAY** choose to support requests to sort resource collections
 according to one or more criteria ("sort fields").
@@ -1063,7 +1063,7 @@ request parameter `sort` is not specified.
 > Note: This section applies to any endpoint that responds with a resource
 collection as primary data, regardless of the request type.
 
-### Pagination <a href="#fetching-pagination" id="fetching-pagination" class="headerlink"></a>
+### <a href="#fetching-pagination" id="fetching-pagination" class="headerlink"></a> Pagination
 
 A server **MAY** choose to limit the number of resources returned in a response
 to a subset ("page") of the whole set available.
@@ -1108,7 +1108,7 @@ per the requirements in [RFC 3986](http://tools.ietf.org/html/rfc3986#section-3.
 > Note: This section applies to any endpoint that responds with a resource
 collection as primary data, regardless of the request type.
 
-### Filtering <a href="#fetching-filtering" id="fetching-filtering" class="headerlink"></a>
+### <a href="#fetching-filtering" id="fetching-filtering" class="headerlink"></a> Filtering
 
 The `filter` query parameter is reserved for filtering data. Servers and clients
 **SHOULD** use this key for filtering operations.
@@ -1117,7 +1117,7 @@ The `filter` query parameter is reserved for filtering data. Servers and clients
 `filter` query parameter can be used as the basis for any number of filtering
 strategies.
 
-## Creating, Updating and Deleting Resources <a href="#crud" id="crud" class="headerlink"></a>
+## <a href="#crud" id="crud" class="headerlink"></a> Creating, Updating and Deleting Resources
 
 A server **MAY** allow resources of a given type to be created. It **MAY**
 also allow existing resources to be modified or deleted.
@@ -1133,7 +1133,7 @@ confusing; it would be hard to remember when it was required and when it was
 not. Therefore, to improve consistency and minimize confusion, `type` is
 always required.
 
-### Creating Resources <a href="#crud-creating" id="crud-creating" class="headerlink"></a>
+### <a href="#crud-creating" id="crud-creating" class="headerlink"></a> Creating Resources
 
 A resource can be created by sending a `POST` request to a URL that represents
 a collection of resources. The request **MUST** include a single [resource object][resource objects]
@@ -1167,7 +1167,7 @@ If a relationship is provided in the `relationships` member of the
 member. The value of this key represents the linkage the new resource is to
 have.
 
-#### Client-Generated IDs <a href="#crud-creating-client-ids" id="crud-creating-client-ids" class="headerlink"></a>
+#### <a href="#crud-creating-client-ids" id="crud-creating-client-ids" class="headerlink"></a> Client-Generated IDs
 
 A server **MAY** accept a client-generated ID along with a request to create
 a resource. An ID **MUST** be specified with an `id` key, the value of
@@ -1203,9 +1203,9 @@ Accept: application/vnd.api+json
 A server **MUST** return `403 Forbidden` in response to an unsupported request
 to create a resource with a client-generated ID.
 
-#### Responses <a href="#crud-creating-responses" id="crud-creating-responses" class="headerlink"></a>
+#### <a href="#crud-creating-responses" id="crud-creating-responses" class="headerlink"></a> Responses
 
-##### 201 Created <a href="#crud-creating-responses-201" id="crud-creating-responses-201" class="headerlink"></a>
+##### <a href="#crud-creating-responses-201" id="crud-creating-responses-201" class="headerlink"></a> 201 Created
 
 If a `POST` request did not include a [Client-Generated
 ID](#crud-creating-client-ids) and the requested resource has been created
@@ -1241,13 +1241,13 @@ Content-Type: application/vnd.api+json
 }
 ```
 
-##### 202 Accepted <a href="#crud-creating-responses-202" id="crud-creating-responses-202" class="headerlink"></a>
+##### <a href="#crud-creating-responses-202" id="crud-creating-responses-202" class="headerlink"></a> 202 Accepted
 
 If a request to create a resource has been accepted for processing, but the
 processing has not been completed by the time the server responds, the
 server **MUST** return a `202 Accepted` status code.
 
-##### 204 No Content <a href="#crud-creating-responses-204" id="crud-creating-responses-204" class="headerlink"></a>
+##### <a href="#crud-creating-responses-204" id="crud-creating-responses-204" class="headerlink"></a> 204 No Content
 
 If a `POST` request *did* include a [Client-Generated
 ID](#crud-creating-client-ids) and the requested resource has been created
@@ -1259,12 +1259,12 @@ with no response document.
 object sent in the request to be accepted by the server, as if the server
 had returned it back in a `201` response.
 
-##### 403 Forbidden <a href="#crud-creating-responses-403" id="crud-creating-responses-403" class="headerlink"></a>
+##### <a href="#crud-creating-responses-403" id="crud-creating-responses-403" class="headerlink"></a> 403 Forbidden
 
 A server **MAY** return `403 Forbidden` in response to an unsupported request
 to create a resource.
 
-##### 409 Conflict <a href="#crud-creating-responses-409" id="crud-creating-responses-409" class="headerlink"></a>
+##### <a href="#crud-creating-responses-409" id="crud-creating-responses-409" class="headerlink"></a> 409 Conflict
 
 A server **MUST** return `409 Conflict` when processing a `POST` request to
 create a resource with a client-generated ID that already exists.
@@ -1276,7 +1276,7 @@ collection represented by the endpoint.
 A server **SHOULD** include error details and provide enough information to
 recognize the source of the conflict.
 
-##### Other Responses <a href="#crud-creating-responses-other" id="crud-creating-responses-other" class="headerlink"></a>
+##### <a href="#crud-creating-responses-other" id="crud-creating-responses-other" class="headerlink"></a> Other Responses
 
 A server **MAY** respond with other HTTP status codes.
 
@@ -1286,7 +1286,7 @@ A server **MUST** prepare responses, and a client **MUST** interpret
 responses, in accordance with
 [`HTTP semantics`](http://tools.ietf.org/html/rfc7231).
 
-### Updating Resources <a href="#crud-updating" id="crud-updating" class="headerlink"></a>
+### <a href="#crud-updating" id="crud-updating" class="headerlink"></a> Updating Resources
 
 A resource can be updated by sending a `PATCH` request to the URL that
 represents the resource.
@@ -1316,7 +1316,7 @@ Accept: application/vnd.api+json
 }
 ```
 
-#### Updating a Resource's Attributes <a href="#crud-updating-resource-attributes" id="crud-updating-resource-attributes" class="headerlink"></a>
+#### <a href="#crud-updating-resource-attributes" id="crud-updating-resource-attributes" class="headerlink"></a> Updating a Resource's Attributes
 
 Any or all of a resource's [attributes] **MAY** be included in the resource
 object included in a `PATCH` request.
@@ -1346,7 +1346,7 @@ Accept: application/vnd.api+json
 }
 ```
 
-#### Updating a Resource's Relationships <a href="#crud-updating-resource-relationships" id="crud-updating-resource-relationships" class="headerlink"></a>
+#### <a href="#crud-updating-resource-relationships" id="crud-updating-resource-relationships" class="headerlink"></a> Updating a Resource's Relationships
 
 Any or all of a resource's [relationships] **MAY** be included in the resource
 object included in a `PATCH` request.
@@ -1413,15 +1413,15 @@ may choose to disallow it. For example, a server may reject full replacement if
 it has not provided the client with the full list of associated objects, and
 does not want to allow deletion of records the client has not seen.
 
-#### Responses <a href="#crud-updating-responses" id="crud-updating-responses" class="headerlink"></a>
+#### <a href="#crud-updating-responses" id="crud-updating-responses" class="headerlink"></a> Responses
 
-##### 202 Accepted <a href="#crud-updating-responses-202" id="crud-updating-responses-202" class="headerlink"></a>
+##### <a href="#crud-updating-responses-202" id="crud-updating-responses-202" class="headerlink"></a> 202 Accepted
 
 If an update request has been accepted for processing, but the processing
 has not been completed by the time the server responds, the server **MUST**
 return a `202 Accepted` status code.
 
-##### 200 OK <a href="#crud-updating-responses-200" id="crud-updating-responses-200" class="headerlink"></a>
+##### <a href="#crud-updating-responses-200" id="crud-updating-responses-200" class="headerlink"></a> 200 OK
 
 If a server accepts an update but also changes the resource(s) in ways other
 than those specified by the request (for example, updating the `updated-at`
@@ -1434,19 +1434,19 @@ the client's current attributes remain up to date, and the server responds
 only with top-level [meta] data. In this case the server **MUST NOT**
 include a representation of the updated resource(s).
 
-##### 204 No Content <a href="#crud-updating-responses-204" id="crud-updating-responses-204" class="headerlink"></a>
+##### <a href="#crud-updating-responses-204" id="crud-updating-responses-204" class="headerlink"></a> 204 No Content
 
 If an update is successful and the server doesn't update any attributes besides
 those provided, the server **MUST** return either a `200 OK` status code and
 response document (as described above) or a `204 No Content` status code with no
 response document.
 
-##### 403 Forbidden <a href="#crud-updating-relationship-responses-403" id="crud-updating-relationship-responses-403" class="headerlink"></a>
+##### <a href="#crud-updating-relationship-responses-403" id="crud-updating-relationship-responses-403" class="headerlink"></a> 403 Forbidden
 
 A server **MUST** return `403 Forbidden` in response to an unsupported request
 to update a resource or relationship.
 
-##### 404 Not Found <a href="#crud-updating-responses-404" id="crud-updating-responses-404" class="headerlink"></a>
+##### <a href="#crud-updating-responses-404" id="crud-updating-responses-404" class="headerlink"></a> 404 Not Found
 
 A server **MUST** return `404 Not Found` when processing a request to modify
 a resource that does not exist.
@@ -1454,7 +1454,7 @@ a resource that does not exist.
 A server **MUST** return `404 Not Found` when processing a request that
 references a related resource that does not exist.
 
-##### 409 Conflict <a href="#crud-updating-responses-409" id="crud-updating-responses-409" class="headerlink"></a>
+##### <a href="#crud-updating-responses-409" id="crud-updating-responses-409" class="headerlink"></a> 409 Conflict
 
 A server **MAY** return `409 Conflict` when processing a `PATCH` request to
 update a resource if that update would violate other server-enforced
@@ -1466,7 +1466,7 @@ which the resource object's `type` and `id` do not match the server's endpoint.
 A server **SHOULD** include error details and provide enough information to
 recognize the source of the conflict.
 
-##### Other Responses <a href="#crud-updating-responses-other" id="crud-updating-responses-other" class="headerlink"></a>
+##### <a href="#crud-updating-responses-other" id="crud-updating-responses-other" class="headerlink"></a> Other Responses
 
 A server **MAY** respond with other HTTP status codes.
 
@@ -1476,7 +1476,7 @@ A server **MUST** prepare responses, and a client **MUST** interpret
 responses, in accordance with
 [`HTTP semantics`](http://tools.ietf.org/html/rfc7231).
 
-### Updating Relationships <a href="#crud-updating-relationships" id="crud-updating-relationships" class="headerlink"></a>
+### <a href="#crud-updating-relationships" id="crud-updating-relationships" class="headerlink"></a> Updating Relationships
 
 Although relationships can be modified along with resources (as described
 above), JSON API also supports updating of relationships independently at
@@ -1495,7 +1495,7 @@ the same in both cases.
 > Note: A server may choose to delete the underlying resource if a
 relationship is deleted (as a garbage collection measure).
 
-#### Updating To-One Relationships <a href="#crud-updating-to-one-relationships" id="crud-updating-to-one-relationships" class="headerlink"></a>
+#### <a href="#crud-updating-to-one-relationships" id="crud-updating-to-one-relationships" class="headerlink"></a> Updating To-One Relationships
 
 A server **MUST** respond to `PATCH` requests to a URL from a to-one
 [relationship link][relationships] as described below.
@@ -1533,7 +1533,7 @@ Accept: application/vnd.api+json
 If the relationship is updated successfully then the server **MUST** return
 a successful response.
 
-#### Updating To-Many Relationships <a href="#crud-updating-to-many-relationships" id="crud-updating-to-many-relationships" class="headerlink"></a>
+#### <a href="#crud-updating-to-many-relationships" id="crud-updating-to-many-relationships" class="headerlink"></a> Updating To-Many Relationships
 
 A server **MUST** respond to `PATCH`, `POST`, and `DELETE` requests to a
 URL from a to-many [relationship link][relationships] as described below.
@@ -1636,15 +1636,15 @@ Accept: application/vnd.api+json
 that a server may reject the request. This spec defines the semantics of a
 server, and we are defining its semantics for JSON API.
 
-#### Responses <a href="#crud-updating-relationship-responses" id="crud-updating-relationship-responses" class="headerlink"></a>
+#### <a href="#crud-updating-relationship-responses" id="crud-updating-relationship-responses" class="headerlink"></a> Responses
 
-##### 202 Accepted <a href="#crud-updating-relationship-responses-202" id="crud-updating-relationship-responses-202" class="headerlink"></a>
+##### <a href="#crud-updating-relationship-responses-202" id="crud-updating-relationship-responses-202" class="headerlink"></a> 202 Accepted
 
 If a relationship update request has been accepted for processing, but the
 processing has not been completed by the time the server responds, the
 server **MUST** return a `202 Accepted` status code.
 
-##### 204 No Content <a href="#crud-updating-relationship-responses-204" id="crud-updating-relationship-responses-204" class="headerlink"></a>
+##### <a href="#crud-updating-relationship-responses-204" id="crud-updating-relationship-responses-204" class="headerlink"></a> 204 No Content
 
 A server **MUST** return a `204 No Content` status code if an update is
 successful and the representation of the resource in the request matches the
@@ -1656,7 +1656,7 @@ exists. It is also the appropriate response to a `DELETE` request sent to a URL
 from a to-many [relationship link][relationships] when that relationship does
 not exist.
 
-##### 200 OK <a href="#crud-updating-relationship-responses-200" id="crud-updating-relationship-responses-200" class="headerlink"></a>
+##### <a href="#crud-updating-relationship-responses-200" id="crud-updating-relationship-responses-200" class="headerlink"></a> 200 OK
 
 If a server accepts an update but also changes the targeted relationship(s)
 in other ways than those specified by the request, it **MUST** return a `200
@@ -1668,12 +1668,12 @@ the client's current data remain up to date, and the server responds
 only with top-level [meta] data. In this case the server **MUST NOT**
 include a representation of the updated relationship(s).
 
-##### 403 Forbidden <a href="#crud-updating-relationship-responses-403" id="crud-updating-relationship-responses-403" class="headerlink"></a>
+##### <a href="#crud-updating-relationship-responses-403" id="crud-updating-relationship-responses-403" class="headerlink"></a> 403 Forbidden
 
 A server **MUST** return `403 Forbidden` in response to an unsupported request
 to update a relationship.
 
-##### Other Responses <a href="#crud-updating-relationship-responses-other" id="crud-updating-relationship-responses-other" class="headerlink"></a>
+##### <a href="#crud-updating-relationship-responses-other" id="crud-updating-relationship-responses-other" class="headerlink"></a> Other Responses
 
 A server **MAY** respond with other HTTP status codes.
 
@@ -1683,7 +1683,7 @@ A server **MUST** prepare responses, and a client **MUST** interpret
 responses, in accordance with
 [`HTTP semantics`](http://tools.ietf.org/html/rfc7231).
 
-### Deleting Resources <a href="#crud-deleting" id="crud-deleting" class="headerlink"></a>
+### <a href="#crud-deleting" id="crud-deleting" class="headerlink"></a> Deleting Resources
 
 An individual resource can be *deleted* by making a `DELETE` request to the
 resource's URL:
@@ -1693,25 +1693,25 @@ DELETE /photos/1 HTTP/1.1
 Accept: application/vnd.api+json
 ```
 
-#### Responses <a href="#crud-deleting-responses" id="crud-deleting-responses" class="headerlink"></a>
+#### <a href="#crud-deleting-responses" id="crud-deleting-responses" class="headerlink"></a> Responses
 
-##### 202 Accepted <a href="#crud-deleting-responses-202" id="crud-deleting-responses-202" class="headerlink"></a>
+##### <a href="#crud-deleting-responses-202" id="crud-deleting-responses-202" class="headerlink"></a> 202 Accepted
 
 If a deletion request has been accepted for processing, but the processing has
 not been completed by the time the server responds, the server **MUST**
 return a `202 Accepted` status code.
 
-##### 204 No Content <a href="#crud-deleting-responses-204" id="crud-deleting-responses-204" class="headerlink"></a>
+##### <a href="#crud-deleting-responses-204" id="crud-deleting-responses-204" class="headerlink"></a> 204 No Content
 
 A server **MUST** return a `204 No Content` status code if a deletion
 request is successful and no content is returned.
 
-##### 200 OK <a href="#crud-deleting-responses-200" id="crud-deleting-responses-200" class="headerlink"></a>
+##### <a href="#crud-deleting-responses-200" id="crud-deleting-responses-200" class="headerlink"></a> 200 OK
 
 A server **MUST** return a `200 OK` status code if a deletion request is
 successful and the server responds with only top-level [meta] data.
 
-##### Other Responses <a href="#crud-deleting-responses-other" id="crud-deleting-responses-other" class="headerlink"></a>
+##### <a href="#crud-deleting-responses-other" id="crud-deleting-responses-other" class="headerlink"></a> Other Responses
 
 A server **MAY** respond with other HTTP status codes.
 
@@ -1721,7 +1721,7 @@ A server **MUST** prepare responses, and a client **MUST** interpret
 responses, in accordance with
 [`HTTP semantics`](http://tools.ietf.org/html/rfc7231).
 
-## Query Parameters <a href="#query-parameters" id="query-parameters" class="headerlink"></a>
+## <a href="#query-parameters" id="query-parameters" class="headerlink"></a> Query Parameters
 
 Implementation specific query parameters **MUST** adhere to the same constraints
 as [member names] with the additional requirement that they **MUST** contain at
@@ -1736,9 +1736,9 @@ parameter from this specification, it **MUST** return `400 Bad Request`.
 > Note: This is to preserve the ability of JSON API to make additive additions
 to standard query parameters without conflicting with existing implementations.
 
-## Errors <a href="#errors" id="errors" class="headerlink"></a>
+## <a href="#errors" id="errors" class="headerlink"></a> Errors
 
-### Processing Errors <a href="#errors-processing" id="errors-processing" class="headerlink"></a>
+### <a href="#errors-processing" id="errors-processing" class="headerlink"></a> Processing Errors
 
 A server **MAY** choose to stop processing as soon as a problem is encountered,
 or it **MAY** continue processing and encounter multiple problems. For instance,
@@ -1750,7 +1750,7 @@ generally applicable HTTP error code **SHOULD** be used in the response. For
 instance, `400 Bad Request` might be appropriate for multiple 4xx errors
 or `500 Internal Server Error` might be appropriate for multiple 5xx errors.
 
-### Error Objects <a href="#error-objects" id="error-objects" class="headerlink"></a>
+### <a href="#error-objects" id="error-objects" class="headerlink"></a> Error Objects
 
 Error objects provide additional information about problems encountered while
 performing an operation. Error objects **MUST** be returned as an array

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -2,7 +2,7 @@
 version: 1.1
 ---
 
-## Introduction <a href="#introduction" id="introduction" class="headerlink"></a>
+## <a href="#introduction" id="introduction" class="headerlink"></a> Introduction
 
 JSON API is a specification for how a client should request that resources be
 fetched or modified, and how a server should respond to those requests.
@@ -15,16 +15,16 @@ JSON API requires use of the JSON API media type
 ([`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json))
 for exchanging data.
 
-## Conventions <a href="#conventions" id="conventions" class="headerlink"></a>
+## <a href="#conventions" id="conventions" class="headerlink"></a> Conventions
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in RFC 2119
 [[RFC2119](http://tools.ietf.org/html/rfc2119)].
 
-## Content Negotiation <a href="#content-negotiation" id="content-negotiation" class="headerlink"></a>
+## <a href="#content-negotiation" id="content-negotiation" class="headerlink"></a> Content Negotiation
 
-### Client Responsibilities <a href="#content-negotiation-clients" id="content-negotiation-clients" class="headerlink"></a>
+### <a href="#content-negotiation-clients" id="content-negotiation-clients" class="headerlink"></a> Client Responsibilities
 
 Clients **MUST** send all JSON API data in request documents with the header
 `Content-Type: application/vnd.api+json` without any media type parameters.
@@ -35,7 +35,7 @@ specify the media type there at least once without any media type parameters.
 Clients **MUST** ignore any parameters for the `application/vnd.api+json`
 media type received in the `Content-Type` header of response documents.
 
-### Server Responsibilities <a href="#content-negotiation-servers" id="content-negotiation-servers" class="headerlink"></a>
+### <a href="#content-negotiation-servers" id="content-negotiation-servers" class="headerlink"></a> Server Responsibilities
 
 Servers **MUST** send all JSON API data in response documents with the header
 `Content-Type: application/vnd.api+json` without any media type parameters.
@@ -52,7 +52,7 @@ of that media type are modified with media type parameters.
 of this specification to use media type parameters for extension negotiation
 and versioning.
 
-## Document Structure <a href="#document-structure" id="document-structure" class="headerlink"></a>
+## <a href="#document-structure" id="document-structure" class="headerlink"></a> Document Structure
 
 This section describes the structure of a JSON API document, which is identified
 by the media type [`application/vnd.api+json`]
@@ -71,7 +71,7 @@ ignore members not recognized by this specification.
 > Note: These conditions allow this specification to evolve through additive
 changes.
 
-### Top Level <a href="#document-top-level" id="document-top-level" class="headerlink"></a>
+### <a href="#document-top-level" id="document-top-level" class="headerlink"></a> Top Level
 
 A JSON object **MUST** be at the root of every JSON API request and response
 containing data. This object defines a document's "top level".
@@ -145,7 +145,7 @@ references the same resource:
 A logical collection of resources **MUST** be represented as an array, even if
 it only contains one item or is empty.
 
-### Resource Objects <a href="#document-resource-objects" id="document-resource-objects" class="headerlink"></a>
+### <a href="#document-resource-objects" id="document-resource-objects" class="headerlink"></a> Resource Objects
 
 "Resource objects" appear in a JSON API document to represent resources.
 
@@ -189,7 +189,7 @@ Here's how an article (i.e. a resource of type "articles") might appear in a doc
 // ...
 ```
 
-#### Identification <a href="#document-resource-object-identification" id="document-resource-object-identification" class="headerlink"></a>
+#### <a href="#document-resource-object-identification" id="document-resource-object-identification" class="headerlink"></a> Identification
 
 Every [resource object][resource objects] **MUST** contain an `id` member and a `type` member.
 The values of the `id` and `type` members **MUST** be strings.
@@ -208,7 +208,7 @@ The values of `type` members **MUST** adhere to the same constraints as
 can be either plural or singular. However, the same value should be used
 consistently throughout an implementation.
 
-#### Fields <a href="#document-resource-object-fields" id="document-resource-object-fields" class="headerlink"></a>
+#### <a href="#document-resource-object-fields" id="document-resource-object-fields" class="headerlink"></a> Fields
 
 A resource object's [attributes] and its [relationships] are collectively called
 its "[fields]".
@@ -218,7 +218,7 @@ other and with `type` and `id`. In other words, a resource can not have an
 attribute and relationship with the same name, nor can it have an attribute
 or relationship named `type` or `id`.
 
-#### Attributes <a href="#document-resource-object-attributes" id="document-resource-object-attributes" class="headerlink"></a>
+#### <a href="#document-resource-object-attributes" id="document-resource-object-attributes" class="headerlink"></a> Attributes
 
 The value of the `attributes` key **MUST** be an object (an "attributes
 object"). Members of the attributes object ("attributes") represent information
@@ -237,7 +237,7 @@ alongside other information to be represented in a resource object, these keys
 
 > Note: See [fields] and [member names] for more restrictions on this container.
 
-#### Relationships <a href="#document-resource-object-relationships" id="document-resource-object-relationships" class="headerlink"></a>
+#### <a href="#document-resource-object-relationships" id="document-resource-object-relationships" class="headerlink"></a> Relationships
 
 The value of the `relationships` key **MUST** be an object (a "relationships
 object"). Members of the relationships object ("relationships") represent
@@ -263,7 +263,7 @@ A relationship object that represents a to-many relationship **MAY** also contai
 
 > Note: See [fields] and [member names] for more restrictions on this container.
 
-#### Related Resource Links <a href="#document-resource-object-related-resource-links" id="document-resource-object-related-resource-links" class="headerlink"></a>
+#### <a href="#document-resource-object-related-resource-links" id="document-resource-object-related-resource-links" class="headerlink"></a> Related Resource Links
 
 A "related resource link" provides access to [resource objects] [linked][links]
 in a [relationship][relationships]. When fetched, the related resource object(s)
@@ -278,7 +278,7 @@ relationship isn't currently associated with any target resources. Additionally,
 a related resource link **MUST NOT** change because its relationship's content
 changes.
 
-#### Resource Linkage <a href="#document-resource-object-linkage" id="document-resource-object-linkage" class="headerlink"></a>
+#### <a href="#document-resource-object-linkage" id="document-resource-object-linkage" class="headerlink"></a> Resource Linkage
 
 Resource linkage in a [compound document] allows a client to link together all
 of the included [resource objects] without having to `GET` any URLs via [links].
@@ -326,7 +326,7 @@ The `author` relationship includes a link for the relationship itself (which
 allows the client to change the related author directly), a related resource
 link to fetch the resource objects, and linkage information.
 
-#### Resource Links <a href="#document-resource-object-links" id="document-resource-object-links" class="headerlink"></a>
+#### <a href="#document-resource-object-links" id="document-resource-object-links" class="headerlink"></a> Resource Links
 
 The optional `links` member within each [resource object][resource objects] contains [links]
 related to the resource.
@@ -352,7 +352,7 @@ identifies the resource represented by the resource object.
 A server **MUST** respond to a `GET` request to the specified URL with a
 response that includes the resource as the primary data.
 
-### Resource Identifier Objects <a href="#document-resource-identifier-objects" id="document-resource-identifier-objects" class="headerlink"></a>
+### <a href="#document-resource-identifier-objects" id="document-resource-identifier-objects" class="headerlink"></a> Resource Identifier Objects
 
 A "resource identifier object" is an object that identifies an individual
 resource.
@@ -362,7 +362,7 @@ A "resource identifier object" **MUST** contain `type` and `id` members.
 A "resource identifier object" **MAY** also include a `meta` member, whose value is a [meta] object that
 contains non-standard meta-information.
 
-### Compound Documents <a href="#document-compound-documents" id="document-compound-documents" class="headerlink"></a>
+### <a href="#document-compound-documents" id="document-compound-documents" class="headerlink"></a> Compound Documents
 
 To reduce the number of HTTP requests, servers **MAY** allow responses that
 include related resources along with the requested primary resources. Such
@@ -470,7 +470,7 @@ the document.
 returned with each response, even when the same resource is referenced
 multiple times.
 
-### Meta Information <a href="#document-meta" id="document-meta" class="headerlink"></a>
+### <a href="#document-meta" id="document-meta" class="headerlink"></a> Meta Information
 
 Where specified, a `meta` member can be used to include non-standard
 meta-information. The value of each `meta` member **MUST** be an object (a
@@ -497,7 +497,7 @@ For example:
 }
 ```
 
-### Links <a href="#document-links" id="document-links" class="headerlink"></a>
+### <a href="#document-links" id="document-links" class="headerlink"></a> Links
 
 Where specified, a `links` member can be used to represent links. The value
 of each `links` member **MUST** be an object (a "links object").
@@ -538,7 +538,7 @@ objects in the future. It is also possible that the allowed values of
 additional members will be expanded (e.g. a `collection` link may support an
 array of values, whereas a `self` link does not).
 
-### JSON API Object <a href="#document-jsonapi-object" id="document-jsonapi-object" class="headerlink"></a>
+### <a href="#document-jsonapi-object" id="document-jsonapi-object" class="headerlink"></a> JSON API Object
 
 A JSON API document **MAY** include information about its implementation
 under a top level `jsonapi` member. If present, the value of the `jsonapi`
@@ -561,7 +561,7 @@ implements at least version 1.0 of the specification.
 > Note: Because JSON API is committed to making additive changes only, the
 version string primarily indicates which new features a server may support.
 
-### Member Names <a href="#document-member-names" id="document-member-names" class="headerlink"></a>
+### <a href="#document-member-names" id="document-member-names" class="headerlink"></a> Member Names
 
 All member names used in a JSON API document **MUST** be treated as case sensitive
 by clients and servers, and they **MUST** meet all of the following conditions:
@@ -574,7 +574,7 @@ by clients and servers, and they **MUST** meet all of the following conditions:
 To enable an easy mapping of member names to URLs, it is **RECOMMENDED** that
 member names use only non-reserved, URL safe characters specified in [RFC 3986](http://tools.ietf.org/html/rfc3986#page-13).
 
-#### Allowed Characters <a href="#document-member-names-allowed-characters" id="document-member-names-allowed-characters" class="headerlink"></a>
+#### <a href="#document-member-names-allowed-characters" id="document-member-names-allowed-characters" class="headerlink"></a> Allowed Characters
 
 The following "globally allowed characters" **MAY** be used anywhere in a member name:
 
@@ -590,7 +590,7 @@ first or last character:
 - U+005F LOW LINE, "_"
 - U+0020 SPACE, " " _(not recommended, not URL safe)_
 
-#### Reserved Characters <a href="#document-member-names-reserved-characters" id="document-member-names-reserved-characters" class="headerlink"></a>
+#### <a href="#document-member-names-reserved-characters" id="document-member-names-reserved-characters" class="headerlink"></a> Reserved Characters
 
 The following characters **MUST NOT** be used in member names:
 
@@ -625,14 +625,14 @@ The following characters **MUST NOT** be used in member names:
 - U+007D RIGHT CURLY BRACKET, "}"
 - U+007E TILDE, "~"
 
-## Fetching Data <a href="#fetching" id="fetching" class="headerlink"></a>
+## <a href="#fetching" id="fetching" class="headerlink"></a> Fetching Data
 
 Data, including resources and relationships, can be fetched by sending a
 `GET` request to an endpoint.
 
 Responses can be further refined with the optional features described below.
 
-### Fetching Resources <a href="#fetching-resources" id="fetching-resources" class="headerlink"></a>
+### <a href="#fetching-resources" id="fetching-resources" class="headerlink"></a> Fetching Resources
 
 A server **MUST** support fetching resource data for every URL provided as:
 
@@ -661,9 +661,9 @@ GET /articles/1/author HTTP/1.1
 Accept: application/vnd.api+json
 ```
 
-#### Responses <a href="#fetching-resources-responses" id="fetching-resources-responses" class="headerlink"></a>
+#### <a href="#fetching-resources-responses" id="fetching-resources-responses" class="headerlink"></a> Responses
 
-##### 200 OK <a href="#fetching-resources-responses-200" id="fetching-resources-responses-200" class="headerlink"></a>
+##### <a href="#fetching-resources-responses-200" id="fetching-resources-responses-200" class="headerlink"></a> 200 OK
 
 A server **MUST** respond to a successful request to fetch an individual
 resource or resource collection with a `200 OK` response.
@@ -766,13 +766,13 @@ Content-Type: application/vnd.api+json
 }
 ```
 
-##### 404 Not Found <a href="#fetching-resources-responses-404" id="fetching-resources-responses-404" class="headerlink"></a>
+##### <a href="#fetching-resources-responses-404" id="fetching-resources-responses-404" class="headerlink"></a> 404 Not Found
 
 A server **MUST** respond with `404 Not Found` when processing a request to
 fetch a single resource that does not exist, except when the request warrants a
 `200 OK` response with `null` as the primary data (as described above).
 
-##### Other Responses <a href="#fetching-resources-responses-other" id="fetching-resources-responses-other" class="headerlink"></a>
+##### <a href="#fetching-resources-responses-other" id="fetching-resources-responses-other" class="headerlink"></a> Other Responses
 
 A server **MAY** respond with other HTTP status codes.
 
@@ -782,7 +782,7 @@ A server **MUST** prepare responses, and a client **MUST** interpret
 responses, in accordance with
 [`HTTP semantics`](http://tools.ietf.org/html/rfc7231).
 
-### Fetching Relationships <a href="#fetching-relationships" id="fetching-relationships" class="headerlink"></a>
+### <a href="#fetching-relationships" id="fetching-relationships" class="headerlink"></a> Fetching Relationships
 
 A server **MUST** support fetching relationship data for every relationship URL
 provided as a `self` link as part of a relationship's `links` object.
@@ -801,9 +801,9 @@ GET /articles/1/relationships/author HTTP/1.1
 Accept: application/vnd.api+json
 ```
 
-#### Responses <a href="#fetching-relationships-responses" id="fetching-relationships-responses" class="headerlink"></a>
+#### <a href="#fetching-relationships-responses" id="fetching-relationships-responses" class="headerlink"></a> Responses
 
-##### 200 OK <a href="#fetching-relationships-responses-200" id="fetching-relationships-responses-200" class="headerlink"></a>
+##### <a href="#fetching-relationships-responses-200" id="fetching-relationships-responses-200" class="headerlink"></a> 200 OK
 
 A server **MUST** respond to a successful request to fetch a relationship
 with a `200 OK` response.
@@ -884,7 +884,7 @@ Content-Type: application/vnd.api+json
 }
 ```
 
-##### 404 Not Found <a href="#fetching-relationships-responses-404" id="fetching-relationships-responses-404" class="headerlink"></a>
+##### <a href="#fetching-relationships-responses-404" id="fetching-relationships-responses-404" class="headerlink"></a> 404 Not Found
 
 A server **MUST** return `404 Not Found` when processing a request to fetch
 a relationship link URL that does not exist.
@@ -896,7 +896,7 @@ does not exist. For example, when `/articles/1` does not exist, request to
 If a relationship link URL exists but the relationship is empty, then
 `200 OK` **MUST** be returned, as described above.
 
-##### Other Responses <a href="#fetching-relationships-responses-other" id="fetching-relationships-responses-other" class="headerlink"></a>
+##### <a href="#fetching-relationships-responses-other" id="fetching-relationships-responses-other" class="headerlink"></a> Other Responses
 
 A server **MAY** respond with other HTTP status codes.
 
@@ -906,7 +906,7 @@ A server **MUST** prepare responses, and a client **MUST** interpret
 responses, in accordance with
 [`HTTP semantics`](http://tools.ietf.org/html/rfc7231).
 
-### Inclusion of Related Resources <a href="#fetching-includes" id="fetching-includes" class="headerlink"></a>
+### <a href="#fetching-includes" id="fetching-includes" class="headerlink"></a> Inclusion of Related Resources
 
 An endpoint **MAY** return resources related to the primary data by default.
 
@@ -983,7 +983,7 @@ data, regardless of the request type. For instance, a server could support
 the inclusion of related resources along with a `POST` request to create a
 resource or relationship.
 
-### Sparse Fieldsets <a href="#fetching-sparse-fieldsets" id="fetching-sparse-fieldsets" class="headerlink"></a>
+### <a href="#fetching-sparse-fieldsets" id="fetching-sparse-fieldsets" class="headerlink"></a> Sparse Fieldsets
 
 A client **MAY** request that an endpoint return only specific [fields] in the
 response on a per-type basis by including a `fields[TYPE]` parameter.
@@ -1008,7 +1008,7 @@ primary or included data, regardless of the request type. For instance, a
 server could support sparse fieldsets along with a `POST` request to create
 a resource.
 
-### Sorting <a href="#fetching-sorting" id="fetching-sorting" class="headerlink"></a>
+### <a href="#fetching-sorting" id="fetching-sorting" class="headerlink"></a> Sorting
 
 A server **MAY** choose to support requests to sort resource collections
 according to one or more criteria ("sort fields").
@@ -1063,7 +1063,7 @@ request parameter `sort` is not specified.
 > Note: This section applies to any endpoint that responds with a resource
 collection as primary data, regardless of the request type.
 
-### Pagination <a href="#fetching-pagination" id="fetching-pagination" class="headerlink"></a>
+### <a href="#fetching-pagination" id="fetching-pagination" class="headerlink"></a> Pagination
 
 A server **MAY** choose to limit the number of resources returned in a response
 to a subset ("page") of the whole set available.
@@ -1108,7 +1108,7 @@ per the requirements in [RFC 3986](http://tools.ietf.org/html/rfc3986#section-3.
 > Note: This section applies to any endpoint that responds with a resource
 collection as primary data, regardless of the request type.
 
-### Filtering <a href="#fetching-filtering" id="fetching-filtering" class="headerlink"></a>
+### <a href="#fetching-filtering" id="fetching-filtering" class="headerlink"></a> Filtering
 
 The `filter` query parameter is reserved for filtering data. Servers and clients
 **SHOULD** use this key for filtering operations.
@@ -1117,7 +1117,7 @@ The `filter` query parameter is reserved for filtering data. Servers and clients
 `filter` query parameter can be used as the basis for any number of filtering
 strategies.
 
-## Creating, Updating and Deleting Resources <a href="#crud" id="crud" class="headerlink"></a>
+## <a href="#crud" id="crud" class="headerlink"></a> Creating, Updating and Deleting Resources
 
 A server **MAY** allow resources of a given type to be created. It **MAY**
 also allow existing resources to be modified or deleted.
@@ -1133,7 +1133,7 @@ confusing; it would be hard to remember when it was required and when it was
 not. Therefore, to improve consistency and minimize confusion, `type` is
 always required.
 
-### Creating Resources <a href="#crud-creating" id="crud-creating" class="headerlink"></a>
+### <a href="#crud-creating" id="crud-creating" class="headerlink"></a> Creating Resources
 
 A resource can be created by sending a `POST` request to a URL that represents
 a collection of resources. The request **MUST** include a single [resource object][resource objects]
@@ -1167,7 +1167,7 @@ If a relationship is provided in the `relationships` member of the
 member. The value of this key represents the linkage the new resource is to
 have.
 
-#### Client-Generated IDs <a href="#crud-creating-client-ids" id="crud-creating-client-ids" class="headerlink"></a>
+#### <a href="#crud-creating-client-ids" id="crud-creating-client-ids" class="headerlink"></a> Client-Generated IDs
 
 A server **MAY** accept a client-generated ID along with a request to create
 a resource. An ID **MUST** be specified with an `id` key, the value of
@@ -1203,9 +1203,9 @@ Accept: application/vnd.api+json
 A server **MUST** return `403 Forbidden` in response to an unsupported request
 to create a resource with a client-generated ID.
 
-#### Responses <a href="#crud-creating-responses" id="crud-creating-responses" class="headerlink"></a>
+#### <a href="#crud-creating-responses" id="crud-creating-responses" class="headerlink"></a> Responses
 
-##### 201 Created <a href="#crud-creating-responses-201" id="crud-creating-responses-201" class="headerlink"></a>
+##### <a href="#crud-creating-responses-201" id="crud-creating-responses-201" class="headerlink"></a> 201 Created
 
 If a `POST` request did not include a [Client-Generated
 ID](#crud-creating-client-ids) and the requested resource has been created
@@ -1241,13 +1241,13 @@ Content-Type: application/vnd.api+json
 }
 ```
 
-##### 202 Accepted <a href="#crud-creating-responses-202" id="crud-creating-responses-202" class="headerlink"></a>
+##### <a href="#crud-creating-responses-202" id="crud-creating-responses-202" class="headerlink"></a> 202 Accepted
 
 If a request to create a resource has been accepted for processing, but the
 processing has not been completed by the time the server responds, the
 server **MUST** return a `202 Accepted` status code.
 
-##### 204 No Content <a href="#crud-creating-responses-204" id="crud-creating-responses-204" class="headerlink"></a>
+##### <a href="#crud-creating-responses-204" id="crud-creating-responses-204" class="headerlink"></a> 204 No Content
 
 If a `POST` request *did* include a [Client-Generated
 ID](#crud-creating-client-ids) and the requested resource has been created
@@ -1259,12 +1259,12 @@ with no response document.
 object sent in the request to be accepted by the server, as if the server
 had returned it back in a `201` response.
 
-##### 403 Forbidden <a href="#crud-creating-responses-403" id="crud-creating-responses-403" class="headerlink"></a>
+##### <a href="#crud-creating-responses-403" id="crud-creating-responses-403" class="headerlink"></a> 403 Forbidden
 
 A server **MAY** return `403 Forbidden` in response to an unsupported request
 to create a resource.
 
-##### 409 Conflict <a href="#crud-creating-responses-409" id="crud-creating-responses-409" class="headerlink"></a>
+##### <a href="#crud-creating-responses-409" id="crud-creating-responses-409" class="headerlink"></a> 409 Conflict
 
 A server **MUST** return `409 Conflict` when processing a `POST` request to
 create a resource with a client-generated ID that already exists.
@@ -1276,7 +1276,7 @@ collection represented by the endpoint.
 A server **SHOULD** include error details and provide enough information to
 recognize the source of the conflict.
 
-##### Other Responses <a href="#crud-creating-responses-other" id="crud-creating-responses-other" class="headerlink"></a>
+##### <a href="#crud-creating-responses-other" id="crud-creating-responses-other" class="headerlink"></a> Other Responses
 
 A server **MAY** respond with other HTTP status codes.
 
@@ -1286,7 +1286,7 @@ A server **MUST** prepare responses, and a client **MUST** interpret
 responses, in accordance with
 [`HTTP semantics`](http://tools.ietf.org/html/rfc7231).
 
-### Updating Resources <a href="#crud-updating" id="crud-updating" class="headerlink"></a>
+### <a href="#crud-updating" id="crud-updating" class="headerlink"></a> Updating Resources
 
 A resource can be updated by sending a `PATCH` request to the URL that
 represents the resource.
@@ -1316,7 +1316,7 @@ Accept: application/vnd.api+json
 }
 ```
 
-#### Updating a Resource's Attributes <a href="#crud-updating-resource-attributes" id="crud-updating-resource-attributes" class="headerlink"></a>
+#### <a href="#crud-updating-resource-attributes" id="crud-updating-resource-attributes" class="headerlink"></a> Updating a Resource's Attributes
 
 Any or all of a resource's [attributes] **MAY** be included in the resource
 object included in a `PATCH` request.
@@ -1346,7 +1346,7 @@ Accept: application/vnd.api+json
 }
 ```
 
-#### Updating a Resource's Relationships <a href="#crud-updating-resource-relationships" id="crud-updating-resource-relationships" class="headerlink"></a>
+#### <a href="#crud-updating-resource-relationships" id="crud-updating-resource-relationships" class="headerlink"></a> Updating a Resource's Relationships
 
 Any or all of a resource's [relationships] **MAY** be included in the resource
 object included in a `PATCH` request.
@@ -1413,15 +1413,15 @@ may choose to disallow it. For example, a server may reject full replacement if
 it has not provided the client with the full list of associated objects, and
 does not want to allow deletion of records the client has not seen.
 
-#### Responses <a href="#crud-updating-responses" id="crud-updating-responses" class="headerlink"></a>
+#### <a href="#crud-updating-responses" id="crud-updating-responses" class="headerlink"></a> Responses
 
-##### 202 Accepted <a href="#crud-updating-responses-202" id="crud-updating-responses-202" class="headerlink"></a>
+##### <a href="#crud-updating-responses-202" id="crud-updating-responses-202" class="headerlink"></a> 202 Accepted
 
 If an update request has been accepted for processing, but the processing
 has not been completed by the time the server responds, the server **MUST**
 return a `202 Accepted` status code.
 
-##### 200 OK <a href="#crud-updating-responses-200" id="crud-updating-responses-200" class="headerlink"></a>
+##### <a href="#crud-updating-responses-200" id="crud-updating-responses-200" class="headerlink"></a> 200 OK
 
 If a server accepts an update but also changes the resource(s) in ways other
 than those specified by the request (for example, updating the `updated-at`
@@ -1434,19 +1434,19 @@ the client's current attributes remain up to date, and the server responds
 only with top-level [meta] data. In this case the server **MUST NOT**
 include a representation of the updated resource(s).
 
-##### 204 No Content <a href="#crud-updating-responses-204" id="crud-updating-responses-204" class="headerlink"></a>
+##### <a href="#crud-updating-responses-204" id="crud-updating-responses-204" class="headerlink"></a> 204 No Content
 
 If an update is successful and the server doesn't update any attributes besides
 those provided, the server **MUST** return either a `200 OK` status code and
 response document (as described above) or a `204 No Content` status code with no
 response document.
 
-##### 403 Forbidden <a href="#crud-updating-relationship-responses-403" id="crud-updating-relationship-responses-403" class="headerlink"></a>
+##### <a href="#crud-updating-relationship-responses-403" id="crud-updating-relationship-responses-403" class="headerlink"></a> 403 Forbidden
 
 A server **MUST** return `403 Forbidden` in response to an unsupported request
 to update a resource or relationship.
 
-##### 404 Not Found <a href="#crud-updating-responses-404" id="crud-updating-responses-404" class="headerlink"></a>
+##### <a href="#crud-updating-responses-404" id="crud-updating-responses-404" class="headerlink"></a> 404 Not Found
 
 A server **MUST** return `404 Not Found` when processing a request to modify
 a resource that does not exist.
@@ -1454,7 +1454,7 @@ a resource that does not exist.
 A server **MUST** return `404 Not Found` when processing a request that
 references a related resource that does not exist.
 
-##### 409 Conflict <a href="#crud-updating-responses-409" id="crud-updating-responses-409" class="headerlink"></a>
+##### <a href="#crud-updating-responses-409" id="crud-updating-responses-409" class="headerlink"></a> 409 Conflict
 
 A server **MAY** return `409 Conflict` when processing a `PATCH` request to
 update a resource if that update would violate other server-enforced
@@ -1466,7 +1466,7 @@ which the resource object's `type` and `id` do not match the server's endpoint.
 A server **SHOULD** include error details and provide enough information to
 recognize the source of the conflict.
 
-##### Other Responses <a href="#crud-updating-responses-other" id="crud-updating-responses-other" class="headerlink"></a>
+##### <a href="#crud-updating-responses-other" id="crud-updating-responses-other" class="headerlink"></a> Other Responses
 
 A server **MAY** respond with other HTTP status codes.
 
@@ -1476,7 +1476,7 @@ A server **MUST** prepare responses, and a client **MUST** interpret
 responses, in accordance with
 [`HTTP semantics`](http://tools.ietf.org/html/rfc7231).
 
-### Updating Relationships <a href="#crud-updating-relationships" id="crud-updating-relationships" class="headerlink"></a>
+### <a href="#crud-updating-relationships" id="crud-updating-relationships" class="headerlink"></a> Updating Relationships
 
 Although relationships can be modified along with resources (as described
 above), JSON API also supports updating of relationships independently at
@@ -1495,7 +1495,7 @@ the same in both cases.
 > Note: A server may choose to delete the underlying resource if a
 relationship is deleted (as a garbage collection measure).
 
-#### Updating To-One Relationships <a href="#crud-updating-to-one-relationships" id="crud-updating-to-one-relationships" class="headerlink"></a>
+#### <a href="#crud-updating-to-one-relationships" id="crud-updating-to-one-relationships" class="headerlink"></a> Updating To-One Relationships
 
 A server **MUST** respond to `PATCH` requests to a URL from a to-one
 [relationship link][relationships] as described below.
@@ -1533,7 +1533,7 @@ Accept: application/vnd.api+json
 If the relationship is updated successfully then the server **MUST** return
 a successful response.
 
-#### Updating To-Many Relationships <a href="#crud-updating-to-many-relationships" id="crud-updating-to-many-relationships" class="headerlink"></a>
+#### <a href="#crud-updating-to-many-relationships" id="crud-updating-to-many-relationships" class="headerlink"></a> Updating To-Many Relationships
 
 A server **MUST** respond to `PATCH`, `POST`, and `DELETE` requests to a
 URL from a to-many [relationship link][relationships] as described below.
@@ -1636,15 +1636,15 @@ Accept: application/vnd.api+json
 that a server may reject the request. This spec defines the semantics of a
 server, and we are defining its semantics for JSON API.
 
-#### Responses <a href="#crud-updating-relationship-responses" id="crud-updating-relationship-responses" class="headerlink"></a>
+#### <a href="#crud-updating-relationship-responses" id="crud-updating-relationship-responses" class="headerlink"></a> Responses
 
-##### 202 Accepted <a href="#crud-updating-relationship-responses-202" id="crud-updating-relationship-responses-202" class="headerlink"></a>
+##### <a href="#crud-updating-relationship-responses-202" id="crud-updating-relationship-responses-202" class="headerlink"></a> 202 Accepted
 
 If a relationship update request has been accepted for processing, but the
 processing has not been completed by the time the server responds, the
 server **MUST** return a `202 Accepted` status code.
 
-##### 204 No Content <a href="#crud-updating-relationship-responses-204" id="crud-updating-relationship-responses-204" class="headerlink"></a>
+##### <a href="#crud-updating-relationship-responses-204" id="crud-updating-relationship-responses-204" class="headerlink"></a> 204 No Content
 
 A server **MUST** return a `204 No Content` status code if an update is
 successful and the representation of the resource in the request matches the
@@ -1656,7 +1656,7 @@ exists. It is also the appropriate response to a `DELETE` request sent to a URL
 from a to-many [relationship link][relationships] when that relationship does
 not exist.
 
-##### 200 OK <a href="#crud-updating-relationship-responses-200" id="crud-updating-relationship-responses-200" class="headerlink"></a>
+##### <a href="#crud-updating-relationship-responses-200" id="crud-updating-relationship-responses-200" class="headerlink"></a> 200 OK
 
 If a server accepts an update but also changes the targeted relationship(s)
 in other ways than those specified by the request, it **MUST** return a `200
@@ -1668,12 +1668,12 @@ the client's current data remain up to date, and the server responds
 only with top-level [meta] data. In this case the server **MUST NOT**
 include a representation of the updated relationship(s).
 
-##### 403 Forbidden <a href="#crud-updating-relationship-responses-403" id="crud-updating-relationship-responses-403" class="headerlink"></a>
+##### <a href="#crud-updating-relationship-responses-403" id="crud-updating-relationship-responses-403" class="headerlink"></a> 403 Forbidden
 
 A server **MUST** return `403 Forbidden` in response to an unsupported request
 to update a relationship.
 
-##### Other Responses <a href="#crud-updating-relationship-responses-other" id="crud-updating-relationship-responses-other" class="headerlink"></a>
+##### <a href="#crud-updating-relationship-responses-other" id="crud-updating-relationship-responses-other" class="headerlink"></a> Other Responses
 
 A server **MAY** respond with other HTTP status codes.
 
@@ -1683,7 +1683,7 @@ A server **MUST** prepare responses, and a client **MUST** interpret
 responses, in accordance with
 [`HTTP semantics`](http://tools.ietf.org/html/rfc7231).
 
-### Deleting Resources <a href="#crud-deleting" id="crud-deleting" class="headerlink"></a>
+### <a href="#crud-deleting" id="crud-deleting" class="headerlink"></a> Deleting Resources
 
 An individual resource can be *deleted* by making a `DELETE` request to the
 resource's URL:
@@ -1693,25 +1693,25 @@ DELETE /photos/1 HTTP/1.1
 Accept: application/vnd.api+json
 ```
 
-#### Responses <a href="#crud-deleting-responses" id="crud-deleting-responses" class="headerlink"></a>
+#### <a href="#crud-deleting-responses" id="crud-deleting-responses" class="headerlink"></a> Responses
 
-##### 202 Accepted <a href="#crud-deleting-responses-202" id="crud-deleting-responses-202" class="headerlink"></a>
+##### <a href="#crud-deleting-responses-202" id="crud-deleting-responses-202" class="headerlink"></a> 202 Accepted
 
 If a deletion request has been accepted for processing, but the processing has
 not been completed by the time the server responds, the server **MUST**
 return a `202 Accepted` status code.
 
-##### 204 No Content <a href="#crud-deleting-responses-204" id="crud-deleting-responses-204" class="headerlink"></a>
+##### <a href="#crud-deleting-responses-204" id="crud-deleting-responses-204" class="headerlink"></a> 204 No Content
 
 A server **MUST** return a `204 No Content` status code if a deletion
 request is successful and no content is returned.
 
-##### 200 OK <a href="#crud-deleting-responses-200" id="crud-deleting-responses-200" class="headerlink"></a>
+##### <a href="#crud-deleting-responses-200" id="crud-deleting-responses-200" class="headerlink"></a> 200 OK
 
 A server **MUST** return a `200 OK` status code if a deletion request is
 successful and the server responds with only top-level [meta] data.
 
-##### Other Responses <a href="#crud-deleting-responses-other" id="crud-deleting-responses-other" class="headerlink"></a>
+##### <a href="#crud-deleting-responses-other" id="crud-deleting-responses-other" class="headerlink"></a> Other Responses
 
 A server **MAY** respond with other HTTP status codes.
 
@@ -1721,7 +1721,7 @@ A server **MUST** prepare responses, and a client **MUST** interpret
 responses, in accordance with
 [`HTTP semantics`](http://tools.ietf.org/html/rfc7231).
 
-## Query Parameters <a href="#query-parameters" id="query-parameters" class="headerlink"></a>
+## <a href="#query-parameters" id="query-parameters" class="headerlink"></a> Query Parameters
 
 Implementation specific query parameters **MUST** adhere to the same constraints
 as [member names] with the additional requirement that they **MUST** contain at
@@ -1736,9 +1736,9 @@ parameter from this specification, it **MUST** return `400 Bad Request`.
 > Note: This is to preserve the ability of JSON API to make additive additions
 to standard query parameters without conflicting with existing implementations.
 
-## Errors <a href="#errors" id="errors" class="headerlink"></a>
+## <a href="#errors" id="errors" class="headerlink"></a> Errors
 
-### Processing Errors <a href="#errors-processing" id="errors-processing" class="headerlink"></a>
+### <a href="#errors-processing" id="errors-processing" class="headerlink"></a> Processing Errors
 
 A server **MAY** choose to stop processing as soon as a problem is encountered,
 or it **MAY** continue processing and encounter multiple problems. For instance,
@@ -1750,7 +1750,7 @@ generally applicable HTTP error code **SHOULD** be used in the response. For
 instance, `400 Bad Request` might be appropriate for multiple 4xx errors
 or `500 Internal Server Error` might be appropriate for multiple 5xx errors.
 
-### Error Objects <a href="#error-objects" id="error-objects" class="headerlink"></a>
+### <a href="#error-objects" id="error-objects" class="headerlink"></a> Error Objects
 
 Error objects provide additional information about problems encountered while
 performing an operation. Error objects **MUST** be returned as an array

--- a/_includes/status.md
+++ b/_includes/status.md
@@ -7,7 +7,7 @@
 {% assign is_latest_version_page = include.is_latest_version %}
 {% assign is_upcoming_version_page = include.is_upcoming_version %}
 
-## Status <a href="#status" id="status" class="headerlink"></a>
+## <a href="#status" id="status" class="headerlink"></a> Status
 
 {% comment %}
   The first paragraph in each case, below, aims to explain what content

--- a/about/index.md
+++ b/about/index.md
@@ -3,7 +3,7 @@ layout: page
 title: About
 ---
 
-## Channels <a href="#channels" id="channels" class="headerlink"></a>
+## <a href="#channels" id="channels" class="headerlink"></a> Channels
 
 JSON API is:
 
@@ -12,7 +12,7 @@ JSON API is:
   * _#jsonapi_ channel on [Freenode IRC](http://freenode.net)
   * [jsonapi discussion forum](http://discuss.jsonapi.org)
 
-## Editors <a href="#editors" id="editors" class="headerlink"></a>
+## <a href="#editors" id="editors" class="headerlink"></a> Editors
 
 There are five primary editors of this specification:
 
@@ -22,15 +22,15 @@ There are five primary editors of this specification:
 - [Tyler Kellen](http://twitter.com/tkellen)
 - [Ethan Resnick](http://twitter.com/ethanresnick)
 
-## Roadmap <a href="#roadmap" id="roadmap" class="headerlink"></a>
+## <a href="#roadmap" id="roadmap" class="headerlink"></a> Roadmap
 
-### 1.1
+### <a href="#roadmap-1-1" id="roadmap-1-1" class="headerlink"></a> 1.1
 **Targeted Release Date:** September 30th, 2015
 
 * Embedding / creating multiple related resources in a single request
 * Extension support
 
-## History <a href="#history" id="history" class="headerlink"></a>
+## <a href="#history" id="history" class="headerlink"></a> History
 
 JSON API was originally drafted by [Yehuda Katz](http://twitter.com/wycats)
 in May 2013. This first draft was extracted from the JSON transport

--- a/examples/index.md
+++ b/examples/index.md
@@ -6,7 +6,7 @@ show_sidebar: true
 
 This page contains additional examples of how to apply various parts of the specification.
 
-## Sparse Fieldsets <a href="#sparse-fieldsets" id="sparse-fieldsets" class="headerlink"></a>
+## <a href="#sparse-fieldsets" id="sparse-fieldsets" class="headerlink"></a> Sparse Fieldsets
 
 Examples of how [sparse fieldsets](http://jsonapi.org/format/#fetching-sparse-fieldsets) work.
 
@@ -127,7 +127,7 @@ Content-Type: application/vnd.api+json
 for readability. In practice, these characters must be percent-encoded, as
 noted in the base specification.
 
-## Pagination Links <a href="#pagination" id="pagination" class="headerlink"></a>
+## <a href="#pagination" id="pagination" class="headerlink"></a> Pagination Links
 
 Example of a page-based strategy on how to add [pagination links](http://jsonapi.org/format/#fetching-pagination).
 
@@ -177,11 +177,11 @@ the `"last"` link, which simply gives the URI of the last page). However, all
 `"meta"` values are implementation-specific, so you can call this member whatever
 you like (`"total"`, `"count"`, etc.) or not use it at all.
 
-## Error Objects <a href="#error-objects" id="error-objects" class="headerlink"></a>
+## <a href="#error-objects" id="error-objects" class="headerlink"></a> Error Objects
 
 Examples of how [error objects](http://jsonapi.org/format/#error-objects) work.
 
-### A Basic Error Object <a href="#error-objects-basics" id="error-objects-basics" class="headerlink"></a>
+### <a href="#error-objects-basics" id="error-objects-basics" class="headerlink"></a> A Basic Error Object
 
 In the response below, the server is indicating that it encountered an error
 while creating/updating the resource, and that this error was caused
@@ -219,7 +219,7 @@ useful for single errors, to save clients the trouble of consulting the HTTP
 headers, or for using JSON API over non-HTTP protocols, which may be officially
 supported in the near future.
 
-### Multiple Errors <a href="#error-objects-multiple-errors" id="error-objects-multiple-errors" class="headerlink"></a>
+### <a href="#error-objects-multiple-errors" id="error-objects-multiple-errors" class="headerlink"></a> Multiple Errors
 
 When multiple errors occur in response to a single request, the server
 can simply add each error to the `errors` array:
@@ -278,7 +278,7 @@ Content-Type: application/vnd.api+json
 also be acceptable. ([http://stackoverflow.com/a/20215807/1261879](More details.))
 JSON API doesn't take a position on 400 vs. 422.
 
-### Error Codes <a href="#error-objects-error-codes" id="error-objects-error-codes" class="headerlink"></a>
+### <a href="#error-objects-error-codes" id="error-objects-error-codes" class="headerlink"></a> Error Codes
 
 The `code` member of an error object contains an application-specific code
 representing the type of problem encountered. `code` is similar to `title`
@@ -334,7 +334,7 @@ JSON API defines.
 Also, notice that the third error object lacks a `detail` member (perhaps
 for security). Again, all error object members are optional.
 
-### Advanced `source` Usage <a href="#error-objects-source-usage" id="error-objects-source-usage" class="headerlink"></a>
+### <a href="#error-objects-source-usage" id="error-objects-source-usage" class="headerlink"></a> Advanced `source` Usage
 
 In the example below, the user is sending an invalid JSON API
 request, because it's missing the `data` member:
@@ -383,7 +383,7 @@ refer to). Here's how the server might respond to an invalid JSON document:
 }
 ```
 
-#### Invalid Query Parameters <a href="#error-objects-invalid-query-parameters" id="error-objects-invalid-query-parameters" class="headerlink"></a>
+#### <a href="#error-objects-invalid-query-parameters" id="error-objects-invalid-query-parameters" class="headerlink"></a> Invalid Query Parameters
 
 The `source` member can also be used to indicate that the error originated
 from a problem with a URI query parameter, like so:

--- a/extensions/bulk/index.md
+++ b/extensions/bulk/index.md
@@ -3,13 +3,13 @@ layout: page
 title: "Bulk Extension"
 ---
 
-## Status <a href="#status" id="status" class="headerlink"></a>
+## <a href="#status" id="status" class="headerlink"></a> Status
 
 **Extensions are an experimental feature** and should be considered a work
 in progress. There is no official support for extensions in the base JSON
 API specification.
 
-## Introduction <a href="#introduction" id="introduction" class="headerlink"></a>
+## <a href="#introduction" id="introduction" class="headerlink"></a> Introduction
 
 The "Bulk extension" is an [official
 extension](/extensions/#official-extensions) of the JSON API specification.
@@ -20,7 +20,7 @@ Servers and clients **MUST** negotiate support for and use of the Bulk extension
 [as described in the base specification](/format/#extending) using `bulk` as the
 name of the extension.
 
-## Bulk Operations <a href="#bulk-operations" id="bulk-operations" class="headerlink"></a>
+## <a href="#bulk-operations" id="bulk-operations" class="headerlink"></a> Bulk Operations
 
 [As mentioned in the base specification](/format/#crud), a request **MUST**
 completely succeed or fail (in a single "transaction").
@@ -29,7 +29,7 @@ Therefore, any request that involves multiple operations **MUST** only
 succeed if all operations are performed successfully. The state of the
 server **MUST NOT** be changed by a request if any individual operation fails.
 
-## Creating Multiple Resources <a href="#creating-multiple-resources" id="creating-multiple-resources" class="headerlink"></a>
+## <a href="#creating-multiple-resources" id="creating-multiple-resources" class="headerlink"></a> Creating Multiple Resources
 
 Multiple resources can be created by sending a `POST` request to a URL that
 represents a collection of resources. The request **MUST** include an array
@@ -61,7 +61,7 @@ Accept: application/vnd.api+json; ext=bulk
 ```
 
 
-## Updating Multiple Resources <a href="#updating-multiple-resources" id="updating-multiple-resources" class="headerlink"></a>
+## <a href="#updating-multiple-resources" id="updating-multiple-resources" class="headerlink"></a> Updating Multiple Resources
 
 Multiple resources can be updated by sending a `PATCH` request to a URL that
 represents a collection of resources to which they all belong. The request
@@ -92,7 +92,7 @@ Accept: application/vnd.api+json; ext=bulk
 }
 ```
 
-## Deleting Multiple Resources <a href="#deleting-multiple-resources" id="deleting-multiple-resources" class="headerlink"></a>
+## <a href="#deleting-multiple-resources" id="deleting-multiple-resources" class="headerlink"></a> Deleting Multiple Resources
 
 Multiple resources can be deleted by sending a `DELETE` request to a URL that
 represents a collection of resources to which they all belong.

--- a/extensions/index.md
+++ b/extensions/index.md
@@ -10,7 +10,7 @@ show_sidebar: true
 in progress. There is no official support for extensions in the base JSON
 API specification.
 
-## Extending JSON API <a href="#extending-json-api" id="extending-json-api" class="headerlink"></a>
+## <a href="#extending-json-api" id="extending-json-api" class="headerlink"></a> Extending JSON API
 
 JSON API can be extended in several ways:
 
@@ -24,7 +24,7 @@ JSON API can be extended in several ways:
 * A profile can be specified in the top-level `meta` object, as discussed
   below.
 
-## Extension Negotiation <a href="#extension-negotiation" id="extension-negotiation" class="headerlink"></a>
+## <a href="#extension-negotiation" id="extension-negotiation" class="headerlink"></a> Extension Negotiation
 
 The JSON API specification **MAY** be extended to support additional
 capabilities.
@@ -82,7 +82,7 @@ When the value of the `ext` or `supported-ext` media type parameter contains
 more than one extension name, the value **MUST** be surrounded with quotation
 marks (U+0022 QUOTATION MARK, """), in accordance with the HTTP specification.
 
-## Official Extensions <a href="#official-extensions" id="official-extensions" class="headerlink"></a>
+## <a href="#official-extensions" id="official-extensions" class="headerlink"></a> Official Extensions
 
 JSON API currently supports the following official extensions:
 
@@ -96,7 +96,7 @@ JSON API currently supports the following official extensions:
   [[RFC6902](http://tools.ietf.org/html/rfc6902)]. The JSON Patch extension is
   referenced with the extension name `jsonpatch`.
 
-## Custom Extensions <a href="#custom-extensions" id="custom-extensions" class="headerlink"></a>
+## <a href="#custom-extensions" id="custom-extensions" class="headerlink"></a> Custom Extensions
 
 The JSON API media type can be extended for your organization by writing your
 own custom extension. This extension should also be specified using the `ext`
@@ -106,7 +106,7 @@ It is strongly recommended that custom extensions be prefixed with a unique
 identifier for your organization to avoid namespace collision. For example,
 `my-org/embedded-resources`.
 
-## Profiles <a href="#profiles" id="profiles" class="headerlink"></a>
+## <a href="#profiles" id="profiles" class="headerlink"></a> Profiles
 
 JSON API can be extended with the profile link relation, defined in [RFC
 6906](http://tools.ietf.org/html/rfc6906). See also [this blog post by Mark

--- a/extensions/jsonpatch/index.md
+++ b/extensions/jsonpatch/index.md
@@ -3,13 +3,13 @@ layout: page
 title: "JSON Patch Extension"
 ---
 
-## Status <a href="#status" id="status" class="headerlink"></a>
+## <a href="#status" id="status" class="headerlink"></a> Status
 
 **Extensions are an experimental feature** and should be considered a work
 in progress. There is no official support for extensions in the base JSON
 API specification.
 
-## Introduction <a href="#introduction" id="introduction" class="headerlink"></a>
+## <a href="#introduction" id="introduction" class="headerlink"></a> Introduction
 
 The "JSON Patch extension" is an [official
 extension](/extensions/#official-extensions) of the JSON API specification.
@@ -24,13 +24,13 @@ Servers and clients **MUST** negotiate support for and use of the JSON Patch
 extension [as described in the base specification](/format/#extending) using
 `jsonpatch` as the name of the extension.
 
-## Patch Operations <a href="#patch-operations" id="patch-operations" class="headerlink"></a>
+## <a href="#patch-operations" id="patch-operations" class="headerlink"></a> Patch Operations
 
 Patch operations **MUST** be sent as an array to conform with the JSON
 Patch format. A server **MAY** limit the type, order, and count of
 operations allowed in this top level array.
 
-### Request URLs and Patch Paths <a href="#patch-urls" id="patch-urls" class="headerlink"></a>
+### <a href="#patch-urls" id="patch-urls" class="headerlink"></a> Request URLs and Patch Paths
 
 The request URL and each Patch operation's `path` are complementary and
 **MUST** combine to target a particular resource, collection, attribute, or
@@ -45,7 +45,7 @@ resource path relative to the root URL. This allows for general "fire hose"
 updates to any resource or relationship represented by an API. As stated
 above, a server **MAY** limit the type, order, and count of bulk operations.
 
-### Creating Resources <a href="#patch-creating" id="patch-creating" class="headerlink"></a>
+### <a href="#patch-creating" id="patch-creating" class="headerlink"></a> Creating Resources
 
 To create a resource, request an `add` operation with a `path` that points
 to the end of its corresponding resource collection (`/-`). The `value`
@@ -73,7 +73,7 @@ Accept: application/vnd.api+json; ext=jsonpatch
 ]
 ```
 
-### Updating Attributes <a href="#patch-updating-attributes" id="patch-updating-attributes" class="headerlink"></a>
+### <a href="#patch-updating-attributes" id="patch-updating-attributes" class="headerlink"></a> Updating Attributes
 
 To update an attribute, perform a `replace` operation with the attribute's
 name specified by the `path`.
@@ -91,7 +91,7 @@ Accept: application/vnd.api+json; ext=jsonpatch
 ]
 ```
 
-### Updating Relationships <a href="#patch-updating-relationships" id="patch-updating-relationships" class="headerlink"></a>
+### <a href="#patch-updating-relationships" id="patch-updating-relationships" class="headerlink"></a> Updating Relationships
 
 To update a relationship, send an appropriate Patch operation to the
 relationship's URL.
@@ -101,7 +101,7 @@ as the resource's URL or the API's root URL. As discussed above, the request
 URL and each Patch operation's `path` must be complementary and combine to
 target a particular relationship's URL.
 
-#### Updating To-One Relationships <a href="#patch-updating-to-one-relationships" id="patch-updating-to-one-relationships" class="headerlink"></a>
+#### <a href="#patch-updating-to-one-relationships" id="patch-updating-to-one-relationships" class="headerlink"></a> Updating To-One Relationships
 
 To update a to-one relationship, perform a `replace` operation with a URL
 and `path` that targets the relationship. The `value` **MUST** be a
@@ -132,7 +132,7 @@ Accept: application/vnd.api+json; ext=jsonpatch
 ]
 ```
 
-#### Updating To-Many Relationships <a href="#patch-updating-to-many-relationships" id="patch-updating-to-many-relationships" class="headerlink"></a>
+#### <a href="#patch-updating-to-many-relationships" id="patch-updating-to-many-relationships" class="headerlink"></a> Updating To-Many Relationships
 
 A server **MUST** respond to Patch operations that target a *to-many
 relationship URL* as described below.
@@ -212,7 +212,7 @@ Accept: application/vnd.api+json; ext=jsonpatch
 ]
 ```
 
-### Deleting a Resource <a href="#patch-deleting" id="patch-deleting" class="headerlink"></a>
+### <a href="#patch-deleting" id="patch-deleting" class="headerlink"></a> Deleting a Resource
 
 To delete a resource, perform a `remove` operation with a URL and `path`
 that targets the resource.
@@ -229,15 +229,15 @@ Accept: application/vnd.api+json; ext=jsonpatch
 ]
 ```
 
-### Responses <a href="#patch-responses" id="patch-responses" class="headerlink"></a>
+### <a href="#patch-responses" id="patch-responses" class="headerlink"></a> Responses
 
-#### 204 No Content <a href="#patch-responses-204" id="patch-responses-204" class="headerlink"></a>
+#### <a href="#patch-responses-204" id="patch-responses-204" class="headerlink"></a> 204 No Content
 
 A server **MUST** return a `204 No Content` status code in response to a
 successful Patch operation in which the client's current attributes remain up to
 date.
 
-#### 200 OK <a href="#patch-responses-200" id="patch-responses-200" class="headerlink"></a>
+#### <a href="#patch-responses-200" id="patch-responses-200" class="headerlink"></a> 200 OK
 
 If a server accepts an update but also changes the resource(s) in other ways
 than those specified by the request (for example, updating the `updatedAt`
@@ -313,7 +313,7 @@ Content-Type: application/vnd.api+json; ext=jsonpatch
 ]
 ```
 
-#### Errors <a href="#patch-responses-errors" id="patch-responses-errors" class="headerlink"></a>
+#### <a href="#patch-responses-errors" id="patch-responses-errors" class="headerlink"></a> Errors
 
 A server **MAY** return error objects that correspond to each operation. The
 body of the response **MUST** contain an array of JSON objects, which

--- a/faq/index.md
+++ b/faq/index.md
@@ -4,7 +4,7 @@ title: Frequently Asked Questions
 show_sidebar: true
 ---
 
-## What is the meaning of JSON API's version? <a href="#what-is-the-meaning-of-json-apis-version" id="what-is-the-meaning-of-json-apis-version" class="headerlink"></a>
+## <a href="#what-is-the-meaning-of-json-apis-version" id="what-is-the-meaning-of-json-apis-version" class="headerlink"></a> What is the meaning of JSON API's version?
 
 Now that JSON API has reached a stable version 1.0, it will always be
 backwards compatible using a _never remove, only add_ strategy.
@@ -14,7 +14,7 @@ A version is maintained in order to:
 * allow tracking of additive changes to the specification.
 * know what features a particular implementation *may potentially* support.
 
-## Why not use the HAL specification? <a href="#why-not-use-the-hal-specification" id="why-not-use-the-hal-specification" class="headerlink"></a>
+## <a href="#why-not-use-the-hal-specification" id="why-not-use-the-hal-specification" class="headerlink"></a> Why not use the HAL specification?
 
 There are several reasons:
 
@@ -42,7 +42,7 @@ It is extracted from a real-world library already used by a number of projects,
 which has informed both the request/response aspects (absent from HAL) and the
 interchange format itself.
 
-## How to discover resource possible actions? <a href="#how-to-discover-resource-possible-actions" id="how-to-discover-resource-possible-actions" class="headerlink"></a>
+## <a href="#how-to-discover-resource-possible-actions" id="how-to-discover-resource-possible-actions" class="headerlink"></a> How to discover resource possible actions?
 
 You should use the OPTIONS HTTP method to discover what can be done with a
 particular resource. The semantics of the methods returned by OPTIONS is defined
@@ -57,7 +57,7 @@ and capabilities and use the errors response to let users know. This error featu
 is still pending to be included in the standard since is still in
 [discussion](https://github.com/json-api/json-api/issues/7).
 
-## Where's PUT? <a href="#wheres-put" id="wheres-put" class="headerlink"></a>
+## <a href="#wheres-put" id="wheres-put" class="headerlink"></a> Where's PUT?
 
 Using PUT to partially update a resource (i.e. to change only some of its state)
 is not allowed by the
@@ -78,7 +78,7 @@ In the past, many APIs used PUT for partial updates because PATCH wasn’t yet
 well-supported. However, almost all clients now support PATCH, and those that
 don’t can be easily [worked around](/recommendations/#patchless-clients).
 
-## Is there a JSON Schema describing JSON API? <a href="#is-there-a-json-schema-describing-json-api" id="is-there-a-json-schema-describing-json-api" class="headerlink"></a>
+## <a href="#is-there-a-json-schema-describing-json-api" id="is-there-a-json-schema-describing-json-api" class="headerlink"></a> Is there a JSON Schema describing JSON API?
 
 Yes, you can find the JSON Schema definition at
 [http://jsonapi.org/schema](http://jsonapi.org/schema). This schema is as
@@ -89,13 +89,13 @@ positives for the sake of flexibility.
 You can find more information about the JSON Schema format at
 [http://json-schema.org](http://json-schema.org).
 
-## Why are resource collections returned as arrays instead of sets keyed by ID? <a href="#resource-collections-returned-as-arrays" id="resource-collections-returned-as-arrays" class="headerlink"></a>
+## <a href="#resource-collections-returned-as-arrays" id="resource-collections-returned-as-arrays" class="headerlink"></a> Why are resource collections returned as arrays instead of sets keyed by ID?
 
 A JSON array is naturally ordered while sets require metadata to specify order
 among members. Therefore, arrays allow for more natural sorting by default or
 specified criteria.
 
-## Why are related resources nested in an `included` object in a compound document? <a href="#why-related-resources-included-compound-document" id="why-related-resources-included-compound-document" class="headerlink"></a>
+## <a href="#why-related-resources-included-compound-document" id="why-related-resources-included-compound-document" class="headerlink"></a> Why are related resources nested in an `included` object in a compound document?
 
 Primary resources should be isolated because their order and number is often
 significant. It's necessary to separate primary and related resources by more
@@ -103,6 +103,6 @@ than type because it's possible that a primary resource may have related
 resources of the same type (e.g. the "parents" of a "person"). Nesting related
 resources in `included` prevents this possible conflict.
 
-## Does JSON API take any position on URI structure, on rules for custom endpoints, which do not fit the paradigm of GET/POST/PATCH/DELETE on the resource URI, etc.? <a href="#position-uri-structure-custom-endpoints" id="position-uri-structure-custom-endpoints" class="headerlink"></a>
+## <a href="#position-uri-structure-custom-endpoints" id="position-uri-structure-custom-endpoints" class="headerlink"></a> Does JSON API take any position on URI structure, on rules for custom endpoints, which do not fit the paradigm of GET/POST/PATCH/DELETE on the resource URI, etc.?
 
 JSON API has no requirements about URI structure, implementations are free to use whatever form they wish.

--- a/implementations/index.md
+++ b/implementations/index.md
@@ -11,9 +11,9 @@ pull request](https://github.com/json-api/json-api).
 below have not been verified for compliance, but a test suite is now being
 assembled to vet them.
 
-## Client libraries <a href="#client-libraries" id="client-libraries" class="headerlink"></a>
+## <a href="#client-libraries" id="client-libraries" class="headerlink"></a> Client libraries
 
-### JavaScript <a href="#client-libraries-javascript" id="client-libraries-javascript" class="headerlink"></a>
+### <a href="#client-libraries-javascript" id="client-libraries-javascript" class="headerlink"></a> JavaScript
 
 * [ember-data](https://github.com/emberjs/data) is one of the original exemplar implementations. There is now an [offical adapter](http://emberjs.com/blog/2015/06/18/ember-data-1-13-released.html#toc_json-api-support) to support json-api.
 * [backbone-jsonapi](https://github.com/guillaumervls/backbone-jsonapi) is a Backbone adapter for JSON API. Supports fetching Models & Collections from a JSON API source.
@@ -33,23 +33,23 @@ assembled to vet them.
 * [superagent-jsonapify](https://github.com/alex94puchades/superagent-jsonapify) A really lightweight (50 lines) JSON-API client addon for [superagent](https://github.com/visionmedia/superagent), the isomorphic ajax client.
 * [angular-jsonapi](https://github.com/jakubrohleder/angular-jsonapi) An Angular JSON API client
 
-### iOS <a href="#client-libraries-ios" id="client-libraries-ios" class="headerlink"></a>
+### <a href="#client-libraries-ios" id="client-libraries-ios" class="headerlink"></a> iOS
 
 * [jsonapi-ios](https://github.com/joshdholtz/jsonapi-ios) is a library for loading data from a JSON API datasource. Parses JSON API data into models with support for auto-linking of resources and custom model classes.
 * [Spine](https://github.com/wvteijlingen/spine) is a Swift library for working with JSON API APIs. It supports mapping to custom model classes, fetching, advanced querying, linking and persisting.
 
-### Ruby <a href="#client-libraries-ruby" id="client-libraries-ruby" class="headerlink"></a>
+### <a href="#client-libraries-ruby" id="client-libraries-ruby" class="headerlink"></a> Ruby
 
 * [jsonapi-consumer](https://github.com/jsmestad/jsonapi-consumer) a ruby library for consuming JSONAPI payloads.
 * [JsonApiClient](https://github.com/chingor13/json_api_client) attempts to give you a query building framework that is easy to understand (similar to ActiveRecord scopes)
 
-### PHP <a href="#client-libraries-php" id="client-libraries-php" class="headerlink"></a>
+### <a href="#client-libraries-php" id="client-libraries-php" class="headerlink"></a> PHP
 
 * [Art4 / json-api-client](https://github.com/Art4/json-api-client) is a library for validating and handling the response body in a simple OOP way.
 
-## Server libraries <a href="#server-libraries" id="server-libraries" class="headerlink"></a>
+## <a href="#server-libraries" id="server-libraries" class="headerlink"></a> Server libraries
 
-### PHP <a href="#server-libraries-php" id="server-libraries-php" class="headerlink"></a>
+### <a href="#server-libraries-php" id="server-libraries-php" class="headerlink"></a> PHP
 
 * [GOintegro / HATEOAS](https://github.com/gointegro/hateoas-bundle) is a library and Symfony 2 bundle that allows you to magically expose your Doctrine 2 mapped entities as resources in a HATEOAS API and supports the full spec of JSON-API for serializing and fetching.
 * [tobscure / json-api](https://github.com/tobscure/json-api)
@@ -61,7 +61,7 @@ assembled to vet them.
 * [nilportugues / symfony2-jsonapi-transformer](https://github.com/nilportugues/symfony2-jsonapi-transformer) Symfony 2 JSON API Transformer Bundle outputting valid API responses in JSON and JSON API formats.
 * [nilportugues / laravel5-jsonapi-transformer](https://github.com/nilportugues/laravel5-jsonapi-transformer) Laravel 5 JSON API Transformer Package outputting valid API responses in JSON and JSON API formats.
 
-### Node.js <a href="#server-libraries-node-js" id="server-libraries-node-js" class="headerlink"></a>
+### <a href="#server-libraries-node-js" id="server-libraries-node-js" class="headerlink"></a> Node.js
 * [Fortune.js](http://fortunejs.com) is a library that includes a [comprehensive implementation of JSON API](https://github.com/fortunejs/fortune-json-api).
 * [json-api](https://www.npmjs.org/package/json-api) turns an Express + Mongoose app into a JSON-API server.
 * [endpoints](https://github.com/endpoints) is an implementation of JSON API using [Bookshelf](http://bookshelfjs.org).
@@ -70,7 +70,7 @@ assembled to vet them.
 * [jsonapi-server](https://github.com/holidayextras/jsonapi-server) is a fully featured NodeJS sever implementation of json:api.
 * [jsonapify](https://github.com/alex94puchades/jsonapify) is an unintrusive, well-tested and easy-to-use library for the development of JSON API (or similar) APIs. It integrates nicely with Mongoose models as connect-compatible middleware. Its development is very recent though, which only means that feature requests and feedback is more than welcome!
 
-### Ruby <a href="#server-libraries-ruby" id="server-libraries-ruby" class="headerlink"></a>
+### <a href="#server-libraries-ruby" id="server-libraries-ruby" class="headerlink"></a> Ruby
 
 * [ActiveModel::Serializers](https://github.com/rails-api/active_model_serializers)
 is one of the original exemplar implementations, but is slightly out of date at
@@ -83,7 +83,7 @@ has a page describing how to emit conformant JSON.
 * [Yaks](https://github.com/plexus/yaks) Library for building hypermedia APIs, contains a JSON API output format.
 * [JSONAPI::Serializers](https://github.com/fotinakis/jsonapi-serializers) provides a pure Ruby, readonly serializer implementation.
 
-### Python <a href="#server-libraries-python" id="server-libraries-python" class="headerlink"></a>
+### <a href="#server-libraries-python" id="server-libraries-python" class="headerlink"></a> Python
 
 * [Hyp](https://github.com/kalasjocke/hyp) is a library for creating json-api responses.
 * [SQLAlchemy-JSONAPI](https://github.com/coltonprovias/sqlalchemy-jsonapi) provides JSON API serialization for SQLAlchemy models.
@@ -95,12 +95,12 @@ has a page describing how to emit conformant JSON.
 * [marshmallow-jsonapi](https://github.com/marshmallow-code/marshmallow-jsonapi) provides JSON API data formatting for any Python web framework.
 * [neoapi](https://pypi.python.org/pypi/neoapi/) serializes JSON API–compliant responses from neomodel StructuredNodes for Neo4j data
 
-### Go <a href="#server-libraries-go" id="server-libraries-go" class="headerlink"></a>
+### <a href="#server-libraries-go" id="server-libraries-go" class="headerlink"></a> Go
 
 * [api2go](https://github.com/univedo/api2go) is a small library to make it easier to provide a JSON API with your Golang project.
 * [jsonapi](https://github.com/shwoodard/jsonapi) serializes and deserializes jsonapi formatted payloads using struct tags to annotate the structs that you already have in your Golang project. [Godoc](http://godoc.org/github.com/shwoodard/jsonapi)
 
-### .NET <a href="#server-libraries-net" id="server-libraries-net" class="headerlink"></a>
+### <a href="#server-libraries-net" id="server-libraries-net" class="headerlink"></a> .NET
 
 * [JsonApiNet](https://github.com/l8nite/JsonApiNet) lets you quickly deserialize JSON API documents into C# entities. Supports compound documents, complex type mapping from attributes, attribute mapping, and more. [See the README](https://github.com/l8nite/JsonApiNet/blob/master/README.md) for full details.
 
@@ -110,30 +110,30 @@ has a page describing how to emit conformant JSON.
 
 * [Migrap.AspNet.Mvc.Jsonapi](https://github.com/migrap/Migrap.AspNet.Mvc.Jsonapi) is an ASP.NET 5 (vNext) library that allows for existing code to build JSON API responses through output formatters.
 
-### Java <a href="#server-libraries-java" id="server-libraries-java" class="headerlink"></a>
+### <a href="#server-libraries-java" id="server-libraries-java" class="headerlink"></a> Java
 
-* [katharsis](http://katharsis.io) has comprehensive coverage of standard allowing to create JSON:API compatible resources with dynamic relation based routing. 
+* [katharsis](http://katharsis.io) has comprehensive coverage of standard allowing to create JSON:API compatible resources with dynamic relation based routing.
 * [katharsis-core](https://github.com/katharsis-project/katharsis-core) is Java 8 based core library for [katharsis](http://katharsis.io) allowing to manage RESTful endpoints compliant with JSON API standard.
 * [katharsis-rs](https://github.com/katharsis-project/katharsis-rs) is adapter for [katharsis](http://katharsis.io) core module for all compatible JAX-RS based frameworks.
 * [katharsis-servlet](https://github.com/katharsis-project/katharsis-servlet) is a generic servlet/filter adapter for [katharsis](http://katharsis.io) core module. This module can be used in traditional servlet or filter based Java web applications, or even non-Servlet-API-based web applications such as Portal/Portlet, Wicket, etc.
 
-## Examples <a href="#examples" id="examples" class="headerlink"></a>
+## <a href="#examples" id="examples" class="headerlink"></a> Examples
 
 * [RestPack::Serializer provides examples](http://restpack-serializer-sample.herokuapp.com/) which demonstrate sample responses.
 * [Endpoints provides a fully working example API](http://github.com/endpoints/example/)
 
-## Related Tools <a href="#related-tools" id="related-tools" class="headerlink"></a>
+## <a href="#related-tools" id="related-tools" class="headerlink"></a> Related Tools
 
-### Ruby <a href="#related-tools-ruby" id="related-tools-ruby" class="headerlink"></a>
+### <a href="#related-tools-ruby" id="related-tools-ruby" class="headerlink"></a> Ruby
 
 * [json-patch](https://github.com/guillec/json-patch) implementation of JSON Patch (rfc6902)
 * [hana](https://github.com/tenderlove/hana) implementation of the JSON Patch and JSON pointer spec
 
-### Node.js <a href="#relted-tools-node-js" id="relted-tools-node-js" class="headerlink"></a>
+### <a href="#relted-tools-node-js" id="relted-tools-node-js" class="headerlink"></a> Node.js
 
 * [json-patch](https://www.npmjs.org/package/json-patch) implementation of JSON Patch (rfc6902)
 
-### Python <a href="#server-python" id="server-python" class="headerlink"></a>
+### <a href="#server-python" id="server-python" class="headerlink"></a> Python
 
 * [jsonpatch](https://python-json-patch.readthedocs.org) implementation of JSON Patch (rfc6902)
 * [drf-json-patch](https://drf-json-patch.readthedocs.org) integrates jsonpatch with Django REST Framework

--- a/index.md
+++ b/index.md
@@ -104,24 +104,24 @@ resources.
 
 JSON API covers creating and updating resources as well, not just responses.
 
-## MIME Types <a href="#mime-types" id="mime-types" class="headerlink"></a>
+## <a href="#mime-types" id="mime-types" class="headerlink"></a> MIME Types
 
 JSON API has been properly registered with the IANA. Its media
 type designation is [`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json).
 
-## Format documentation <a href="#format-documentation" id="format-documentation" class="headerlink"></a>
+## <a href="#format-documentation" id="format-documentation" class="headerlink"></a> Format documentation
 
 To get started with JSON API, check out [documentation for the base
 specification](/format).
 
-## Extensions <a href="#extensions" id="extensions" class="headerlink"></a>
+## <a href="#extensions" id="extensions" class="headerlink"></a> Extensions
 
 JSON API has [experimental support for extensions](/extensions).
 
 Official extensions are being developed for [Bulk](/extensions/bulk/) and
 [JSON Patch](/extensions/jsonpatch/) operations.
 
-## Update history <a href="#update-history" id="update-history" class="headerlink"></a>
+## <a href="#update-history" id="update-history" class="headerlink"></a> Update history
 
 - 2015-05-29: 1.0 final released.
 - 2015-05-21: Release candidate 4 released.

--- a/recommendations/index.md
+++ b/recommendations/index.md
@@ -8,16 +8,16 @@ This section contains recommendations for JSON API implementations. These
 recommendations are intended to establish a level of consistency in areas that
 are beyond the scope of the base JSON API specification.
 
-## Naming <a href="#naming" id="naming" class="headerlink"></a>
+## <a href="#naming" id="naming" class="headerlink"></a> Naming
 
 The allowed and recommended characters for an URL safe naming of members are defined in the format spec. To also standardize member names, the following (more restrictive) rules are recommended:
 
 - Member names **SHOULD** start and end with the characters "a-z" (U+0061 to U+007A)
 - Member names **SHOULD** contain only the characters "a-z" (U+0061 to U+007A), "0-9" (U+0030 to U+0039), and the hyphen minus (U+002D HYPHEN-MINUS, "-") as separator between multiple words.
 
-## URL Design <a href="#urls" id="urls" class="headerlink"></a>
+## <a href="#urls" id="urls" class="headerlink"></a> URL Design
 
-### Reference Document <a href="#urls-reference-document" id="urls-reference-document" class="headerlink"></a>
+### <a href="#urls-reference-document" id="urls-reference-document" class="headerlink"></a> Reference Document
 
 When determining an API's URL structure, it is helpful to consider that all of
 its resources exist in a single "reference document" in which each resource is
@@ -34,7 +34,7 @@ collections in the reference document are represented as sets because members
 must be addressable by ID, while collections are represented as arrays in
 transport documents because order is significant.
 
-### URLs for Resource Collections <a href="#urls-resource-collections" id="urls-resource-collections" class="headerlink"></a>
+### <a href="#urls-resource-collections" id="urls-resource-collections" class="headerlink"></a> URLs for Resource Collections
 
 It is recommended that the URL for a collection of resources be formed from
 the resource type.
@@ -45,7 +45,7 @@ For example, a collection of resources of type `photos` will have the URL:
 /photos
 ```
 
-### URLs for Individual Resources <a href="#urls-individual-resources" id="urls-individual-resources" class="headerlink"></a>
+### <a href="#urls-individual-resources" id="urls-individual-resources" class="headerlink"></a> URLs for Individual Resources
 
 Treat collections of resources as sets keyed by resource ID. The URL for an
 individual resource can be formed by appending the resource's ID to the
@@ -57,7 +57,7 @@ For example, a photo with an ID of `"1"` will have the URL:
 /photos/1
 ```
 
-### Relationship URLs and Related Resource URLs <a href="#urls-relationships" id="urls-relationships" class="headerlink"></a>
+### <a href="#urls-relationships" id="urls-relationships" class="headerlink"></a> Relationship URLs and Related Resource URLs
 
 As described in the base specification, there are two URLs that can be exposed
 for each relationship:
@@ -106,7 +106,7 @@ Because these URLs represent resources in relationships, they should not be
 used as `self` links for the resources themselves. Instead the recommendations
 for individual resource URLs should still apply when forming `self` links.
 
-## Filtering <a href="#filtering" id="filtering" class="headerlink"></a>
+## <a href="#filtering" id="filtering" class="headerlink"></a> Filtering
 
 The base specification is agnostic about filtering strategies supported by a
 server. The `filter` query parameter is reserved to be used as the basis for
@@ -135,7 +135,7 @@ Furthermore, multiple filters can be applied to a single request:
 GET /comments?filter[post]=1,2&filter[author]=12
 ```
 
-## Supporting Clients Lacking `PATCH` <a href="#patchless-clients" id="patchless-clients" class="headerlink"></a>
+## <a href="#patchless-clients" id="patchless-clients" class="headerlink"></a> Supporting Clients Lacking `PATCH`
 
 Some clients, like IE8, lack support for HTTP's `PATCH` method. API servers
 that wish to support these clients are recommended to treat `POST` requests as
@@ -143,14 +143,14 @@ that wish to support these clients are recommended to treat `POST` requests as
 header. This allows clients that lack `PATCH` support to have their update
 requests honored, simply by adding the header.
 
-## Formatting Date and Time Fields <a href="#date-and-time-fields" id="date-and-time-fields" class="headerlink"></a>
+## <a href="#date-and-time-fields" id="date-and-time-fields" class="headerlink"></a> Formatting Date and Time Fields
 
 Although JSON API does not specify the format of date and time fields, it is
 recommended that servers align with ISO 8601. [This W3C
 NOTE](http://www.w3.org/TR/NOTE-datetime) provides an overview of the
 recommended formats.
 
-## Asynchronous Processing <a href="#asynchronous-processing" id="asynchronous-processing" class="headerlink"></a>
+## <a href="#asynchronous-processing" id="asynchronous-processing" class="headerlink"></a> Asynchronous Processing
 
 Consider a situation when you need to create a resource and the operation takes long time to complete.
 

--- a/stylesheets/all.css
+++ b/stylesheets/all.css
@@ -85,11 +85,19 @@ body {
   color: rgba(90, 90, 90, 0.35); }
 
 h1, h2, h3, h4, h5 {
-  font-weight: 300; }
+  font-weight: 300;
+  position: relative;
+  left: -1em;
+  padding-left: 1em; }
   h1:first-child, h2:first-child, h3:first-child, h4:first-child, h5:first-child {
     margin-top: 0; }
-  h1:hover .headerlink::after, h2:hover .headerlink::after, h3:hover .headerlink::after, h4:hover .headerlink::after, h5:hover .headerlink::after {
-    content: "¶"; }
+  h1:hover .headerlink, h1 .headerlink:hover, h2:hover .headerlink, h2 .headerlink:hover, h3:hover .headerlink, h3 .headerlink:hover, h4:hover .headerlink, h4 .headerlink:hover, h5:hover .headerlink, h5 .headerlink:hover {
+    font-size: inherit; }
+    h1:hover .headerlink::after, h1 .headerlink:hover::after, h2:hover .headerlink::after, h2 .headerlink:hover::after, h3:hover .headerlink::after, h3 .headerlink:hover::after, h4:hover .headerlink::after, h4 .headerlink:hover::after, h5:hover .headerlink::after, h5 .headerlink:hover::after {
+      margin-left: -0.8em;
+      width: 0.8em;
+      position: absolute;
+      content: "¶"; }
 
 h1 {
   text-transform: uppercase; }

--- a/stylesheets/all.sass
+++ b/stylesheets/all.sass
@@ -36,12 +36,20 @@ body
 
 h1, h2, h3, h4, h5
   font-weight: 300
+  position: relative
+  left: -1em
+  padding-left: 1em
 
   &:first-child
     margin-top: 0
 
-  &:hover .headerlink::after
-    content: "¶"
+  &:hover .headerlink, .headerlink:hover
+    font-size: inherit
+    &::after
+      margin-left: -.8em
+      width: .8em
+      position: absolute
+      content: "¶"
 
 h1
   text-transform: uppercase


### PR DESCRIPTION
When the user loaded the page with an anchor already selected (from the URI hash), it was the case that the browser often jumped the user to below the header, causing the section heading to be off-screen. This fixes that, by putting all the `<a>`s before the header text, and updating the CSS appropriately.
