### PR TITLE
Add jsonapi_for_rails to implementations

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -84,6 +84,8 @@ assembled to vet them.
 
 ### <a href="#server-libraries-ruby" id="server-libraries-ruby" class="headerlink"></a> Ruby
 
+* [Jsonapi-for-rails](https://github.com/doga/jsonapi_for_rails)
+empowers your JSONAPI compliant [Rails](http://rubyonrails.org/) APIs. Implement your APIs with very little coding.
 * [ActiveModel::Serializers](https://github.com/rails-api/active_model_serializers)
 is one of the original exemplar implementations, but is slightly out of date at
 the moment.


### PR DESCRIPTION
Hello to the JSON API team,

JSON API is a very useful specification in real-world settings, and I plan to use it production, so congratulations.

I have added [jsonapi_for_rails](https://github.com/doga/jsonapi_for_rails) to your [list of implementations](http://jsonapi.org/implementations/#server-libraries-ruby), if you are kind enough to pull that in. I am the author, by the way.

Regards.
