### PR TITLE
Upgrade deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,12 +3,12 @@
 source 'http://rubygems.org'
 
 gem "rake", "~> 10.0"
-gem "jekyll", "~> 2.4.0"
+gem "jekyll", "~> 3.0.0"
 gem "redcarpet", "~> 3.3"
 gem "rb-fsevent", "~> 0.9"
 gem "compass", "~> 1.0"
 gem "sass", "~> 3.4"
 gem "launchy", "~> 2.3"
 gem "redcard", "~> 1.0"
-gem "jekyll-redirect-from", "~> 0.8.0"
+gem "jekyll-redirect-from", "~> 0.9.1"
 gem "pygments.rb", "~> 0.6.3"

--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,7 @@ defaults:
       is_spec_page: true
 
 latest_version: 1.0
-
+excerpt_separator: ""
 
 # `safe `must be set false for jekyll-redirect-from
 # to run in development. (Github Pages will override


### PR DESCRIPTION
So, GitHub upgraded to Jekyll 3: https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0

But we don't build properly with it. I've been getting emails but only now had the chance to look into it.

This doesn't yet _work_ but it at least gets us back with what GitHub should be actually using. I couldn't figure out why it doesn't work, so I filed https://github.com/jekyll/jekyll/issues/4564. That should block this PR from landing.
