### PR TITLE
Update schema to require relationship keys.

### DIFF
--- a/schema
+++ b/schema
@@ -225,6 +225,11 @@
               "$ref": "#/definitions/meta"
             }
           },
+          "anyOf": [
+            {"required": ["data"]},
+            {"required": ["meta"]},
+            {"required": ["links"]}
+          ],
           "additionalProperties": false
         }
       },


### PR DESCRIPTION
According to the documentation, both

```
relationships: { author: {} }
relationships: { author: null }
```

Are invalid. However, they validate against the current schema. This
ensures a relationship object is only valid when one of meta/links/data
are present.

See: https://github.com/json-api/json-api/issues/1092
