### PR TITLE
Ruby Server Handler: jsonapi-realizer

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -172,6 +172,7 @@ and writing of JSON API documents.
 * Plain Ruby
   * [Yaks](https://github.com/plexus/yaks) Library for building hypermedia APIs, contains a JSON API output format.
   * [JSONAPI::Serializers](https://github.com/fotinakis/jsonapi-serializers) provides a pure Ruby, readonly serializer implementation.
+  * [JSONAPI::Realizer](https://github.com/krainboltgreene/jsonapi-realizer) provides a pure Ruby pattern for turning JSON:API requests into models (has active record support and rails instructions)
   * [Roar](https://github.com/apotonick/roar) Renders and parses represenations of Ruby objects
   * [Jbuilder::JsonAPI](https://github.com/vladfaust/jbuilder-json_api) Simple & lightweight extension for Jbuilder
   * [jsonapi-rb](http://jsonapi-rb.org) Ruby library for efficiently building and consuming JSON API documents - with Rails and Hanami integrations.


### PR DESCRIPTION
jsonapi-realizer is a new server side hander, intended to be a sister to jsonapi-serializers.