### PR TITLE
Adjust so that description of paths goes along with accompanying note

### DIFF
--- a/_format/1.0/index.md
+++ b/_format/1.0/index.md
@@ -926,12 +926,12 @@ If an endpoint supports the `include` parameter and a client supplies it,
 the server **MUST NOT** include unrequested [resource objects] in the `included`
 section of the [compound document].
 
+If a server is unable to identify a relationship path or does not support
+inclusion of resources from a path, it **MUST** respond with 400 Bad Request.
+
 The value of the `include` parameter **MUST** be a comma-separated (U+002C
 COMMA, ",") list of relationship paths. A relationship path is a dot-separated
 (U+002E FULL-STOP, ".") list of [relationship][relationships] names.
-
-If a server is unable to identify a relationship path or does not support
-inclusion of resources from a path, it **MUST** respond with 400 Bad Request.
 
 > Note: For example, a relationship path could be `comments.author`, where
 `comments` is a relationship listed under a `articles` [resource object][resource objects], and

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -926,12 +926,12 @@ If an endpoint supports the `include` parameter and a client supplies it,
 the server **MUST NOT** include unrequested [resource objects] in the `included`
 section of the [compound document].
 
+If a server is unable to identify a relationship path or does not support
+inclusion of resources from a path, it **MUST** respond with 400 Bad Request.
+
 The value of the `include` parameter **MUST** be a comma-separated (U+002C
 COMMA, ",") list of relationship paths. A relationship path is a dot-separated
 (U+002E FULL-STOP, ".") list of [relationship][relationships] names.
-
-If a server is unable to identify a relationship path or does not support
-inclusion of resources from a path, it **MUST** respond with 400 Bad Request.
 
 > Note: For example, a relationship path could be `comments.author`, where
 `comments` is a relationship listed under a `articles` [resource object][resource objects], and


### PR DESCRIPTION
This was really confusing to me when I read it, but then I realized that the note seems to go with the description of formatting `include` parameters, not with the item about identifying a relationship path.
