### PR TITLE
Clarify full linkage.

### DIFF
--- a/_format/1.0/index.md
+++ b/_format/1.0/index.md
@@ -375,17 +375,19 @@ In a compound document, all included resources **MUST** be represented as an
 array of [resource objects] in a top-level `included` member.
 
 Compound documents require "full linkage", meaning that every included
-resource **MUST** be identified by at least one [resource identifier object]
-in the same document. These resource identifier objects could either be
-primary data or represent resource linkage contained within primary or
-included resources.
+resource **MUST** be identified by at least one [resource identifier object] in
+the same document, representing resource linkage contained within an
+*accessible* resource object. A resource object is *accessible* if it is either
+primary data or it is identified by at least one [resource identifier object] in
+the same document, representing resource linkage contained within an
+*accessible* resource object.
 
 The only exception to the full linkage requirement is when relationship fields
 that would otherwise contain linkage data are excluded via [sparse fieldsets](#fetching-sparse-fieldsets).
 
-> Note: Full linkage ensures that included resources are related to either
-the primary data (which could be [resource objects] or [resource identifier
-objects][resource identifier object]) or to each other.
+> Note: Full linkage ensures that included resources are related (directly or
+indirectly) to the primary data (which could be [resource objects] or [resource identifier
+objects][resource identifier object]).
 
 A complete example document with multiple included relationships:
 


### PR DESCRIPTION
The current definition of _full linkage_ formally allows full linkage to happen only between resources within `included`, whereas the intention is (I believe) to ensure every resource object within `included` is identified by at least one resource identifier object within the transitive closure of primary data by its relationships. Any input on better wording warmly welcome. (:

TL;DR: Currently the spec could be interpreted to allow the following payload:

``` json
{
  "data": null,
  "included": [
    {
      "type": "people", 
      "id": "1",
      "relationships": {
        "best-friend": {
          "data": { "type": "people", "id": "2" }
        }
      }
    },
    {
      "type": "people", 
      "id": "2",
      "relationships": {
        "best-friend": {
          "data": { "type": "people", "id": "1" }
        }
      }
    }
  ]
}
```
