### PR TITLE
Better multiple related resources request example

### DIFF
--- a/_format/1.0/index.md
+++ b/_format/1.0/index.md
@@ -971,7 +971,7 @@ resources.
 Multiple related resources can be requested in a comma-separated list:
 
 ```http
-GET /articles/1?include=author,comments.author HTTP/1.1
+GET /articles/1?include=ratings,comments.author HTTP/1.1
 Accept: application/vnd.api+json
 ```
 

--- a/_format/1.0/index.md
+++ b/_format/1.0/index.md
@@ -971,7 +971,7 @@ resources.
 Multiple related resources can be requested in a comma-separated list:
 
 ```http
-GET /articles/1?include=ratings,comments.author HTTP/1.1
+GET /articles/1?include=comments.author,ratings HTTP/1.1
 Accept: application/vnd.api+json
 ```
 


### PR DESCRIPTION
> GET /articles/1?include=author,comments.author

is confusing since `author` and `comments.author` both reference the `author` resource', 
but with different meaning.

It looks a lot like how

> GET /users/1?include=articles,articles.comments

is identical to

> GET /users/1?include=articles.comments

since full linkage requires intermediate resources to be returned

So, I've changed the the related resources to be more obviously different