### PR TITLE
Fix footer Social & License links

### DIFF
--- a/stylesheets/all.css
+++ b/stylesheets/all.css
@@ -277,6 +277,9 @@ footer {
   footer span {
     display: inline-block;
     vertical-align: middle; }
+  footer .license a {
+    display: block;
+    padding: 0.75em; }
   footer .social-links {
     width: 9em;
     position: relative;

--- a/stylesheets/all.css
+++ b/stylesheets/all.css
@@ -285,7 +285,8 @@ footer {
       width: 0; }
     footer .social-links i {
       width: 1em;
-      padding: 0.75em; }
+      padding: 0.75em;
+      display: inline-block; }
 
 /** Content */
 .site-wrapper {

--- a/stylesheets/all.sass
+++ b/stylesheets/all.sass
@@ -253,6 +253,11 @@ footer
     display: inline-block
     vertical-align: middle
 
+  .license
+    a
+      display: block
+      padding: .75em
+
   .social-links
     @extend %distribute-children
     width: 9em

--- a/stylesheets/all.sass
+++ b/stylesheets/all.sass
@@ -267,7 +267,7 @@ footer
     i
       width: 1em
       padding: .75em
-
+      display: inline-block
 
 /** Content */
 


### PR DESCRIPTION
The clickable area for the links in the footer is slightly to small and does not extend the entire child image/icon.

This PR aims to fix that 
