### PR TITLE
Spacing bugfix

### DIFF
--- a/stylesheets/all.css
+++ b/stylesheets/all.css
@@ -209,12 +209,14 @@ header {
     height: 130px;
     margin: 0;
     padding: 0;
+    left: 0;
     background: url("../images/jsonapi.png") no-repeat center;
     background-size: contain; }
   header h2 {
     text-align: center;
     margin: 14px 0 40px 0;
     padding: 0;
+    left: 0;
     font-size: 124%;
     font-weight: bold;
     text-transform: uppercase; }

--- a/stylesheets/all.sass
+++ b/stylesheets/all.sass
@@ -160,6 +160,7 @@ header
     height: 130px
     margin: 0
     padding: 0
+    left: 0
     background: url('../images/jsonapi.png') no-repeat center
     background-size: contain
 
@@ -167,6 +168,7 @@ header
     text-align: center
     margin: 14px 0 40px 0
     padding: 0
+    left: 0
     font-size: 124%
     font-weight: bold
     text-transform: uppercase


### PR DESCRIPTION
A small bug fix for the style changes in #888, which left the homepage
headers 1em off center (because they had their padding set to 0 without
the -left adjustment zeroed out). Whoops!
