### PR TITLE
Add kitsu to JS implementations

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -39,6 +39,7 @@ assembled to vet them.
 * [active-resource](https://github.com/nicklandgrebe/activeresource.js) A standalone, convention-driven JavaScript ORM that maps to your JSON API server and allows for advanced queries and relational management through a smooth interface.
 * [redux-bees](https://github.com/cantierecreativo/redux-bees) A nice, short and declarative way to interact with JSON APIs in React+Redux
 * [Coloquent](https://github.com/DavidDuwaer/Coloquent) A library mapping objects and their interrelations to JSON API, with a fluent syntax inspired by Laravel's Eloquent.
+* [kitsu](https://github.com/wopian/kitsu) A simple, lightweight & framework agnostic JSON API client
 
 ### <a href="#client-libraries-typescript" id="client-libraries-typescript" class="headerlink"></a> Typescript
 * [ts-angular-jsonapi](https://github.com/reyesoft/ts-angular-jsonapi) A JSON API library developed for AngularJS in Typescript


### PR DESCRIPTION
Originally built it just for [Kitsu.io](https://github.com/hummingbird-me/hummingbird)'s API as a _far_ [simpler](https://github.com/wopian/kitsu/blob/master/DOCS.md#get)/lighter alternative to Devour after many (beginners) had issue using Devour's definition system

Although has no dependency on their API and is just the default `apiUrl` which can be overridden: 

```js
// https://example.org/api/2
const api = new kitsu({
  apiUrl: 'https://example.org/api',
  apiVer: 2
})
```