### PR TITLE
Update index.md - change from 'post' -> 'article'

### DIFF
--- a/index.md
+++ b/index.md
@@ -96,9 +96,9 @@ Here's an example response from a blog that implements JSON API:
 }
 ```
 
-The response above contains the first in a collection of "posts", as well as
+The response above contains the first in a collection of "articles", as well as
 links to subsequent members in that collection. It also contains resources
-linked to the post, including its author and comments. Last but not least,
+linked to the article, including its author and comments. Last but not least,
 links are provided that can be used to fetch or update any of these
 resources.
 


### PR DESCRIPTION
In the example response, the resource name is 'article' but below, the word 'post' is used instead. Corrected to 'article'.
