### PR TITLE
Update link to point to new repo location

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -170,7 +170,7 @@ has a page describing how to emit conformant JSON.
 * [api2go](https://github.com/manyminds/api2go) is a full-fledged library to make it simple to provide a JSON API with your Golang project.
 * [jsonapi](https://github.com/google/jsonapi) serializes and deserializes jsonapi formatted payloads using struct tags to annotate the structs that you already have in your Golang project. [Godoc](http://godoc.org/github.com/google/jsonapi)
 * [go-json-spec-handler](https://github.com/derekdowling/go-json-spec-handler) drop-in library for handling requests and sending responses in an existing API.
-* [jsh-api](https://github.com/derekdowling/jsh-api) deals with the dirty work of building JSON API resource endpoints. Built on top of [jsh](https://github.com/derekdowling/go-json-spec-handler)
+* [jsh-api](https://github.com/derekdowling/go-json-spec-handler/tree/master/jsh-api) deals with the dirty work of building JSON API resource endpoints. Built on top of [jsh](https://github.com/derekdowling/go-json-spec-handler)
 
 ### <a href="#server-libraries-net" id="server-libraries-net" class="headerlink"></a> .NET
 


### PR DESCRIPTION
The repo location has changed to be a submodule of the parent repository. I'm updating the link to help avoid confusion for future readers. 