### PR TITLE
Added jsonapi-converter link to the list of client libraries

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -51,6 +51,10 @@ assembled to vet them.
 
 * [PONAPI::Client](https://metacpan.org/pod/PONAPI::Client) is a simple/extensible JSON API v1.0 client.
 
+### <a href="#client-libraries-java" id="client-libraries-java" class="headerlink"></a> Java
+
+* [jsonapi-converter](https://github.com/jasminb/jsonapi-converter) is a Java JSON API v1.0 client. Besides providing means for serialisation/deserialisation, client comes with Retrofit plugin.
+
 ## <a href="#server-libraries" id="server-libraries" class="headerlink"></a> Server libraries
 
 ### <a href="#server-libraries-php" id="server-libraries-php" class="headerlink"></a> PHP


### PR DESCRIPTION
This PR adds link to the Java client library that I created recently.

Following is the list of futures:
- Serialisation/deserialisation using annotated Java classes
- Retrofit plugin
- Relationship resolution using pluggable resolves (global or per type)

Library uses jackson for JSON handling.

More details: https://github.com/jasminb/jsonapi-converter.
