### PR TITLE
add an 'id' attribute and include version in the URL.

### DIFF
--- a/schema
+++ b/schema
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "http://jsonapi.org/schema/1.0",
+  "id": "http://jsonapi.org/schema/1.0#",
   "title": "JSON API Schema",
   "description": "This is a schema for responses in the JSON API format. For more, see http://jsonapi.org",
   "oneOf": [

--- a/schema
+++ b/schema
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://jsonapi.org/schema/1.0",
   "title": "JSON API Schema",
   "description": "This is a schema for responses in the JSON API format. For more, see http://jsonapi.org",
   "oneOf": [


### PR DESCRIPTION
@bf4 https://github.com/json-api/json-api/issues/1220 

Implementing this will require putting this schema version at http://jsonapi.org/schema/1.0 and doing the same for http://jsonapi.org/schema/1.1 and so on as new versions roll out.  I note the current unversioned 1.0 schema is at http://jsonapi.org/schema.