### PR TITLE
Make the exception to the full linkage requirement more visible

### DIFF
--- a/_format/1.0/index.md
+++ b/_format/1.0/index.md
@@ -378,9 +378,10 @@ Compound documents require "full linkage", meaning that every included
 resource **MUST** be identified by at least one [resource identifier object]
 in the same document. These resource identifier objects could either be
 primary data or represent resource linkage contained within primary or
-included resources. The only exception to the full linkage requirement is
-when relationship fields that would otherwise contain linkage data are
-excluded via [sparse fieldsets](#fetching-sparse-fieldsets).
+included resources.
+
+The only exception to the full linkage requirement is when relationship fields
+that would otherwise contain linkage data are excluded via [sparse fieldsets](#fetching-sparse-fieldsets).
 
 > Note: Full linkage ensures that included resources are related to either
 the primary data (which could be [resource objects] or [resource identifier
@@ -949,10 +950,11 @@ GET /articles/1?include=comments.author HTTP/1.1
 Accept: application/vnd.api+json
 ```
 
-> Note: Because [compound documents][compound document] require full linkage,
-intermediate resources in a multi-part path must be returned along with the leaf
-nodes. For example, a response to a request for `comments.author` should
-include `comments` as well as the `author` of each of those `comments`.
+> Note: Because [compound documents][compound document] require full linkage
+(except when relationship linkage is excluded by sparse fieldsets), intermediate
+resources in a multi-part path must be returned along with the leaf nodes. For
+example, a response to a request for `comments.author` should include `comments`
+as well as the `author` of each of those `comments`.
 
 > Note: A server may choose to expose a deeply nested relationship such as
 `comments.author` as a direct relationship with an alias such as

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -378,9 +378,10 @@ Compound documents require "full linkage", meaning that every included
 resource **MUST** be identified by at least one [resource identifier object]
 in the same document. These resource identifier objects could either be
 primary data or represent resource linkage contained within primary or
-included resources. The only exception to the full linkage requirement is
-when relationship fields that would otherwise contain linkage data are
-excluded via [sparse fieldsets](#fetching-sparse-fieldsets).
+included resources.
+
+The only exception to the full linkage requirement is when relationship fields
+that would otherwise contain linkage data are excluded via [sparse fieldsets](#fetching-sparse-fieldsets).
 
 > Note: Full linkage ensures that included resources are related to either
 the primary data (which could be [resource objects] or [resource identifier
@@ -949,10 +950,11 @@ GET /articles/1?include=comments.author HTTP/1.1
 Accept: application/vnd.api+json
 ```
 
-> Note: Because [compound documents][compound document] require full linkage,
-intermediate resources in a multi-part path must be returned along with the leaf
-nodes. For example, a response to a request for `comments.author` should
-include `comments` as well as the `author` of each of those `comments`.
+> Note: Because [compound documents][compound document] require full linkage
+(except when relationship linkage is excluded by sparse fieldsets), intermediate
+resources in a multi-part path must be returned along with the leaf nodes. For
+example, a response to a request for `comments.author` should include `comments`
+as well as the `author` of each of those `comments`.
 
 > Note: A server may choose to expose a deeply nested relationship such as
 `comments.author` as a direct relationship with an alias such as


### PR DESCRIPTION
Make it its own paragraph in the compound documents section and allude to it in a relevant note.

This is meant to clear up the confusion [here](http://discuss.jsonapi.org/t/introducing-ponapi-a-perl-implementation-of-json-api/268/4).
