### PR TITLE
Fix: a resource can't have an attribute or relationship named type or id

### DIFF
--- a/schema
+++ b/schema
@@ -197,7 +197,7 @@
       "description": "Members of the attributes object (\"attributes\") represent information about the resource object in which it's defined.",
       "type": "object",
       "patternProperties": {
-        "^(?!relationships$|links$)\\w[-\\w_]*$": {
+        "^(?!relationships$|links$|id$|type$)\\w[-\\w_]*$": {
           "description": "Attributes may contain any valid JSON value."
         }
       },
@@ -208,7 +208,7 @@
       "description": "Members of the relationships object (\"relationships\") represent references from the resource object in which it's defined to other resource objects.",
       "type": "object",
       "patternProperties": {
-        "^\\w[-\\w_]*$": {
+        "^(?!id$|type$)\\w[-\\w_]*$": {
           "properties": {
             "links": {
               "$ref": "#/definitions/links"


### PR DESCRIPTION
According with the latest specification (v1.0):

> Fields for a resource object MUST share a common namespace with each other and with type and id. In other words, **a resource** can not have an attribute and relationship with the same name, **nor can it have an attribute or relationship named type or id**.