### PR TITLE
Remove RestPack::Serializer from implementations

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -161,7 +161,6 @@ is one of the original exemplar implementations, but is slightly out of date at
 the moment.
 * [The rabl wiki](https://github.com/nesquena/rabl/wiki/Conforming-to-jsonapi.org-format)
 has a page describing how to emit conformant JSON.
-* [RestPack::Serializer](https://github.com/RestPack/restpack_serializer) implements the read elements of json-api. It also supports paging and side-loading.
 * [Oat](https://github.com/ismasan/oat#adapters) ships with a JSON API adapter.
 * [JSONAPI::Resources](https://github.com/cerebris/jsonapi-resources) provides a complete framework for developing a JSON API server. It is designed to work with Rails, and provides routes, controllers, and serializers.
 * [Yaks](https://github.com/plexus/yaks) Library for building hypermedia APIs, contains a JSON API output format.


### PR DESCRIPTION
Remove `RestPack::Serializer` from implementations as it is unmaintained and non-conformant to the spec.
Refs: https://github.com/RestPack/restpack_serializer/issues/128, https://github.com/RestPack/restpack_serializer/issues/123