### PR TITLE
Proposal to follow Google and Schema.org's JSON Style Guide: Use "camelCase" Naming Convention

### DIFF
--- a/recommendations/index.md
+++ b/recommendations/index.md
@@ -20,16 +20,14 @@ The allowed and recommended characters for an URL safe naming of members are def
 
 ### JSON  
 
-Naming format should follows the [Google JSON Style Guide](https://google.github.io/styleguide/jsoncstyleguide.xml?showone=Property_Name_Format#Property_Name_Format), where:
+It is important to adhere to a defined convention. Recommended property names **SHOULD** conform to the following guidelines:
 
-> Property names must conform to the following guidelines:
+- Property names **SHOULD** be camel-cased, ascii strings.
+- First characters **SHOULD** be "a-z" (U+0061 to U+007A).
+- Property names **SHOULD** be meaningful names with defined semantics.
 
-> * Property names should be meaningful names with defined semantics.
-> * Property names must be camel-cased, ascii strings.
-> * The first character must be a letter, an underscore (_) or a dollar sign ($).
-> * Subsequent characters can be a letter, a digit, an underscore, or a dollar sign.
-> * Reserved JavaScript keywords should be avoided (A list of reserved JavaScript keywords can be found below).
-> * These guidelines mirror the guidelines for naming JavaScript identifiers. This allows JavaScript clients to access properties using dot notation. (for example, result.thisIsAnInstanceVariable). 
+
+These guidelines mirror the guidelines for naming JavaScript identifiers. This allows JavaScript clients to access properties using dot notation.
 
 > Here's an example of an object with one property:
 

--- a/recommendations/index.md
+++ b/recommendations/index.md
@@ -10,10 +10,35 @@ are beyond the scope of the base JSON API specification.
 
 ## <a href="#naming" id="naming" class="headerlink"></a> Naming
 
+
+### URLs
+
 The allowed and recommended characters for an URL safe naming of members are defined in the format spec. To also standardize member names, the following (more restrictive) rules are recommended:
 
 - Member names **SHOULD** start and end with the characters "a-z" (U+0061 to U+007A)
 - Member names **SHOULD** contain only the characters "a-z" (U+0061 to U+007A), "0-9" (U+0030 to U+0039), and the hyphen minus (U+002D HYPHEN-MINUS, "-") as separator between multiple words.
+
+### JSON  
+
+Naming format should follows the [Google JSON Style Guide](https://google.github.io/styleguide/jsoncstyleguide.xml?showone=Property_Name_Format#Property_Name_Format), where:
+
+> Property names must conform to the following guidelines:
+
+> * Property names should be meaningful names with defined semantics.
+> * Property names must be camel-cased, ascii strings.
+> * The first character must be a letter, an underscore (_) or a dollar sign ($).
+> * Subsequent characters can be a letter, a digit, an underscore, or a dollar sign.
+> * Reserved JavaScript keywords should be avoided (A list of reserved JavaScript keywords can be found below).
+> * These guidelines mirror the guidelines for naming JavaScript identifiers. This allows JavaScript clients to access properties using dot notation. (for example, result.thisIsAnInstanceVariable). 
+
+> Here's an example of an object with one property:
+
+```json
+{
+  "thisPropertyIsAnIdentifier": "identifier value"
+}
+```
+
 
 ## <a href="#urls" id="urls" class="headerlink"></a> URL Design
 


### PR DESCRIPTION
Updating Naming Rules.
<hr>

* JSON <strike>**MUST**</strike> **SHOULD** use camelCase 
* URLs **SHOULD** use kebab-case.

with a emphasize on the first
> JSON <strike>**MUST**</strike> **SHOULD**  use camelCase 
<hr>

Here goes.

**I think it should be changed or dropped.**

I know this is a heavily opinionated topic, but here goes.
The JSON object property naming conventions seem to favor camelCase.



## Styleguides that explicitly say to use `camelCase`.

#### [Google JSON Style Guide](https://google.github.io/styleguide/jsoncstyleguide.xml?showone=Property_Name_Format#Property_Name_Format) (they follow the [JSON.org](http://json.org) spec):

> * Property names must be camel-cased, ascii strings.

 here are a few more:

####  [W3resource](https://www.w3resource.com/slides/json-style-guide.php)(same thing) state:

> Property names must be camel-cased, ascii strings.

#### [Crockford](http://crockford.com/javascript/code.html#names) state:

> * Most variables and functions should start with a lower case letter.
> * Names should be formed from the 26 upper and lower case letters (A .. Z, a .. z), the 10 digits (0 .. 9) 

#### [Schema.org](https://schema.org/docs/old_extension.html) 

> Properties start with a lower case letter and are also camelCase.


 **`camelCase` in the wild:**
*  [Mozilla Objects and properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#Objects_and_properties)
* [W3School's [JS JSON](https://www.w3schools.com/js/js_json.asp) and [JS Conventions](https://www.w3schools.com/js/js_conventions.asp)
* [Codecademy](https://www.codecademy.com/courses/javascript-beginner-en-xTAfX/0/1)
* **graphql** spec uses `camelCase` for fields.




# Using `kebab-case`

`kebab-case` notation has collisions (or does not play nicely) with:
* The JavaScript Language (you cannot do `person.first-name`)
* EmberJs Framework
* Schema.org / JSON-LD
* GraphQL / GraphQL Queries? (admittedly haven't done much here)


# Conclusion

**Issues as a result or related to the spec using saying to use `kebab-case`** are as follows:
https://github.com/json-api/json-api/issues/323
https://github.com/json-api/json-api/issues/571
https://github.com/json-api/json-api/issues/191
https://github.com/json-api/json-api/issues/127
https://github.com/json-api/json-api/issues/1242
https://github.com/json-api/json-api/issues/850
https://github.com/json-api/json-api/issues/525
https://github.com/json-api/json-api/pull/341

I'd expect they will continue until this issue is resolved, especially as GraphQL becomes more popular.

I think it's safe to assume `camelCase` won this battle, especially with JSON-LD, schema.org and as GraphQL continues to grow.

I think this spec should it be changed or dropped, curious on your take @dgeb @ethanresnick @tkellen 


# More Resource and Discussion on web


* https://en.wikipedia.org/wiki/Naming_convention_%28programming%29#Multiple-word_identifiers
* https://stackoverflow.com/a/19287394/4642530
* https://github.com/emberjs/data/blob/aeccf38a5193a9fbf763a835588cc4ad315324b7/packages/ember-data/lib/serializers/json-api-serializer.js#L319-L351
* https://github.com/interagent/http-api-design/issues/18
* https://tools.ietf.org/html/rfc3986
* https://ember-cli.com/naming-conventions
* https://github.com/holidayextras/jsonapi-server/issues/206
* https://github.com/kurko/ember-json-api
* https://discuss.codecademy.com/t/object-property-naming-conventions-camelcase-or-under-score/36878/3
* https://discuss.emberjs.com/t/ams-with-jsonapi-underscored-vs-dasherized-types/8930/2
* https://github.com/interagent/http-api-design/issues/18
* https://github.com/imazen/imageflow/issues/99
* https://github.com/kurko/ember-json-api/issues/53
