### PR TITLE
Always return "included" where "include" has been requested

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -943,6 +943,8 @@ client to customize which related resources should be returned.
 If an endpoint does not support the `include` parameter, it **MUST** respond
 with `400 Bad Request` to any requests that include it.
 
+If an endpoint supports the `include` parameter and a client supplies it, the server **MUST** respond with the `included` section of the [compound document].
+
 If an endpoint supports the `include` parameter and a client supplies it,
 the server **MUST NOT** include unrequested [resource objects] in the `included`
 section of the [compound document].

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -945,8 +945,7 @@ with `400 Bad Request` to any requests that include it.
 
 If an endpoint supports the `include` parameter and a client supplies it:
 
- - The server **MUST** respond with the `included` section of the [compound document] — even if
-there are no [resource objects] to include (represented as an empty array `[]`.)
+ - The server's response **MUST** be a [compound document] with an `included` key — even if that `included` key holds an empty array (because the requested relationships are empty).
  - The server **MUST NOT** include unrequested [resource objects] in the `included`
 section of the [compound document].
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -943,10 +943,10 @@ client to customize which related resources should be returned.
 If an endpoint does not support the `include` parameter, it **MUST** respond
 with `400 Bad Request` to any requests that include it.
 
-If an endpoint supports the `include` parameter and a client supplies it, the server **MUST** respond with the `included` section of the [compound document].
+If an endpoint supports the `include` parameter and a client supplies it:
 
-If an endpoint supports the `include` parameter and a client supplies it,
-the server **MUST NOT** include unrequested [resource objects] in the `included`
+ - The server **MUST** respond with the `included` section of the [compound document] -- even if there are no [resource objects] to include (represented as an empty array `[]`.)
+ - The server **MUST NOT** include unrequested [resource objects] in the `included`
 section of the [compound document].
 
 The value of the `include` parameter **MUST** be a comma-separated (U+002C

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -945,7 +945,8 @@ with `400 Bad Request` to any requests that include it.
 
 If an endpoint supports the `include` parameter and a client supplies it:
 
- - The server **MUST** respond with the `included` section of the [compound document] -- even if there are no [resource objects] to include (represented as an empty array `[]`.)
+ - The server **MUST** respond with the `included` section of the [compound document] — even if
+there are no [resource objects] to include (represented as an empty array `[]`.)
  - The server **MUST NOT** include unrequested [resource objects] in the `included`
 section of the [compound document].
 


### PR DESCRIPTION
https://github.com/json-api/json-api/issues/1230

One additional thing that may be worthwhile is reiterating that the `included` param **must** always be an array, and that an empty array should be returned when no additional resources are available to add to the response.

Open to feedback. :)