### PR TITLE
Support `"href"` in resource identifier objects

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -362,8 +362,14 @@ resource.
 
 A "resource identifier object" **MUST** contain `type` and `id` members.
 
-A "resource identifier object" **MAY** also include a `meta` member, whose value is a [meta] object that
-contains non-standard meta-information.
+A "resource identifier object" **MAY** also include the following members:
+
+* `href`: a URI that, when derefenced, retuns a JSON API resource object with
+  the same `type` and `id` as in the resource identifier object. If the
+  returned resource object contains a `"self"` link, that link's URI **SHOULD**
+  match the URI provided in this key.
+
+* `meta`: a [meta] object that contains non-standard meta-information.
 
 ### <a href="#document-compound-documents" id="document-compound-documents" class="headerlink"></a> Compound Documents
 

--- a/_format/1.1/normative-statements.json
+++ b/_format/1.1/normative-statements.json
@@ -71,6 +71,8 @@ layout: null
             { "id": "resource-link-response", "type": "normative-statements" },
             { "id": "resource-identifier-required-members", "type": "normative-statements" },
             { "id": "resource-identifier-optional-member", "type": "normative-statements" },
+            { "id": "resource-identifier-optional-member-href", "type": "normative-statements" },
+            { "id": "resource-identifier-optional-member-href-self-match", "type": "normative-statements" },
             { "id": "compound-documents-allow", "type": "normative-statements" },
             { "id": "compound-documents-top-level-included", "type": "normative-statements" },
             { "id": "compound-documents-full-linkage", "type": "normative-statements" },
@@ -748,6 +750,32 @@ layout: null
       "attributes": {
         "level": "MAY",
         "description": "A \"resource identifier object\" **MAY** also include a meta member, whose value is a meta object that contains non-standard meta-information."
+      },
+      "relationships": {
+        "section": {
+          "data": { "id": "document-structure", "type": "sections" }
+        }
+      }
+    },
+    {
+      "id": "resource-identifier-optional-member-href",
+      "type": "normative-statements",
+      "attributes": {
+        "level": "MAY",
+        "description": "A \"resource identifier object\" **MAY** also include an `href` member whose value is a URI that, when derefenced, retuns a JSON API resource object with the same `type` and `id` as in the resource identifier object."
+      },
+      "relationships": {
+        "section": {
+          "data": { "id": "document-structure", "type": "sections" }
+        }
+      }
+    },
+    {
+      "id": "resource-identifier-optional-member-href-self-match",
+      "type": "normative-statements",
+      "attributes": {
+        "level": "SHOULD",
+        "description": "If the returned resource object contains a `\"self\"` link, that link's URI **SHOULD** match the URI provided in the resource identifier object's `\"href\"`."
       },
       "relationships": {
         "section": {


### PR DESCRIPTION
It is sometimes useful for a resource identifier object that points to a resource that isn't included in the document to contain the URI of that resource. That way, the client can request it without having to ask for the whole `"related"` collection, and without the server needing to support the related endpoint.

This need has come up repeatedly on the discourse forum, and is also the issue in #477.

Here, I'm suggesting we address this use case by adding an `"href"` key to resource identifier objects. I prefer this approach over, say, adding a `"links"` key to resource identifier objects, because it stresses the conceptual similarity between link and resource identifier objects (without going as far as I propose in #913). By contrast, adding a `"links"` key would suggest a similarity between resource objects and resource identifier objects, which are conceptually very distinct and are (if anything) already too easy to confuse.
