### PR TITLE
Associate "relationship object" with everything else

### DIFF
--- a/_format/1.0/index.md
+++ b/_format/1.0/index.md
@@ -240,13 +240,14 @@ alongside other information to be represented in a resource object, these keys
 #### <a href="#document-resource-object-relationships" id="document-resource-object-relationships" class="headerlink"></a> Relationships
 
 The value of the `relationships` key **MUST** be an object (a "relationships
-object"). Members of the relationships object ("relationships") represent
-references from the [resource object][resource objects] in which it's defined to other resource
-objects.
+object"). Members of the relationships object represent "relationships", i.e.,
+references from the [resource object][resource objects] in which they are defined
+to other resource objects.
 
 Relationships may be to-one or to-many.
 
-A "relationship object" **MUST** contain at least one of the following:
+Each relationship **MUST** be represented by an object (a "relationship object")
+containing at least one of the following:
 
 * `links`: a [links object][links] containing at least one of the following:
   * `self`: a link for the relationship itself (a "relationship link"). This
@@ -268,7 +269,7 @@ A relationship object that represents a to-many relationship **MAY** also contai
 
 #### <a href="#document-resource-object-related-resource-links" id="document-resource-object-related-resource-links" class="headerlink"></a> Related Resource Links
 
-A "related resource link" provides access to [resource objects] [linked][links]
+A "related resource link" provides access to [resource objects][] [linked][links]
 in a [relationship][relationships]. When fetched, the related resource object(s)
 are returned as the response's primary data.
 

--- a/_format/1.0/normative-statements.json
+++ b/_format/1.0/normative-statements.json
@@ -643,7 +643,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "A \"relationship object\" **MUST** contain at least one of the following:]\\n\\n- `links`: a links object containing at least one of the following:\\n  - `self`: a link for the relationship itself (a \"relationship link\"). This link allows the client to directly manipulate the relationship. For example, it would allow a client to remove an author from an article without deleting the people resource itself.\\n  - `related`: a related resource link\\n- `data`: resource linkage\\n- `meta`: a meta object that contains non-standard meta-information about the relationship."
+        "description": "Each relationship **MUST** be represented by an object (a \"relationship object\") containing at least one of the following:\\n\\n- `links`: a links object containing at least one of the following:\\n  - `self`: a link for the relationship itself (a \"relationship link\"). This link allows the client to directly manipulate the relationship. For example, it would allow a client to remove an author from an article without deleting the people resource itself.\\n  - `related`: a related resource link\\n- `data`: resource linkage\\n- `meta`: a meta object that contains non-standard meta-information about the relationship."
       },
       "relationships": {
         "section": {

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -240,13 +240,14 @@ alongside other information to be represented in a resource object, these keys
 #### <a href="#document-resource-object-relationships" id="document-resource-object-relationships" class="headerlink"></a> Relationships
 
 The value of the `relationships` key **MUST** be an object (a "relationships
-object"). Members of the relationships object ("relationships") represent
-references from the [resource object][resource objects] in which it's defined to other resource
-objects.
+object"). Members of the relationships object represent "relationships", i.e.,
+references from the [resource object][resource objects] in which they are defined
+to other resource objects.
 
 Relationships may be to-one or to-many.
 
-A "relationship object" **MUST** contain at least one of the following:
+Each relationship **MUST** be represented by an object (a "relationship object")
+containing at least one of the following:
 
 * `links`: a [links object][links] containing at least one of the following:
   * `self`: a link for the relationship itself (a "relationship link"). This
@@ -268,7 +269,7 @@ A relationship object that represents a to-many relationship **MAY** also contai
 
 #### <a href="#document-resource-object-related-resource-links" id="document-resource-object-related-resource-links" class="headerlink"></a> Related Resource Links
 
-A "related resource link" provides access to [resource objects] [linked][links]
+A "related resource link" provides access to [resource objects][] [linked][links]
 in a [relationship][relationships]. When fetched, the related resource object(s)
 are returned as the response's primary data.
 

--- a/_format/1.1/normative-statements.json
+++ b/_format/1.1/normative-statements.json
@@ -643,7 +643,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "A \"relationship object\" **MUST** contain at least one of the following:]\\n\\n- `links`: a links object containing at least one of the following:\\n  - `self`: a link for the relationship itself (a \"relationship link\"). This link allows the client to directly manipulate the relationship. For example, it would allow a client to remove an author from an article without deleting the people resource itself.\\n  - `related`: a related resource link\\n- `data`: resource linkage\\n- `meta`: a meta object that contains non-standard meta-information about the relationship."
+        "description": "Each relationship **MUST** be represented by an object (a \"relationship object\") containing at least one of the following:\\n\\n- `links`: a links object containing at least one of the following:\\n  - `self`: a link for the relationship itself (a \"relationship link\"). This link allows the client to directly manipulate the relationship. For example, it would allow a client to remove an author from an article without deleting the people resource itself.\\n  - `related`: a related resource link\\n- `data`: resource linkage\\n- `meta`: a meta object that contains non-standard meta-information about the relationship."
       },
       "relationships": {
         "section": {


### PR DESCRIPTION
- Formally connects _relationship objects_ to relationships and, by extension, to relationships objects.
  
  The current language effectively doesn't specify what can go inside relationships objects.
  
  Also, clearly stating the parity between "each relationship" and "an object" hopefully helps emphasize the fact that the section is discussing two different concepts. The distinction between relationships objects and relationship objects is too easy to overlook at first.
- Edits the sentence that defines members of a relationships object as "relationships". Rather, the members only _represent_ relationships.
- Fixes a broken link nearby.
