### PR TITLE
Schema should allow pagination links to be null

### DIFF
--- a/schema
+++ b/schema
@@ -37,7 +37,7 @@
         },
         "links": {
           "description": "Link members related to the primary data.",
-          "allOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/links"
             },


### PR DESCRIPTION
I have cases where my pagination links `next` and `prev` are null. The current schema does not allow that, the proposed change does.