### PR TITLE
Clarify pagination links in relationship object

### DIFF
--- a/_format/1.0/index.md
+++ b/_format/1.0/index.md
@@ -262,7 +262,9 @@ A "relationship object" **MUST** contain at least one of the following:
   relationship.
 
 A relationship object that represents a to-many relationship **MAY** also contain
-[pagination] links under the `links` member, as described below.
+[pagination] links under the `links` member, as described below. Any
+[pagination] links in a relationship object **MUST** paginate the relationship
+data, not the related resources.
 
 > Note: See [fields] and [member names] for more restrictions on this container.
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -262,7 +262,9 @@ A "relationship object" **MUST** contain at least one of the following:
   relationship.
 
 A relationship object that represents a to-many relationship **MAY** also contain
-[pagination] links under the `links` member, as described below.
+[pagination] links under the `links` member, as described below. Any
+[pagination] links in a relationship object **MUST** paginate the relationship
+data, not the related resources.
 
 > Note: See [fields] and [member names] for more restrictions on this container.
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -512,7 +512,7 @@ Each member of a links object is a "link". A link **MUST** be represented as
 either:
 
 * a string containing the link's URL.
-* <a id="document-links-link-object"></a>an object ("link object") which can 
+* <a id="document-links-link-object"></a>an object ("link object") which can
   contain the following members:
   * `href`: a string containing the link's URL.
   * `meta`: a meta object containing non-standard meta-information about the


### PR DESCRIPTION
This is a clarification, not a change, so I'm comfortable using MUST here.

I believe this is just a refinement of the [pagination](http://jsonapi.org/format/#fetching-pagination) section which already contains statements such as:

> A server MAY provide links to traverse a paginated data set (“pagination links”).

> Pagination links MUST appear in the links object that corresponds to a collection. 

In other words, the pagination links clearly correspond to the collection. And for relationship objects, the collection is relationship data, not related resources.

Closes #509 
