### PR TITLE
Allow null data

### DIFF
--- a/schema
+++ b/schema
@@ -111,6 +111,10 @@
             "$ref": "#/definitions/resource"
           },
           "uniqueItems": true
+        },
+        {
+          "description": "null if the request is one that might correspond to a single resource, but doesn't currently.",
+          "type": "null"
         }
       ]
     },


### PR DESCRIPTION
This was brought to my attention in elliotttf/jsonapi-validator#9. It appears that the schema is not allowing data to be `null`.

Per the spec:

> A server **MUST** respond to a successful request to fetch an individual resource with a resource object or `null` provided as the response document's primary data.
> 
> `null` is only an appropriate response when the requested URL is one that might correspond to a single resource, but doesn't currently.

It's a bit of a weird case since the validity of `null` is entirely conditional – which I don't think JSON schema really accounts for – but I thought I'd raise this anyway for discussion. I don't know if this will have further implications for elements that use `data` references.
