### PR TITLE
Clarify sparse fieldset restrictions

### DIFF
--- a/_format/1.0/index.md
+++ b/_format/1.0/index.md
@@ -991,8 +991,9 @@ response on a per-type basis by including a `fields[TYPE]` parameter.
 The value of the `fields` parameter **MUST** be a comma-separated (U+002C
 COMMA, ",") list that refers to the name(s) of the fields to be returned.
 
-If a client requests a restricted set of [fields], an endpoint **MUST NOT**
-include additional [fields] in the response.
+If a client requests a restricted set of [fields] for a given resource type,
+an endpoint **MUST NOT** include additional [fields] in resource objects of
+that type in its response.
 
 ```http
 GET /articles?include=author&fields[articles]=title,body&fields[people]=name HTTP/1.1

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -991,8 +991,9 @@ response on a per-type basis by including a `fields[TYPE]` parameter.
 The value of the `fields` parameter **MUST** be a comma-separated (U+002C
 COMMA, ",") list that refers to the name(s) of the fields to be returned.
 
-If a client requests a restricted set of [fields], an endpoint **MUST NOT**
-include additional [fields] in the response.
+If a client requests a restricted set of [fields] for a given resource type,
+an endpoint **MUST NOT** include additional [fields] in resource objects of
+that type in its response.
 
 ```http
 GET /articles?include=author&fields[articles]=title,body&fields[people]=name HTTP/1.1


### PR DESCRIPTION
The requirement about not including extra fields is _on a per type basis_.

This clarification inspired by http://discuss.jsonapi.org/t/clarification-on-the-sparse-fieldset-response/221
