### PR TITLE
clarify that resource object links allow only self, 1.0

### DIFF
--- a/_format/1.0/index.md
+++ b/_format/1.0/index.md
@@ -333,7 +333,7 @@ link to fetch the resource objects, and linkage information.
 The optional `links` member within each [resource object][resource objects] contains [links]
 related to the resource.
 
-If present, this links object **MAY** contain a `self` [link][links] that
+If present, this links object **MAY** only contain a `self` [link][links] that
 identifies the resource represented by the resource object.
 
 ```json


### PR DESCRIPTION
The wording is already clearer on the 1.1 spec. I'm not sure what the policy is on back-porting clarifications to 1.0, but I don't believe this changes the meaning or intent.

This PR is motivated by this forum thread:
http://discuss.jsonapi.org/t/resource-objects-links-vs-relationships/774
