### PR TITLE
Fix broken page titles

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -116,7 +116,7 @@
                 </select>
               </div>
             {% else %}
-              <h1 class="sidebar-top">{{ page.title }}</h1>
+              <h1 class="sidebar-top">{{ page_title }}</h1>
             {% endif %}
           </nav>
         </div>
@@ -124,11 +124,7 @@
       <div class="content">
         {% unless page.show_masthead %}
           <h1>
-            {% if page.is_spec_page %}
-              {{ page_title }}
-            {% else %}
-              {{ page.title }}
-            {% endif %}
+            {{ page_title }}
           </h1>
         {% endunless %}
         <section>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -7,19 +7,18 @@
 
     {% comment %}
       Below, we're either dealing with a generic page or a page from the
-      specification collection. Generic pages have a title, so we identify
-      them that way. For specification pages, we build the title dynamically to
-      take into account the version number and its relationship to the latest version.
+      specification collection. For generic pages, we get a title just by
+      reading page.title but, for specification pages, we build their title
+      dynamically to take into account the page's version number and its
+      relationship to the latest version.
     {% endcomment %}
 
-    {% if page.title %}
-      {% comment %}We're on a generic page.{% endcomment %}
-      {% assign page_title = page.title %}
-
-    {% else %}
+    {% if page.is_spec_page %}
       {% capture page_title %}
         {% include title_for_version.md is_latest_version=page.is_latest_version is_upcoming_version=page.is_upcoming_version version=page.version %}
       {% endcapture %}
+    {% else %}
+      {% assign page_title = page.title %}
     {% endif %}
     <title>JSON API &mdash; {{page_title|strip }}</title>
 


### PR DESCRIPTION
At some point (in the upgrade to Jekyll 3, I suspect), some code we were using to generate the page titles on the various specification pages broke. This fixes it. 
