### PR TITLE
Fix duplicate range in character class (in schema)

### DIFF
--- a/schema
+++ b/schema
@@ -194,7 +194,7 @@
       "description": "Members of the attributes object (\"attributes\") represent information about the resource object in which it's defined.",
       "type": "object",
       "patternProperties": {
-        "^(?!relationships$|links$)\\w[-\\w_]*$": {
+        "^(?!relationships$|links$)\\w[-\\w]*$": {
           "description": "Attributes may contain any valid JSON value."
         }
       },
@@ -205,7 +205,7 @@
       "description": "Members of the relationships object (\"relationships\") represent references from the resource object in which it's defined to other resource objects.",
       "type": "object",
       "patternProperties": {
-        "^\\w[-\\w_]*$": {
+        "^\\w[-\\w]*$": {
           "properties": {
             "links": {
               "$ref": "#/definitions/links"


### PR DESCRIPTION
This removes redundancy in a couple character classes within regular expressions in the JSON schema. Specifically, there were 2 places where a character class like `[\w_]` was being used, which is redundant because `\w` already includes `_`.

I happened to notice this because I was using the `json-schema-rspec` library in a Ruby project (with warnings turned on), and saw the following printed to the console:

```
  warning: character class has duplicated range: /^(?!relationships$|links$)\w[-\w_]*$/
```