### PR TITLE
Add SimpleJSONAPIClient to Ruby implementations

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -60,6 +60,7 @@ assembled to vet them.
 * [JsonApiParser](https://github.com/beauby/jsonapi_parser) a ruby library for parsing/validating/handling JSONAPI documents.
 * [Munson](https://github.com/coryodaniel/munson) is a ruby JSONAPI client that can act as an ORM or integrate with your models via fine-grained agnosticism. Easy to configure and customize. Includes a chainable/customizable query builder, attributes API and dirty tracking.
 * [json-api-vanilla](https://github.com/trainline/json-api-vanilla) a reference-aware ruby library for JSONAPI deserialization that doesn't require setting up classes.
+* [SimpleJSONAPIClient](https://github.com/amcaplan/simple_jsonapi_client) gives you lower-level control for API operations, while your models and their relationships maintain a neat, ActiveRecord-inspired interface.
 
 ### <a href="#client-libraries-php" id="client-libraries-php" class="headerlink"></a> PHP
 


### PR DESCRIPTION
Exactly what it says.

For context: The reason this project exists is because none of the listed Ruby implementations allow you to switch request context (e.g. use a different Authorization header) across multiple requests; they all require setting global state. They also tend to assume APIs allow all the usual JSONAPI routes, and many don't (working with e.g. Rails' shallow routes often doesn't seem possible). In my use case, I needed to allow using different API keys on a per-request basis, and some of the routes of this API are, though compliant, somewhat complicated.

Once I had to start from scratch, I ended up building a framework for building Ruby clients that tries to balance between allowing more low-level per-request tweaks, leveraging the power of JSON API `filter` and `includes`, using a lot of laziness, but still making most of the complexity optional through semantically parsing the responses and fetching related records as-needed.

I appreciate the beauty of `post.authors.map(&:comments)`, but I was less convinced of the need to use relational algebra to enable `includes` through `Post.includes(author: :comments).find(1)` when `Post.fetch(url_opts: { id: 1 }, includes: ['author.comments'])` works just fine. I get why other people like it, I just thought a simpler solution might be all that's necessary.

That said, the syntax isn't the main goal here; it's more about customization of routes and request details, which weren't provided by any solution I could find.