### PR TITLE
updates schema to allow URI references

### DIFF
--- a/schema
+++ b/schema
@@ -158,7 +158,7 @@
         "self": {
           "description": "A `self` member, whose value is a URL for the relationship itself (a \"relationship URL\"). This URL allows the client to directly manipulate the relationship. For example, it would allow a client to remove an `author` from an `article` without deleting the people resource itself.",
           "type": "string",
-          "format": "uri"
+          "format": "uri-reference"
         },
         "related": {
           "$ref": "#/definitions/link"
@@ -172,7 +172,7 @@
         {
           "description": "A string containing the link's URL.",
           "type": "string",
-          "format": "uri"
+          "format": "uri-reference"
         },
         {
           "type": "object",
@@ -183,7 +183,7 @@
             "href": {
               "description": "A string containing the link's URL.",
               "type": "string",
-              "format": "uri"
+              "format": "uri-reference"
             },
             "meta": {
               "$ref": "#/definitions/meta"
@@ -287,28 +287,28 @@
         "first": {
           "description": "The first page of data",
           "oneOf": [
-            { "type": "string", "format": "uri" },
+            { "type": "string", "format": "uri-reference" },
             { "type": "null" }
           ]
         },
         "last": {
           "description": "The last page of data",
           "oneOf": [
-            { "type": "string", "format": "uri" },
+            { "type": "string", "format": "uri-reference" },
             { "type": "null" }
           ]
         },
         "prev": {
           "description": "The previous page of data",
           "oneOf": [
-            { "type": "string", "format": "uri" },
+            { "type": "string", "format": "uri-reference" },
             { "type": "null" }
           ]
         },
         "next": {
           "description": "The next page of data",
           "oneOf": [
-            { "type": "string", "format": "uri" },
+            { "type": "string", "format": "uri-reference" },
             { "type": "null" }
           ]
         }


### PR DESCRIPTION
As discussed in #898 JSON API specification does not make any assertions
about URI structure. Also specification contains examples using "relative
URIs".

RFC 3986, which is referenced by JSON Schema specification, distinguish
between an uri and an uri reference like "relative" or "partial URIs":

> 1.2.3. Hierarchical Identifiers
> [...]
> NOTE: Previous specifications used the terms "partial URI" and "relative
> URI" to denote a relative reference to a URI. As some readers misunderstood
> those terms to mean that relative URIs are a subset of URIs rather than
> a method of referencing URIs, this specification simply refers to them as
> relative references.

Therefore relative URIs would fail validation if `uri` format (8.3.6 in JSON
Schema draft) is used. `uri-reference` format (8.3.7) allow both.