### PR TITLE
Replace "it's" with "its" in two spots

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -9,7 +9,7 @@
       Below, we're either dealing with a generic page or a page from the
       specification collection. Generic pages have a title, so we identify
       them that way. For specification pages, we build the title dynamically to
-      take into account the version number and it's relationship to the latest version.
+      take into account the version number and its relationship to the latest version.
     {% endcomment %}
 
     {% if page.title %}

--- a/stylesheets/all.sass
+++ b/stylesheets/all.sass
@@ -294,7 +294,7 @@ footer
 // Push the content to the right, except on small viewports
 // The padding-left: calc(...) functions to grow the gutter gradually by 25px
 // as the window grows. If this isn't supported, it's ok; the gutter width will
-// just jump to it's final size at the next media query.
+// just jump to its final size at the next media query.
 @media screen and (min-width: $page-width + ($page-padding * 2) - 59px)
   .sidebar + .content
     margin-left: $sidebar-width + 15px


### PR DESCRIPTION
Just a quick fix to replace "it's" with "its" in two spots.

(I know I've submitted two minor fixes, but that's because the rest is great!)
