### PR TITLE
Link to the json-api-vanilla Ruby gem

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -47,6 +47,7 @@ assembled to vet them.
 * [JsonApiClient](https://github.com/chingor13/json_api_client) attempts to give you a query building framework that is easy to understand (similar to ActiveRecord scopes).
 * [JsonApiParser](https://github.com/beauby/jsonapi_parser) a ruby library for parsing/validating/handling JSONAPI documents.
 * [Munson](https://github.com/stacksocial/munson) is a ruby JSONAPI client that can act as an ORM or integrate with your models via fine-grained agnosticism. Easy to configure and customize. Includes a chainable/customizable query builder, attributes API and dirty tracking.
+* [json-api-vanilla](https://github.com/trainline/json-api-vanilla) a reference-aware ruby library for JSONAPI deserialization that doesn't require setting up classes.
 
 ### <a href="#client-libraries-php" id="client-libraries-php" class="headerlink"></a> PHP
 


### PR DESCRIPTION
Adds link to the [`json-api-vanilla`](https://github.com/trainline/json-api-vanilla) gem within the implementations page.
