### PR TITLE
[WIP] Sideposting draft

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1330,6 +1330,14 @@ Content-Type: application/vnd.api+json
 }
 ```
 
+If a `POST` request *did* include some [Sideposted resources](#sideposting), the server
+**MAY** default to including the created related resources within the `included`
+member.
+
+If a sideposted resource is present in the response document, then it **MUST**
+have a `temp-id` member that identifies the corresponding resource from the request
+document.
+
 ##### <a href="#crud-creating-responses-202" id="crud-creating-responses-202" class="headerlink"></a> 202 Accepted
 
 If a request to create a resource has been accepted for processing, but the

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1235,13 +1235,12 @@ to create a resource with a client-generated ID.
 #### <a href="#crud-sideposting" id="crud-sideposting" class="headerlink"></a> Sideposting
 
 A server **MAY** accept a request to create related resources along with the primary
-resource, which is referred to as *sideposting*. The related resources **MUST**
-be placed within the `included` member. A sideposted resource **MUST** be referred to
-(from the linkage data of resource relationships) either via standard
-[resource identifier objects][resource identifier object] when using a
-client-generated ID, or as a [resource pointer object][resource pointer object]
-otherwise (that is an object with a single `pointer` member the value of which is a
-JSON Pointer [[RFC6901](https://tools.ietf.org/html/rfc6901)] to a resource object).
+resource, which is referred to as *sideposting*. A related resource **MUST**
+be placed within the `included` member, and have a `temp-id` member the value of which
+is an arbitrary string that uniquely identifies a related resource within the request
+document. The related resources **MUST** be referred to (from the linkage data of
+resource relationships) via a *temporary resource identifier object* (that is an
+object with a single `temp-id` member referring to a related resource).
 
 The document **MUST** still respect the full linkage requirement.
 
@@ -1262,20 +1261,22 @@ Accept: application/vnd.api+json
     "relationships": {
       "tags": {
         "data": [{ "type": "tags", "id": "9" },
-                 { "pointer": "/included/0" },
-                 { "pointer": "/included/1" }]
+                 { "temp-id": "1" },
+                 { "temp-id": "2" }]
       }
     }
   },
   "included": [
     {
       "type": "tags",
+      "temp-id": "1",
       "attributes": {
         "label": "JSON"
       }
     },
     {
       "type": "tags",
+      "temp-id": "2",
       "attributes": {
         "label": "REST"
       }

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1235,12 +1235,17 @@ to create a resource with a client-generated ID.
 #### <a href="#crud-sideposting" id="crud-sideposting" class="headerlink"></a> Sideposting
 
 A server **MAY** accept a request to create related resources along with the primary
-resource, which is referred to as *sideposting*. A related resource **MUST**
-be placed within the `included` member, and have a `temp-id` member the value of which
-is an arbitrary string that uniquely identifies a related resource within the request
-document. The related resources **MUST** be referred to (from the linkage data of
-resource relationships) via a *temporary resource identifier object* (that is an
-object with a single `temp-id` member referring to a related resource).
+resource, which is referred to as *sideposting*. Related resources **MUST**
+be placed within the `included` section, and have a `temp-id` member the value of
+which is an arbitrary string.
+Linkage with sideposted resources **MUST** be expressed via *temporary resource
+identifier objects*, that is [resource identifier objects][resource identifier object]
+where the `id` member is replaced with a `temp-id` member. A temporary resource
+identifier object **MUST** identify an individual resource within a request document.
+
+In case a sideposted resource refers to the primary resource, the primary resource
+**MUST** have a `temp-id` member, and linkage **MUST** be expressed using a
+temporary resource identifier object.
 
 The document **MUST** still respect the full linkage requirement.
 
@@ -1261,8 +1266,8 @@ Accept: application/vnd.api+json
     "relationships": {
       "tags": {
         "data": [{ "type": "tags", "id": "9" },
-                 { "temp-id": "1" },
-                 { "temp-id": "2" }]
+                 { "type": "tags", "temp-id": "1" },
+                 { "type": "tags", "temp-id": "2" }]
       }
     }
   },

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1232,6 +1232,24 @@ Accept: application/vnd.api+json
 A server **MUST** return `403 Forbidden` in response to an unsupported request
 to create a resource with a client-generated ID.
 
+#### <a href="#crud-sideposting" id="crud-sideposting" class="headerlink"></a> Sideposting
+
+A server **MAY** accept a request to create related resources along with the primary
+resource, which is referred to as *sideposting*. The related resources **MUST**
+be placed within the `included` member. A sideposted resource **MUST** be referred to
+(from the linkage data of resource relationships) either via standard
+[resource identifier objects][resource identifier object] when using a
+client-generated ID, or as a [resource pointer object][resource pointer object]
+otherwise (that is an object with a single `pointer` member the value of which is a
+JSON pointer to a resource object). The document **MUST** still respect the full
+linkage requirement.
+
+A server **MUST** handle sideposting requests transactionally, and either create all
+requested resources or none.
+
+A server **MUST** return `403 Forbidden` in response to an unsupported request to
+create a resource with sideposting.
+
 #### <a href="#crud-creating-responses" id="crud-creating-responses" class="headerlink"></a> Responses
 
 ##### <a href="#crud-creating-responses-201" id="crud-creating-responses-201" class="headerlink"></a> 201 Created

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1338,6 +1338,46 @@ If a sideposted resource is present in the response document, then it **MUST**
 have a `temp-id` member that identifies the corresponding resource from the request
 document.
 
+```http
+HTTP/1.1 201 Created
+Content-Type: application/vnd.api+json
+
+{
+  "data": {
+    "type": "articles",
+    "id": "123",
+    "attributes": {
+      "title": "Sideposting with json:api"
+    },
+    "relationships": {
+      "tags": {
+        "data": [{ "type": "tags", "id": "9" },
+                 { "type": "tags", "id": "14" },
+                 { "type": "tags", "id": "42" }]
+      }
+    }
+  },
+  "included": [
+    {
+      "type": "tags",
+      "id": "14",
+      "temp-id": "1",
+      "attributes": {
+        "label": "JSON"
+      }
+    },
+    {
+      "type": "tags",
+      "id": "42",
+      "temp-id": "2",
+      "attributes": {
+        "label": "REST"
+      }
+    }
+  ]
+}
+```
+
 ##### <a href="#crud-creating-responses-202" id="crud-creating-responses-202" class="headerlink"></a> 202 Accepted
 
 If a request to create a resource has been accepted for processing, but the

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1241,8 +1241,9 @@ be placed within the `included` member. A sideposted resource **MUST** be referr
 [resource identifier objects][resource identifier object] when using a
 client-generated ID, or as a [resource pointer object][resource pointer object]
 otherwise (that is an object with a single `pointer` member the value of which is a
-JSON Pointer [[RFC6901](https://tools.ietf.org/html/rfc6901)] to a resource object). The document **MUST** still respect the full
-linkage requirement.
+JSON Pointer [[RFC6901](https://tools.ietf.org/html/rfc6901)] to a resource object).
+
+The document **MUST** still respect the full linkage requirement.
 
 For instance, a new article might be created along with two tags with the following 
 request:

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1244,6 +1244,45 @@ otherwise (that is an object with a single `pointer` member the value of which i
 JSON pointer to a resource object). The document **MUST** still respect the full
 linkage requirement.
 
+For instance, a new article might be created along with two tags with the following 
+request:
+
+```http
+POST /articles HTTP/1.1
+Content-Type: application/vnd.api+json
+Accept: application/vnd.api+json
+
+{
+  "data": {
+    "type": "articles",
+    "attributes": {
+      "title": "Sideposting with json:api"
+    },
+    "relationships": {
+      "tags": {
+        "data": [{ "type": "tags", "id": "9" },
+                 { "pointer": "/included/0" },
+                 { "pointer": "/included/1" }]
+      }
+    }
+  },
+  "included": [
+    {
+      "type": "tags",
+      "attributes": {
+        "label": "JSON"
+      }
+    },
+    {
+      "type": "tags",
+      "attributes": {
+        "label": "REST"
+      }
+    }
+  ]
+}
+```
+
 A server **MUST** handle sideposting requests transactionally, and either create all
 requested resources or none.
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1241,7 +1241,7 @@ be placed within the `included` member. A sideposted resource **MUST** be referr
 [resource identifier objects][resource identifier object] when using a
 client-generated ID, or as a [resource pointer object][resource pointer object]
 otherwise (that is an object with a single `pointer` member the value of which is a
-JSON pointer to a resource object). The document **MUST** still respect the full
+JSON Pointer [[RFC6901](https://tools.ietf.org/html/rfc6901)] to a resource object). The document **MUST** still respect the full
 linkage requirement.
 
 For instance, a new article might be created along with two tags with the following 


### PR DESCRIPTION
This PR is a work in progress, following discussions in #1089, #795, and #536.

Questions:

1. `POST`ing
    1. Expressing linkage between (fresh) resources in the request document
        - [x] Should we use ~~JSON pointers~~ or temp ids?
            - [x] Should temp ids be unique throughout a document or ~~just unique per type~~?
            - [x] What key should we use for temp ids? `tempid`? ~~`tid`? `tmpid`?~~
        - [ ] Should sideposted resources be within the `included` member or within some new ad-hoc member? (see #1215)

    2. Expressing linkage between (fresh) resources in the request document and persisted resources in the response document
        - [x] How do we tell the client which created resources correspond to which resources in the request? **Keep the temp ids in the response**
          - [ ] Should the temp id be in each resource object in the response, or should there be a single, document-level temp id => permanent id mapping object?
        - [ ] What should happen if a client uses `?include` on their POST and (for some reason) doesn't list in that param all the relationship paths for which they sideposted resources?
        - [ ] Should created sideposted resources in the response be within the `included` member or within some other ad-hoc member? (see #1215)

    3. Supported linkage graphs for sideposting
        - [ ] Should we put restrictions on the kinds of graphs allowed or should we leave it to the server implementations?
        - [ ] Should we put minimum requirements of the kind of graphs a server must support?
        - [ ] Should we offer further guidance on responding to unsupported sideposting requests? (Unsupported graph, etc.)

    4. Updating/deleting related resources
        - [x] ~~Should we allow updates of related resources while `POST`ing a new primary resource?~~ Not in 1.1, but maybe down the line
        - [x] ~~Should we allow deletion of related resources while `POST`ing a new primary resource?~~ Not in 1.1, but maybe down the line

2. `PATCH`ing
    - [ ] Should we allow updates of related resources while `PATCH`ing a resource endpoint?
    - [ ] Should we allow deletion of related resources while `PATCH`ing a resource endpoint?

3. Other
    - [ ] Should we allow bulk creation? (which is simply a matter of relaxing the constraint on the primary data being a single resource object).
    - [ ] If so, should we allow bulk updates? deletions?