### PR TITLE
Standardize code block syntax highlighting

### DIFF
--- a/_format/1.0/index.md
+++ b/_format/1.0/index.md
@@ -337,7 +337,7 @@ related to the resource.
 If present, this links object **MAY** contain a `self` [link][links] that
 identifies the resource represented by the resource object.
 
-```json
+```javascript
 // ...
 {
   "type": "articles",
@@ -388,7 +388,7 @@ objects][resource identifier object]) or to each other.
 
 A complete example document with multiple included relationships:
 
-```json
+```javascript
 {
   "data": [{
     "type": "articles",
@@ -516,7 +516,7 @@ either:
 
 The following `self` link is simply a URL:
 
-```json
+```javascript
 "links": {
   "self": "http://example.com/posts",
 }
@@ -525,7 +525,7 @@ The following `self` link is simply a URL:
 The following `related` link includes a URL as well as meta-information
 about a related resource collection:
 
-```json
+```javascript
 "links": {
   "related": {
     "href": "http://example.com/articles/1/comments",
@@ -550,7 +550,7 @@ contain a `version` member whose value is a string indicating the highest JSON
 API version supported. This object **MAY** also contain a `meta` member, whose
 value is a [meta] object that contains non-standard meta-information.
 
-```json
+```javascript
 {
   "jsonapi": {
     "version": "1.0"

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -337,7 +337,7 @@ related to the resource.
 If present, this links object **MAY** contain a `self` [link][links] that
 identifies the resource represented by the resource object.
 
-```json
+```javascript
 // ...
 {
   "type": "articles",
@@ -388,7 +388,7 @@ objects][resource identifier object]) or to each other.
 
 A complete example document with multiple included relationships:
 
-```json
+```javascript
 {
   "data": [{
     "type": "articles",
@@ -516,7 +516,7 @@ either:
 
 The following `self` link is simply a URL:
 
-```json
+```javascript
 "links": {
   "self": "http://example.com/posts",
 }
@@ -525,7 +525,7 @@ The following `self` link is simply a URL:
 The following `related` link includes a URL as well as meta-information
 about a related resource collection:
 
-```json
+```javascript
 "links": {
   "related": {
     "href": "http://example.com/articles/1/comments",
@@ -550,7 +550,7 @@ contain a `version` member whose value is a string indicating the highest JSON
 API version supported. This object **MAY** also contain a `meta` member, whose
 value is a [meta] object that contains non-standard meta-information.
 
-```json
+```javascript
 {
   "jsonapi": {
     "version": "1.0"


### PR DESCRIPTION
#### What's this PR do?

Switches code blocks on the Specification page from `json` to `javascript` to improve the syntax highlighting.
#### Background context

This is a follow-up to PR #702 and should replace it. The discussion in that PR ended with the consensus to switch the code blocks to `javascript`, rather than modifying the content to appease the JSON syntax highlighter.

Many of the examples are partial JSON data structures or contain JS-style comments. The JSON syntax highlighter does not handle them very well, often not applying any highlighting at all. The JS highlighter does a better job with these code blocks.

Not all of the code blocks need to be marked as JS; some of them are perfectly valid JSON. It's my opinion that it's best to be consistent so that future contributors don't need to guess at which syntax highlighter to use, so I've marked them all as JS.
