### PR TITLE
Allow meta in linkage

### DIFF
--- a/schema
+++ b/schema
@@ -264,6 +264,9 @@
         },
         "id": {
           "type": "string"
+        },
+        "meta": {
+          "$ref": "#/definitions/meta"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
The [docs](http://jsonapi.org/format/#document-resource-identifier-objects) indicate that it is valid for linked resources to contain a meta object; however, this is missing from the schema.
