### PR TITLE
Bring GH pages parity to local config (Jekyll 3)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,27 @@
-# If you have OpenSSL installed, we recommend updating
-# the following line to use "https"
-source 'http://rubygems.org'
+source "https://rubygems.org"
+
+# http://jekyllrb.com/docs/github-pages/
+require 'json'
+require 'open-uri'
+versions =
+  begin
+    versions = JSON.parse(open('https://pages.github.com/versions.json').read)
+    unless $skip_print_versions == true
+      require 'pp'
+      STDERR.puts 'Gem versions are:'
+      pp versions
+      $skip_print_versions = true
+    end
+    versions
+  rescue SocketError
+    { 'github-pages' => 52 }
+  end
+
+gem 'github-pages', versions['github-pages']
 
 gem "rake", "~> 10.0"
-gem "jekyll", "~> 3.0.0"
-gem "redcarpet", "~> 3.3"
 gem "rb-fsevent", "~> 0.9"
 gem "compass", "~> 1.0"
 gem "sass", "~> 3.4"
 gem "launchy", "~> 2.3"
 gem "redcard", "~> 1.0"
-gem "jekyll-redirect-from", "~> 0.9.1"
-gem "pygments.rb", "~> 0.6.3"

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,44 @@
 url: http://jsonapi.org
-
-lsi: false
 source: .
 destination: ./public
+
+# github pages we cannot customize
+lsi: false
+whitelist:
+  - jekyll-coffeescript
+  - jekyll-gist
+  - jekyll-paginate
+  - jekyll-redirect-from
+  - jekyll-mentions
+  - jekyll-sitemap
+  - jekyll-feed
+  - jekyll-seo-tag
+  - jekyll-gist
+  - jemoji
+incremental: false
+highlighter: rouge
+gist:
+  noscript: false
+# `safe `must be set false for jekyll-redirect-from
+# to run in development. (Github Pages will override
+# `safe` to be true on deploy, but it makes an
+# exception for jekyll-redirect from.)
+safe: false
+# customize github pages
+quiet: false
+kramdown:
+  input: GFM
+  hard_wrap: false
+  template: '' # cannot customize
+  math_engine: mathjax # cannot customize
+  syntax_highligher: rouge # cannot customize
+jailed: false
+gems:
+  - jekyll-redirect-from
+markdown: redcarpet
+redcarpet:
+  extensions: ["tables"]
+
 exclude:
   - Rakefile
   - README.md
@@ -12,10 +48,6 @@ exclude:
   - .gitignore
   - ./public
   - ./stylesheets/*.scss
-markdown: redcarpet
-redcarpet:
-  extensions: ["tables"]
-highlighter: pygments
 port: 9876
 
 collections:
@@ -33,14 +65,6 @@ defaults:
 
 latest_version: 1.0
 excerpt_separator: ""
-
-# `safe `must be set false for jekyll-redirect-from
-# to run in development. (Github Pages will override
-# `safe` to be true on deploy, but it makes an
-# exception for jekyll-redirect from.)
-safe: false
-gems:
-  - jekyll-redirect-from
 
 navigation:
 - title: JSON API


### PR DESCRIPTION
Follows https://github.com/json-api/json-api/pull/988

Fixes needed for jekyll 3
- https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0
- https://jekyllrb.com/docs/upgrading/2-to-3/

re: parity, see:
- https://github.com/github/pages-gem/pull/209/files
  `gem 'github-pages', group: :jekyll_plugins`
  - https://help.github.com/articles/configuring-jekyll/ via
    https://help.github.com/articles/using-jekyll-as-a-static-site-generator-with-github-pages/
