### PR TITLE
Remove uniqueItems restriction on relationships.

### DIFF
--- a/schema
+++ b/schema
@@ -254,8 +254,7 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/linkage"
-      },
-      "uniqueItems": true
+      }
     },
     "empty": {
       "description": "Describes an empty to-one relationship.",


### PR DESCRIPTION
Discussion opened: http://discuss.jsonapi.org/t/impossible-to-have-a-relationship-on-another-object-twice/951
This patch is here to highlight the proposition.