### PR TITLE
Remove redundant gem name in the server libraries list

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -103,7 +103,7 @@ has a page describing how to emit conformant JSON.
 * [JSONAPI::Serializers](https://github.com/fotinakis/jsonapi-serializers) provides a pure Ruby, readonly serializer implementation.
 * [Roar](https://github.com/apotonick/roar) Renders and parses represenations of Ruby objects
 * [Jbuilder::JsonAPI](https://github.com/vladfaust/jbuilder-json_api) Simple & lightweight extension for Jbuilder
-* [JSONAPI::Utils](https://github.com/b2beauty/jsonapi-utils) `JSONAPI::Utils` works on top of the awesome `jsonapi-resources` gem bringing to controllers a Rails way to render JSON API-compliant responses.
+* [JSONAPI::Utils](https://github.com/b2beauty/jsonapi-utils) works on top of the awesome [JSONAPI::Resources](https://github.com/cerebris/jsonapi-resources) gem bringing to controllers a Rails way to render JSON API-compliant responses.
 
 ### <a href="#server-libraries-python" id="server-libraries-python" class="headerlink"></a> Python
 


### PR DESCRIPTION
Just removed a redundant gem name at the beginning of `JSONAPI::Utils`' description and linked the `JSONAPI::Resources` gem.

Sorry, I guess now it's well formatted :-)
