### PR TITLE
Update schema to fix bug in errors

### DIFF
--- a/schema
+++ b/schema
@@ -70,6 +70,9 @@
         },
         "jsonapi": {
           "$ref": "#/definitions/jsonapi"
+        },
+        "links": {
+          "$ref": "#/definitions/links"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
The current schema prevents a top-level `links` object from existing when the response is a failure. This restriction is not stated in v1 of the spec, and was purposely omitted from the spec based on the discussion here: https://github.com/json-api/json-api/pull/694

I'm building an API that returns the following response in an integration test:

```js
{
  errors: [
    // ...array of well-formatted errors
  ],
  links: {
    self: '/v1/no_metas'
  }
}
```

The current schema explodes the test. This fix allows the test to pass.