### PR TITLE
JSON Schema bug fix: empty linkage cannot be represented by an object

### DIFF
--- a/schema
+++ b/schema
@@ -247,9 +247,7 @@
     },
     "empty": {
       "description": "Describes an empty to-one relationship.",
-      "type": ["object", "null"],
-      "properties": {},
-      "additionalProperties": false
+      "type": "null"
     },
     "linkage": {
       "description": "The \"type\" and \"id\" to non-empty members.",


### PR DESCRIPTION
(Even one with no properties.) It must be null.
