### PR TITLE
Suggested structural change and fix to meet schema

### DIFF
--- a/schema
+++ b/schema
@@ -206,30 +206,36 @@
       "type": "object",
       "patternProperties": {
         "^\\w[-\\w_]*$": {
-          "properties": {
-            "links": {
-              "$ref": "#/definitions/links"
-            },
-            "data": {
-              "description": "Member, whose value represents \"resource linkage\".",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/relationshipToOne"
-                },
-                {
-                  "$ref": "#/definitions/relationshipToMany"
-                }
-              ]
-            },
-            "meta": {
-              "$ref": "#/definitions/meta"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "#/definitions/relationship"
         }
       },
       "additionalProperties": false
     },
+
+    "relationship": {
+      "type": "object",
+      "properties": {
+        "links": {
+          "$ref": "#/definitions/links"
+        },
+        "data": {
+          "description": "Member, whose value represents \"resource linkage\".",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/relationshipToOne"
+            },
+            {
+              "$ref": "#/definitions/relationshipToMany"
+            }
+          ]
+        },
+        "meta": {
+          "$ref": "#/definitions/meta"
+        }
+      },
+      "additionalProperties": false
+    },
+
     "relationshipToOne": {
       "description": "References to other resource objects in a to-one (\"relationship\"). Relationships can be specified by including a member in a resource's links object.",
       "anyOf": [


### PR DESCRIPTION
Moved "relationship" out of "relationships" into its own definition, added missing "type":"object" requirement.

**Previously:**
1. There was no (good) way to reference the "relationship object" definition.
2. The schema did not check that "relationship object" was actually an object.
