### PR TITLE
Set the "id" attribute for the schema

### DIFF
--- a/schema
+++ b/schema
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://jsonapi.org/schema#",
   "title": "JSON API Schema",
   "description": "This is a schema for responses in the JSON API format. For more, see http://jsonapi.org",
   "oneOf": [


### PR DESCRIPTION
As per [json-schema documentation](http://json-schema.org/latest/json-schema-core.html#anchor27) the `id` attribute can be used to alter the resolution scope. It also allows referencing {json:api} definitions from schemas defined in other files e.g.

```
"$ref": "http://jsonapi.org/schema#/definitions/link"
```

[More examples](https://spacetelescope.github.io/understanding-json-schema/structuring.html#the-id-property).
