### PR TITLE
Introduce Profiles to v1.1

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1859,7 +1859,7 @@ add new features over time.
 
 A profile **SHOULD** explicitly declare "keywords" for any elements that it
 introduces to the document structure. If a profile does not explicitly declare a
-keyword for an element, then the name of the element itself can be considered a
+keyword for an element, then the name of the element itself is considered to be its
 keyword. Keywords **MAY** be aliased in any representation through the use of
 [profile descriptors](profile-descriptors), as described below.
 
@@ -1873,9 +1873,9 @@ parameter **MUST** equal a whitespace-separated list of profile URIs.
 > specification requires that its value be surrounded by quotation marks 
 > (U+0022 QUOTATION MARK, "\"") if it contains more than one URI.
 
-Clients and servers **SHOULD** use the `profile` media type parameter in
-conjunction with the JSON API media type in a `Content-Type` header to specify
-the application of one or more profiles to a JSON API document.
+Clients and servers **MUST** include the `profile` media type parameter in
+conjunction with the JSON API media type in a `Content-Type` header to indicate
+that they have applied one or more profiles to a JSON API document.
 
 A client **MAY** use the `profile` media type parameter in conjunction with the
 JSON API media type in an `Accept` header to _request_, but not _require_, that

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1869,6 +1869,10 @@ The `profile` media type parameter is used to describe the application of
 one or more profiles to the JSON API media type. The value of the `profile`
 parameter **MUST** equal a whitespace-separated list of profile URIs.
 
+> Note: When serializing the `profile` media type parameter, the HTTP 
+> specification requires that its value be surrounded by quotation marks 
+> (U+0022 QUOTATION MARK, "\"") if it contains more than one URI.
+
 Clients and servers **SHOULD** use the `profile` media type parameter in
 conjunction with the JSON API media type in a `Content-Type` header to specify
 the application of one or more profiles to a JSON API document.

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1840,24 +1840,10 @@ identification:
 However, to aid human understanding, profile URIs **SHOULD** return
 documentation of the profile.
 
-A profile **MAY** assign meaning to particular elements of the document
-structure, such as resource attributes or members of meta objects, and even
-to query parameters whose behavior is left up to each implementation, such
-as `filter` and all those that contain a non a-z character.
-
-The scope of a profile **MUST** be clearly delineated. The elements reserved by
-a profile, and the meaning assigned to those elements, **MUST NOT** change over
-time or else the profile **MUST** be considered a new profile with a new URI.
-
-Profiles **MAY** be updated over time to add new capabilities. However, any such
-changes **MUST** be [backwards and forwards compatible](http://www.w3.org/2001/tag/doc/versioning-compatibility-strategies#terminology),
-in order to not break existing users of the profile. This requirement usually
-limits changes to adding optional keys within objects specified in the profile's
-original definition.
-
 The following example profile reserves a `timestamps` member in the `meta`
 object of every resource:
 
+<a id="profiles-timestamp-profile"></a>
 ```text
 # Timestamps profile
 
@@ -1888,20 +1874,6 @@ This profile defines the following keywords:
 
 * `timestamps`
 ```
-
-This profile could evolve to allow other optional members, such as `deleted`,
-in the `timestamps` object. But it could not make that member required, nor
-could it introduce a new sibling to `timestamps`.
-
-To aid evoluation and interoperability, profiles **SHOULD** reserve an
-object-valued member anywhere they expect to potentially add new features over
-time.
-
-> Note: When a profile changes its URI, a huge amount of interoperability is lost.
-> Users that reference the new URI will have their messages not understood by
-> implementations still aware only of the old URI, and vice-versa.
-> Accordingly, the advice above is aimed at allowing profifiles to grow
-> without needing to change their URI.
 
 ### <a href="#profile-media-type-parameter" id="profile-media-type-parameter" class="headerlink"></a> `profile` Media Type Parameter
 
@@ -2068,6 +2040,36 @@ key `version` described in the profile:
 }
 ```
 
+### <a href="#profiles-authoring" id="profiles-authoring" class="headerlink"></a> Authoring Profiles
+
+A profile **MAY** assign meaning to particular elements of the document
+structure, such as resource attributes or members of meta objects, and even
+to query parameters whose behavior is left up to each implementation, such
+as `filter` and all those that contain a non a-z character.
+
+The scope of a profile **MUST** be clearly delineated. The elements reserved by
+a profile, and the meaning assigned to those elements, **MUST NOT** change over
+time or else the profile **MUST** be considered a new profile with a new URI.
+
+Profiles **MAY** be updated over time to add new capabilities. However, any such
+changes **MUST** be [backwards and forwards compatible](http://www.w3.org/2001/tag/doc/versioning-compatibility-strategies#terminology),
+in order to not break existing users of the profile. This requirement usually
+limits changes to adding optional keys within objects specified in the profile's
+original definition.
+
+The hypothetical [timestamps profile], for example, could evolve to allow other 
+optional members, such as `deleted`, in the `timestamps` object. But it could 
+not make that member required, nor could it introduce a new sibling to `timestamps`.
+
+To aid evoluation and interoperability, profiles **SHOULD** reserve an
+object-valued member anywhere they expect to potentially add new features over
+time.
+
+> Note: When a profile changes its URI, a huge amount of interoperability is lost.
+> Users that reference the new URI will have their messages not understood by
+> implementations still aware only of the old URI, and vice-versa.
+> Accordingly, the advice above is aimed at allowing profifiles to grow
+> without needing to change their URI.
 ## <a href="#errors" id="errors" class="headerlink"></a> Errors
 
 ### <a href="#errors-processing" id="errors-processing" class="headerlink"></a> Processing Errors
@@ -2129,6 +2131,7 @@ An error object **MAY** have the following members:
 [link]: #document-links-link
 [link object]: #document-links-link-object
 [profiles]: #profiles
+[timestamps profile]: #profiles-timestamp-profile
 [profile aliases]: #profile-keywords-and-aliases
 [error details]: #errors
 [error objects]: #errror-objects

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1863,6 +1863,8 @@ keyword for an element, then the name of the element itself is considered to be 
 keyword. Keywords **MAY** be aliased in any representation through the use of
 [profile descriptors](profile-descriptors), as described below.
 
+All profile keywords **MUST** meet this specification's requirements for [member names].
+
 ### <a href="#profile-media-type-parameter" id="profile-media-type-parameter" class="headerlink"></a> `profile` Media Type Parameter
 
 The `profile` media type parameter is used to describe the application of

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1809,34 +1809,34 @@ to standard query parameters without conflicting with existing implementations.
 
 ## <a href="#profiles" id="profiles" class="headerlink"></a> Profiles
 
-JSON API supports the use of "profiles" as a means to describe additional
-semantics to the media type, without altering the basic semantics described in
-this specification.
+JSON API supports the use of "profiles" as a way to indicate additional
+semantics that apply to a JSON:API request/document, without altering the 
+basic semantics described in this specification.
 
 [RFC 6906](https://tools.ietf.org/html/rfc6906) covers the nature of profile
 identification:
 
-> Profiles are identified by URI.  However, as is the case with, for
+> Profiles are identified by URI. However, as is the case with, for
   example, XML namespace URIs, the URI in this case only serves as an
   identifier, meaning that the presence of a specific URI has to be
   sufficient for a client to assert that a resource representation
-  conforms to a profile.  Thus, clients SHOULD treat profile URIs as
-  identifiers and not as links, but profiles MAY be defined in a way
-  that the URIs do identify retrievable profile description and thus
-  can be accessed by clients by dereferencing the profile URI.  For
-  profiles intended for use in environments where clients may encounter
-  unknown profile URIs, profile maintainers SHOULD consider to make the
-  profile URI dereferencable and provide useful documentation at that
-  URI.  The design and representation of such profile descriptions,
-  however, is outside the scope of this specification.
+  conforms to a profile. Thus, clients SHOULD treat profile URIs as
+  identifiers and not as links.
+
+However, to aid human understanding, profile URIs **SHOULD** return 
+documentation of the profile.
 
 A profile **MAY** assign meaning to particular elements of the document
 structure, such as resource attributes or members of meta objects, and even
-reserved query parameters, such as `filter`. The scope of a profile **MUST** be
-clearly delineated. The elements reserved by a profile, and the meaning assigned
-to those elements, **MUST NOT** change over time or else the profile **MUST** be
-considered a new profile with a new URI. However, a profile **MAY** evolve
-additively within the scope originally claimed by the profile.
+to query parameters whose behavior is left up to each implementation, such 
+as `filter` and all those that contain a non a-z character.
+
+The scope of a profile **MUST** be clearly delineated. The elements reserved by 
+a profile, and the meaning assigned to those elements, **MUST NOT** change over 
+time or else the profile **MUST** be considered a new profile with a new URI. 
+
+However, a profile **MAY** evolve additively within the scope originally claimed 
+by the profile.
 
 For example, let's say that a profile reserves a `timestamps` member in the
 `meta` object of every resource. Originally, this profile defines the value

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1945,7 +1945,41 @@ Bad Request` status code.
 > with some extra information, as described in the requested profile. By
 > contrast, when a client lists a profile in the `profile` *query parameter*,
 > it's asking the server to *process the incoming request* according to the
-> rules of the profile.
+> rules of the profile. This can fundamentally change the meaning of the 
+> server's response.
+
+#### <a href="#profile-query-parameter-omitting" id="profile-query-parameter" class="headerlink"></a> Omitting the `profile` Query Parameter
+
+A server **MAY** define an internal mapping from query parameter names to 
+profile URIs. The profile URI for a query parameter name in this mapping 
+**MUST NOT** change over time.
+
+If a requested URL does not contain the `profile` query parameter and does 
+contain one or more query parameters in the server's internal mapping, the 
+server may act as though the request URL contained a `profile` query parameter 
+whose value was the comma-separated list of each profile URI found in the 
+server's internal mapping for the query parameters in use on the request.
+
+For example, the server might support a profile that defines a meaning for the
+values of the `filter` query param. Then, it could define its internal 
+param name to profile uri mapping like so:
+
+```json
+{ "filter": "https://example.com/my-filter-profile" }
+```
+
+Accordingly, when a request for 
+
+```
+https://example.com/?filter=xyz
+```
+
+would be interpreted by the server as:
+
+```
+https://example.com/?filter=xyz&profile=https://example.com/my-filter-profile
+```
+
 
 ### <a href="#profile-keywords-and-aliases" id="profile-keywords-and-aliases" class="headerlink"></a> Profile Keywords and Aliases
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1831,18 +1831,16 @@ A profile is a separate specification defining these additional semantics.
 [RFC 6906](https://tools.ietf.org/html/rfc6906) covers the nature of profile
 identification:
 
-> Profiles are identified by URI. However, as is the case with, for
-  example, XML namespace URIs, the URI in this case only serves as an
-  identifier, meaning that the presence of a specific URI has to be
-  sufficient for a client to assert that a resource representation
-  conforms to a profile. Thus, clients SHOULD treat profile URIs as
-  identifiers and not as links.
+> Profiles are identified by URI... The presence of a specific URI has to be
+  sufficient for a client to assert that a resource representation conforms to 
+  a profile [regardless of any content that may or may not be available at that 
+  URI].
 
-However, to aid human understanding, profile URIs **SHOULD** return
+However, to aid human understanding, visiting a profile's URI **SHOULD** return
 documentation of the profile.
 
 The following example profile reserves a `timestamps` member in the `meta`
-object of every resource:
+object of every resource object:
 
 <a id="profiles-timestamp-profile"></a>
 ```text
@@ -1865,8 +1863,10 @@ Every resource object **MAY** include a `timestamps` member in its associated
 * `created`
 * `updated`
 
-The value of each member **MUST** comply with the ISO 8601 standard. Any 
-unrecognized members in this object **MUST** be ignored by the application 
+The value of each member **MUST** comply with the variant of ISO 8601 used by 
+JavaScript's `JSON.stringify` method to format Javascript `Date` objects. 
+
+Any unrecognized members in this object **MUST** be ignored by the application 
 processing the document. 
 
 ## Keywords
@@ -1906,7 +1906,7 @@ Accept: application/vnd.api+json;profile="http://example.com/extensions/last-mod
 Servers **MAY** add profiles to a JSON API document even if the client has not
 requested them. The recipient of a document **MUST** ignore any profile extensions
 in that document that it does not understand. The only exception to this is profiles
-whose support is required using the `profile` query parameter, as described below.
+whose support is required using the `profile` query parameter, as described later.
 
 #### <a href="#profiles-sending" id="profiles-sending" class="headerlink"></a> Sending Profiled Documents
 
@@ -2052,10 +2052,10 @@ For example, it would be illegal for a profile to define a new key in a
 document's [top-level][top level] object, or in a [links object], as JSON API 
 implementations are not allowed to add custom keys in those areas.
 
-Likewise, a profile **MAY** assign a meaning to query parameters whose behavior 
-is left up to each implementation, such as `filter` and all those that contain a 
-non a-z character. However, profiles **MUST NOT** assign a meaning to query 
-parameters that [are reserved](#query-parameters).
+Likewise, a profile **MAY** assign a meaning to query parameters or parameter 
+values whose details are left up to each implementation, such as `filter` and 
+all those that parameters that contain a non a-z character. However, profiles 
+**MUST NOT** assign a meaning to query parameters that [are reserved](#query-parameters).
 
 The meaning of an element defined by a profile **MUST NOT** vary based on the 
 presence or absence of other profiles.

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -111,8 +111,8 @@ The top-level [links object][links] **MAY** contain the following members:
 * `self`: the [link][links] that generated the current response document.
 * `related`: a [related resource link] when the primary data represents a
   resource relationship.
-* `profile`: an array of [links][link], each giving the URI of a
-  [profile][profiles] in use in the document.
+* `profile`: an array of [links][link], each specifying a [profile][profiles]
+  in use in the document.
 * [pagination] links for the primary data.
 
 The document's "primary data" is a representation of the resource or collection
@@ -525,10 +525,10 @@ of this member **MUST** be an object (a "links object").
 <a href="#document-links-link" id="document-links-link"></a>
 Within this object, a link **MUST** be represented as either:
 
-* a string containing the link's URL.
+* a string containing the link's URI.
 * <a id="document-links-link-object"></a>an object ("link object") which can
   contain the following members:
-  * `href`: a string containing the link's URL.
+  * `href`: a string containing the link's URI.
   * `meta`: a meta object containing non-standard meta-information about the
     link.
 
@@ -536,7 +536,7 @@ Except for the `profile` key, each key present in a links object **MUST** have
 a single link as its value. The `profile` key, if present, **MUST** hold an
 array of links.
 
-For example, the following `self` link is simply a URL:
+For example, the following `self` link is simply a URI:
 
 ```json
 "links": {
@@ -544,7 +544,7 @@ For example, the following `self` link is simply a URL:
 }
 ```
 
-By contrast, the following `related` link includes a URL as well as
+By contrast, the following `related` link includes a URI as well as
 meta-information about a related resource collection:
 
 ```json

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -2157,6 +2157,12 @@ The scope of a profile **MUST** be clearly delineated. The elements reserved by
 a profile, and the meaning assigned to those elements, **MUST NOT** change over
 time or else the profile **MUST** be considered a new profile with a new URI.
 
+> Note: When a profile changes its URI, a huge amount of interoperability is lost.
+> Users that reference the new URI will not have their messages understood by
+> implementations still aware only of the old URI, and vice-versa. Accordingly,
+> it's important to design your profile so that it can evolve without its URI
+> needing to change. See ["Revising a Profile"](#profiles-updating) for details.
+
 Finally, a profile **MUST NOT**:
 
 1. assume that, if it is supported, then other specific profiles will be 
@@ -2167,25 +2173,60 @@ supported as well.
 3. alter the JSON structure of any concept defined in this specification, 
 including to allow a superset of JSON structures.
 
-Profiles **MAY** be updated over time to add new capabilities. However, any such
-changes **MUST** be [backwards and forwards compatible](http://www.w3.org/2001/tag/doc/versioning-compatibility-strategies#terminology),
-in order to not break existing users of the profile. This requirement usually
-limits changes to adding optional keys within objects specified in the profile's
-original definition.
+#### <a href="#profiles-updating" id="profiles-updating" class="headerlink"></a> Revising a Profile
 
-The hypothetical [timestamps profile], for example, could evolve to allow other 
-optional members, such as `deleted`, in the `timestamps` object. But it could 
-not make that member required, nor could it introduce a new sibling to `timestamps`.
+Profiles **MAY** be revised over time, e.g., to add new capabilities. However, 
+any such changes **MUST** be [backwards and forwards compatible](http://www.w3.org/2001/tag/doc/versioning-compatibility-strategies#terminology) 
+("compatible evolution"), in order to not break existing users of the profile.
 
-To aid evoluation and interoperability, profiles **SHOULD** reserve an
-object-valued member anywhere they expect to potentially add new features over
-time.
+For example, the hypothetical [timestamps profile] *could not* introduce a new,
+required `deleted` member within the `timestamps` object, as that would be 
+incompatible with existing deployments of the profile, which would not include 
+this new member.
 
-> Note: When a profile changes its URI, a huge amount of interoperability is lost.
-> Users that reference the new URI will have their messages not understood by
-> implementations still aware only of the old URI, and vice-versa.
-> Accordingly, the advice above is aimed at allowing profifiles to grow
-> without needing to change their URI.
+The timestamps profile also *could not* evolve to define a new element as a 
+sibling of the `timestamps` key, as that would be incompatible with the rule 
+that "The elements reserved by profile... **MUST NOT** change over time."
+
+> The practical issue with adding a sibling element is that another profile 
+> in use on the document might already define a sibling element of the same 
+> name, and existing documents would not have any aliases defined to resolve 
+> this conflict.
+
+However, the timestamps profile could evolve to allow other optional members, 
+such as `deleted`, in the `timestamps` object. This is possible because the 
+`timestamps` object is already a reserved element of the profile, and the profile
+is subject to the default rule that new (previously unrecognized) keys will
+simply be ignored by existing applications.
+
+##### <a href="#profiles-design-for-evolution" id="profiles-design-for-evolution" class="headerlink"></a> Designing Profiles to Evolve Over Time
+
+Fundamentally, for a profile to be able to change in a compatible way over time, 
+it must define -- from the beginning -- a rule describing how an application 
+that is only familiar with the original version of the profile should process 
+documents/requests that use features from an updated version of the profile.
+
+One major approach is to simply have applications ignore (at least some types of) 
+unrecognized data. This allows the profile to define new, optional features; 
+old applications will continue to work, but simply won't process/"see" these new 
+capabilities.
+
+This is essentially the strategy that JSON:API itself uses when it says that:
+
+> Client and server implementations **MUST** ignore members not recognized by 
+> this specification.
+
+Other protocols use analogous strategies. E.g., in HTTP, unknown headers are 
+simply ignored; they don't crash the processing of the request/response.
+
+As a profile author, you may define your own rules for how applications should 
+process uses of the profile that contain unrecognized data, or you may simply 
+allow the default rules described in the ["Processing Profiled Documents/Requests"](#profiles-processing)
+to take effect.
+
+If you choose to use the default rules, you **SHOULD** reserve an object-valued 
+element anywhere you expect to potentially add new features over time.
+
 ## <a href="#errors" id="errors" class="headerlink"></a> Errors
 
 ### <a href="#errors-processing" id="errors-processing" class="headerlink"></a> Processing Errors

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -537,19 +537,13 @@ Except for the `profile` key, each key present in a links object **MUST** have
 a single link as its value. The `profile` key, if present, **MUST** hold an
 array of links.
 
-For example, the following `self` link is simply a URI:
+In the example below, the `self` link is simply a URI string, whereas the 
+`related` link uses the object form to provide meta information about a 
+related resource collection:
 
 ```json
 "links": {
-  "self": "http://example.com/posts"
-}
-```
-
-By contrast, the following `related` link includes a URI as well as
-meta-information about a related resource collection:
-
-```json
-"links": {
+  "self": "http://example.com/articles/1",
   "related": {
     "href": "http://example.com/articles/1/comments",
     "meta": {
@@ -561,9 +555,9 @@ meta-information about a related resource collection:
 
 #### <a href="#profile-links" id="profile-links" class="headerlink"></a> Profile Links
 
-Each link in an array of `profile` links **MAY** be represented by a links
-object. This object **MAY** contain an `aliases` member to represent
-any [profile aliases].
+Like all [links][link], a link in an array of `profile` links can be represented
+with a [link object]. In that case, the link object **MAY** contain an `aliases` 
+member listing any [profile aliases].
 
 Here, the `profile` key specifies an array of `profile` links, including one
 that includes a [profile alias][profile aliases]:
@@ -1875,9 +1869,9 @@ significant timestamps in a consistent way.
 
 ## Document Structure
 
-Every resource **MAY** include a `timestamps` member in its associated `meta`
-object. If this member is present, its value **MUST** be an object that **MAY**
-contain any of the following members:
+Every resource object **MAY** include a `timestamps` member in its associated 
+`meta` object. If this member is present, its value **MUST** be an object that 
+**MAY** contain any of the following members:
 
 * `created`
 * `updated`
@@ -1908,7 +1902,7 @@ time.
 ### <a href="#profile-media-type-parameter" id="profile-media-type-parameter" class="headerlink"></a> `profile` Media Type Parameter
 
 The `profile` media type parameter is used to describe the application of
-one or more profiles to the JSON API media type. The value of the `profile`
+one or more profiles to a JSON API document. The value of the `profile`
 parameter **MUST** equal a space-separated (U+0020 SPACE, " ") list of profile URIs.
 
 > Note: When serializing the `profile` media type parameter, the HTTP
@@ -2129,6 +2123,7 @@ An error object **MAY** have the following members:
 [meta]: #document-meta
 [links]: #document-links
 [link]: #document-links-link
+[link object]: #document-links-link-object
 [profiles]: #profiles
 [profile aliases]: #profile-keywords-and-aliases
 [error details]: #errors

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1878,10 +1878,6 @@ parameter **MUST** equal a whitespace-separated list of profile URIs.
 > specification requires that its value be surrounded by quotation marks 
 > (U+0022 QUOTATION MARK, "\"") if it contains more than one URI.
 
-Clients and servers **MUST** include the `profile` media type parameter in
-conjunction with the JSON API media type in a `Content-Type` header to indicate
-that they have applied one or more profiles to a JSON API document.
-
 A client **MAY** use the `profile` media type parameter in conjunction with the
 JSON API media type in an `Accept` header to _request_, but not _require_, that
 the server apply one or more profiles to the response document. When such a 
@@ -1903,6 +1899,26 @@ Servers **MAY** add profiles to a JSON API document even if the client has not
 requested them. The recipient of a document **MUST** ignore any profile extensions 
 in that document that it does not understand. The only exception to this is profiles
 whose support is required using the `profile` query parameter, as described below.
+
+#### <a href="#profiles-sending" id="profiles-sending" class="headerlink"></a> Sending Profiled Documents
+
+Clients and servers **MUST** include the `profile` media type parameter in
+conjunction with the JSON API media type in a `Content-Type` header to indicate
+that they have applied one or more profiles to a JSON API document.
+
+When an older JSON API server that doesn't support the `profile` media type 
+parameter receives a document with one or more profiles, it will respond with a
+`415 Unsupported Media Type` error.
+
+After attempting to rule out other possible causes of this error, a client that
+receives a `415 Unsupported Media Type` **SHOULD** remove the profile extensions
+it has applied to the document and retry its request without the `profile` media
+type parameter. If this resolves the error, the client **SHOULD NOT** attempt to
+use profile extensions in subsequent interactions with the same API.
+
+> The most likely other causes of a 415 error are that the server doesn't
+support JSON API at all or that the client has failed to provide a required 
+profile.
 
 ### <a href="#profile-query-parameter" id="profile-query-parameter" class="headerlink"></a> `profile` Query Parameter
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1985,9 +1985,15 @@ https://example.com/?filter=xyz&profile=https://example.com/my-filter-profile
 
 A profile **SHOULD** explicitly declare "keywords" for any elements that it
 introduces to the document structure. If a profile does not explicitly declare a
-keyword for an element, then the name of the element itself is considered to be
-its keyword. All profile keywords **MUST** meet this specification's
-requirements for [member names].
+keyword for an element, then the name of the element itself (i.e., its key in
+the document) is considered to be its keyword. All profile keywords **MUST** 
+meet this specification's requirements for [member names].
+
+For the purposes of aliasing, a profiles elements are defined shallowly. 
+In other words, if a profile introduces an object-valued document member, that 
+member is an element (and so subject to aliasing), but any keys in it are not 
+themselves elements. Likewise, if the profile defines an array-valued element, 
+the keys in nested objects within that array are not elements.
 
 The following example profile defines a single keyword, `version`:
 
@@ -2075,10 +2081,10 @@ key `version` described in the profile:
 ### <a href="#profiles-processing" id="profiles-processing" class="headerlink"></a> Processing Profiled Documents/Requests
 
 When a profile is applied to a request and/or document, the value used for each 
-of the profile's elements (document members or query parameters) is said to be 
-"a recognized value" if that value, including all parts of it, has a legal, 
-defined meaning *according to the latest revision of the profile that the 
-application is aware of*.
+of the profile's document members or query parameters is said to be "a 
+recognized value" if that value, including all parts of it, has a legal, defined
+meaning *according to the latest revision of the profile that the application is 
+aware of*.
 
 > Note: The set of recognized values is also/more technically known as the 
 > [defined text set](http://www.w3.org/2001/tag/doc/versioning-compatibility-strategies#terminology).
@@ -2184,11 +2190,11 @@ values whose details are left up to each implementation, such as `filter` and
 all those that parameters that contain a non a-z character. However, profiles 
 **MUST NOT** assign a meaning to query parameters that [are reserved](#query-parameters).
 
-The meaning of an element defined by a profile **MUST NOT** vary based on the 
-presence or absence of other profiles.
+The meaning of an element or query parameter defined by a profile **MUST NOT** 
+vary based on the presence or absence of other profiles.
 
-The scope of a profile **MUST** be clearly delineated. The elements reserved by
-a profile, and the meaning assigned to those elements, **MUST NOT** change over
+The scope of a profile **MUST** be clearly delineated. The elements and query 
+parameters specified by a profile, and their meanings, **MUST NOT** change over
 time or else the profile **MUST** be considered a new profile with a new URI.
 
 > Note: When a profile changes its URI, a huge amount of interoperability is lost.
@@ -2220,7 +2226,7 @@ this new member.
 
 The timestamps profile also *could not* evolve to define a new element as a 
 sibling of the `timestamps` key, as that would be incompatible with the rule 
-that "The elements reserved by profile... **MUST NOT** change over time."
+that "The elements... specified by a profile... **MUST NOT** change over time."
 
 > The practical issue with adding a sibling element is that another profile 
 > in use on the document might already define a sibling element of the same 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1825,6 +1825,8 @@ JSON API supports the use of "profiles" as a way to indicate additional
 semantics that apply to a JSON:API request/document, without altering the
 basic semantics described in this specification.
 
+A profile is a separate specification defining these additional semantics. 
+
 [RFC 6906](https://tools.ietf.org/html/rfc6906) covers the nature of profile
 identification:
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1950,14 +1950,18 @@ Bad Request` status code.
 
 #### <a href="#profile-query-parameter-omitting" id="profile-query-parameter" class="headerlink"></a> Omitting the `profile` Query Parameter
 
-A server **MAY** define an internal mapping from query parameter names to 
-profile URIs. The profile URI for a query parameter name in this mapping 
+Requiring the client to specify the `profile` query parameter would be 
+cumbersome. Accordingly, JSON:API defines a way that server's may infer its 
+value in many cases.
+
+To do so, a server **MAY** define an internal mapping from query parameter names 
+to profile URIs. The profile URI for a query parameter name in this mapping 
 **MUST NOT** change over time.
 
 If a requested URL does not contain the `profile` query parameter and does 
 contain one or more query parameters in the server's internal mapping, the 
 server may act as though the request URL contained a `profile` query parameter 
-whose value was the comma-separated list of each profile URI found in the 
+whose value was the comma-separated list of each unique profile URI found in the 
 server's internal mapping for the query parameters in use on the request.
 
 For example, the server might support a profile that defines a meaning for the
@@ -1968,7 +1972,7 @@ param name to profile uri mapping like so:
 { "filter": "https://example.com/my-filter-profile" }
 ```
 
-Accordingly, when a request for 
+Accordingly, a request for:
 
 ```
 https://example.com/?filter=xyz
@@ -1989,7 +1993,7 @@ keyword for an element, then the name of the element itself (i.e., its key in
 the document) is considered to be its keyword. All profile keywords **MUST** 
 meet this specification's requirements for [member names].
 
-For the purposes of aliasing, a profiles elements are defined shallowly. 
+For the purposes of aliasing, a profile's elements are defined shallowly. 
 In other words, if a profile introduces an object-valued document member, that 
 member is an element (and so subject to aliasing), but any keys in it are not 
 themselves elements. Likewise, if the profile defines an array-valued element, 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1961,8 +1961,9 @@ to profile URIs. The profile URI for a query parameter name in this mapping
 If a requested URL does not contain the `profile` query parameter and does 
 contain one or more query parameters in the server's internal mapping, the 
 server may act as though the request URL contained a `profile` query parameter 
-whose value was the comma-separated list of each unique profile URI found in the 
-server's internal mapping for the query parameters in use on the request.
+whose value was the URI-encoded space-separated list of each unique profile URI 
+found in the server's internal mapping for the query parameters in use on the 
+request.
 
 For example, the server might support a profile that defines a meaning for the
 values of the `filter` query param. Then, it could define its internal 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1825,7 +1825,7 @@ to standard query parameters without conflicting with existing implementations.
 ## <a href="#profiles" id="profiles" class="headerlink"></a> Profiles
 
 JSON API supports the use of "profiles" as a way to indicate additional
-semantics that apply to a JSON:API request/document, without altering the 
+semantics that apply to a JSON:API request/document, without altering the
 basic semantics described in this specification.
 
 [RFC 6906](https://tools.ietf.org/html/rfc6906) covers the nature of profile
@@ -1838,19 +1838,19 @@ identification:
   conforms to a profile. Thus, clients SHOULD treat profile URIs as
   identifiers and not as links.
 
-However, to aid human understanding, profile URIs **SHOULD** return 
+However, to aid human understanding, profile URIs **SHOULD** return
 documentation of the profile.
 
 A profile **MAY** assign meaning to particular elements of the document
 structure, such as resource attributes or members of meta objects, and even
-to query parameters whose behavior is left up to each implementation, such 
+to query parameters whose behavior is left up to each implementation, such
 as `filter` and all those that contain a non a-z character.
 
-The scope of a profile **MUST** be clearly delineated. The elements reserved by 
-a profile, and the meaning assigned to those elements, **MUST NOT** change over 
-time or else the profile **MUST** be considered a new profile with a new URI. 
+The scope of a profile **MUST** be clearly delineated. The elements reserved by
+a profile, and the meaning assigned to those elements, **MUST NOT** change over
+time or else the profile **MUST** be considered a new profile with a new URI.
 
-Profiles **MAY** be updated over time to add new capabilities. However, any such 
+Profiles **MAY** be updated over time to add new capabilities. However, any such
 changes **MUST** be [backwards and forwards compatible](http://www.w3.org/2001/tag/doc/versioning-compatibility-strategies#terminology),
 in order to not break existing users of the profile. This requirement usually
 limits changes to adding optional keys within objects specified in the profile's
@@ -1864,12 +1864,12 @@ object. But it could not make that member required, nor could it introduce
 a new sibling to `timestamps`.
 
 Profiles **SHOULD** reserve at least one object-valued member, and **SHOULD**
-consider reserving an object-valued member anywhere they expect to potentially 
+consider reserving an object-valued member anywhere they expect to potentially
 add new features over time.
 
 > Note: When a profile changes its URI, a huge amount of interoperability is lost.
 > Users that reference the new URI will have their messages not understood by
-> implementations still aware only of the old URI, and vice-versa. 
+> implementations still aware only of the old URI, and vice-versa.
 > Accordingly, the advice above is aimed at allowing profifiles to grow
 > without needing to change their URI.
 
@@ -1889,14 +1889,14 @@ The `profile` media type parameter is used to describe the application of
 one or more profiles to the JSON API media type. The value of the `profile`
 parameter **MUST** equal a space-separated (U+0020 SPACE, " ") list of profile URIs.
 
-> Note: When serializing the `profile` media type parameter, the HTTP 
-> specification requires that its value be surrounded by quotation marks 
+> Note: When serializing the `profile` media type parameter, the HTTP
+> specification requires that its value be surrounded by quotation marks
 > (U+0022 QUOTATION MARK, "\"") if it contains more than one URI.
 
 A client **MAY** use the `profile` media type parameter in conjunction with the
 JSON API media type in an `Accept` header to _request_, but not _require_, that
-the server apply one or more profiles to the response document. When such a 
-request is received, a server **SHOULD** attempt to apply the requested profiles 
+the server apply one or more profiles to the response document. When such a
+request is received, a server **SHOULD** attempt to apply the requested profiles
 to its response.
 
 For example, in the following request, the client asks that the server apply the
@@ -1911,7 +1911,7 @@ Accept: application/vnd.api+json;profile="http://jsonapi.org/extensions/last-mod
   It is used to support old servers that don't understand the profile parameter.
 
 Servers **MAY** add profiles to a JSON API document even if the client has not
-requested them. The recipient of a document **MUST** ignore any profile extensions 
+requested them. The recipient of a document **MUST** ignore any profile extensions
 in that document that it does not understand. The only exception to this is profiles
 whose support is required using the `profile` query parameter, as described below.
 
@@ -1921,12 +1921,12 @@ Clients and servers **MUST** include the `profile` media type parameter in
 conjunction with the JSON API media type in a `Content-Type` header to indicate
 that they have applied one or more profiles to a JSON API document.
 
-Likewise, clients and servers applying profiles to a JSON API document **MUST** 
-include a [top-level][top level] [`links` object][links] with a `profile` key, 
-and that `profile` key **MUST** include a [link] to the URI of each profile 
+Likewise, clients and servers applying profiles to a JSON API document **MUST**
+include a [top-level][top level] [`links` object][links] with a `profile` key,
+and that `profile` key **MUST** include a [link] to the URI of each profile
 that has been applied.
 
-When an older JSON API server that doesn't support the `profile` media type 
+When an older JSON API server that doesn't support the `profile` media type
 parameter receives a document with one or more profiles, it will respond with a
 `415 Unsupported Media Type` error.
 
@@ -1937,24 +1937,25 @@ type parameter. If this resolves the error, the client **SHOULD NOT** attempt to
 use profile extensions in subsequent interactions with the same API.
 
 > The most likely other causes of a 415 error are that the server doesn't
-support JSON API at all or that the client has failed to provide a required 
+support JSON API at all or that the client has failed to provide a required
 profile.
 
 ### <a href="#profile-query-parameter" id="profile-query-parameter" class="headerlink"></a> `profile` Query Parameter
 
 A client **MAY** use the `profile` query parameter to _require_ the server to
-apply one or more profiles when processing the request. The value of the `profile` 
+apply one or more profiles when processing the request. The value of the `profile`
 query parameter **MUST** equal a URI-encoded whitespace-separated list of profile URIs.
 
 If a server receives a request requiring the application of a profile or
 combination of profiles that it can not apply, it **MUST** respond with a `400
 Bad Request` status code.
 
-> Note: When a client lists a profile in the `Accept` header, it's asking the server
-> to compute its response as normal, but then send the response document with some
-> extra information, as described in the requested profile. By contrarst, when a client 
-> lists a profile in the `profile` *query parameter*, it's asking the server to *process
-> the incoming request* according to the rules of the profile.
+> Note: When a client lists a profile in the `Accept` header, it's asking the
+> server to compute its response as normal, but then send the response document
+> with some extra information, as described in the requested profile. By
+> contrast, when a client lists a profile in the `profile` *query parameter*,
+> it's asking the server to *process the incoming request* according to the
+> rules of the profile.
 
 ### <a href="#profile-descriptors" id="profile-descriptors" class="headerlink"></a> Profile Descriptors
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -5,7 +5,8 @@ version: 1.1
 ## <a href="#introduction" id="introduction" class="headerlink"></a> Introduction
 
 JSON API is a specification for how a client should request that resources be
-fetched or modified, and how a server should respond to those requests.
+fetched or modified, and how a server should respond to those requests. JSON API
+can also be easily extended with [profiles].
 
 JSON API is designed to minimize both the number of requests and the amount of
 data transmitted between clients and servers. This efficiency is achieved
@@ -110,6 +111,8 @@ The top-level [links object][links] **MAY** contain the following members:
 * `self`: the [link][links] that generated the current response document.
 * `related`: a [related resource link] when the primary data represents a
   resource relationship.
+* `profile`: an array of [links][link], each giving the URI of a
+  [profile][profiles] in use in the document.
 * [pagination] links for the primary data.
 
 The document's "primary data" is a representation of the resource or collection
@@ -517,10 +520,10 @@ For example:
 ### <a href="#document-links" id="document-links" class="headerlink"></a> Links
 
 Where specified, a `links` member can be used to represent links. The value
-of each `links` member **MUST** be an object (a "links object").
+of this member **MUST** be an object (a "links object").
 
-Each member of a links object is a "link". A link **MUST** be represented as
-either:
+<a href="#document-links-link" id="document-links-link"></a>
+Within this object, a link **MUST** be represented as either:
 
 * a string containing the link's URL.
 * <a id="document-links-link-object"></a>an object ("link object") which can
@@ -529,7 +532,11 @@ either:
   * `meta`: a meta object containing non-standard meta-information about the
     link.
 
-The following `self` link is simply a URL:
+Except for the `profile` key, each key present in a links object **MUST** have
+a single link as its value. The `profile` key, if present, **MUST** hold an
+array of links.
+
+For example, the following `self` link is simply a URL:
 
 ```json
 "links": {
@@ -537,8 +544,8 @@ The following `self` link is simply a URL:
 }
 ```
 
-The following `related` link includes a URL as well as meta-information
-about a related resource collection:
+By contrast, the following `related` link includes a URL as well as
+meta-information about a related resource collection:
 
 ```json
 "links": {
@@ -548,6 +555,14 @@ about a related resource collection:
       "count": 10
     }
   }
+}
+```
+
+Here, the `profile` key specifies an array of `profile` links:
+
+```json
+"links": {
+  "profile": [{ "href": "http://jsonapi.org/ext/example-ext" }]
 }
 ```
 
@@ -1852,7 +1867,7 @@ Profiles **SHOULD** reserve at least one object-valued member, and **SHOULD**
 consider reserving an object-valued member anywhere they expect to potentially 
 add new features over time.
 
-> Note: hen a profile changes its URI, a huge amount of interoperability is lost.
+> Note: When a profile changes its URI, a huge amount of interoperability is lost.
 > Users that reference the new URI will have their messages not understood by
 > implementations still aware only of the old URI, and vice-versa. 
 > Accordingly, the advice above is aimed at allowing profifiles to grow
@@ -1872,7 +1887,7 @@ All profile keywords **MUST** meet this specification's requirements for [member
 
 The `profile` media type parameter is used to describe the application of
 one or more profiles to the JSON API media type. The value of the `profile`
-parameter **MUST** equal a whitespace-separated list of profile URIs.
+parameter **MUST** equal a space-separated (U+0020 SPACE, " ") list of profile URIs.
 
 > Note: When serializing the `profile` media type parameter, the HTTP 
 > specification requires that its value be surrounded by quotation marks 
@@ -1905,6 +1920,11 @@ whose support is required using the `profile` query parameter, as described belo
 Clients and servers **MUST** include the `profile` media type parameter in
 conjunction with the JSON API media type in a `Content-Type` header to indicate
 that they have applied one or more profiles to a JSON API document.
+
+Likewise, clients and servers applying profiles to a JSON API document **MUST** 
+include a [top-level][top level] [`links` object][links] with a `profile` key, 
+and that `profile` key **MUST** include a [link] to the URI of each profile 
+that has been applied.
 
 When an older JSON API server that doesn't support the `profile` media type 
 parameter receives a document with one or more profiles, it will respond with a
@@ -2025,6 +2045,7 @@ An error object **MAY** have the following members:
 * `meta`: a [meta object][meta] containing non-standard meta-information about the
   error.
 
+[top level]: #document-top-level
 [resource objects]: #document-resource-objects
 [attributes]: #document-resource-object-attributes
 [relationships]: #document-resource-object-relationships
@@ -2036,6 +2057,8 @@ An error object **MAY** have the following members:
 [compound document]: #document-compound-documents
 [meta]: #document-meta
 [links]: #document-links
+[profiles]: #profiles
 [error details]: #errors
+[error objects]: #errror-objects
 [member names]: #document-member-names
 [pagination]: #fetching-pagination

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -2129,6 +2129,7 @@ An error object **MAY** have the following members:
 [compound document]: #document-compound-documents
 [meta]: #document-meta
 [links]: #document-links
+[link]: #document-links-link
 [profiles]: #profiles
 [profile aliases]: #profile-keywords-and-aliases
 [error details]: #errors

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1805,7 +1805,7 @@ responses, in accordance with
 
 ## <a href="#query-parameters" id="query-parameters" class="headerlink"></a> Query Parameters
 
-Implementation specific query parameter names **MUST** adhere to the same
+Implementation-specific query parameter names **MUST** adhere to the same
 constraints as [member names], with the additional requirement that they
 **MUST** contain at least one non a-z character (i.e., outside U+0061 to U+007A).
 
@@ -1816,8 +1816,9 @@ If a server encounters a query parameter that does not follow the naming
 conventions above, and the server does not know how to process it as a query
 parameter from this specification, it **MUST** return `400 Bad Request`.
 
-> Note: This is to preserve the ability of JSON API to make additive additions
-to standard query parameters without conflicting with existing implementations.
+> Note: By forbidding the use of query parameters that contain only the characters
+> \[a-z\], JSON API is reserving the ability to standardize additional query
+> parameters later without conflicting with existing implementations.
 
 ## <a href="#profiles" id="profiles" class="headerlink"></a> Profiles
 
@@ -2042,14 +2043,36 @@ key `version` described in the profile:
 
 ### <a href="#profiles-authoring" id="profiles-authoring" class="headerlink"></a> Authoring Profiles
 
-A profile **MAY** assign meaning to particular elements of the document
-structure, such as resource attributes or members of meta objects, and even
-to query parameters whose behavior is left up to each implementation, such
-as `filter` and all those that contain a non a-z character.
+A profile **MAY** assign meaning to elements of the document structure whose use
+is left up to each implementation, such as resource fields or members of meta
+objects. A profile **MUST NOT** define/assign a meaning to document members 
+in areas of the document reserved for future use by the JSON API specification. 
+
+For example, it would be illegal for a profile to define a new key in a 
+document's [top-level][top level] object, or in a [links object], as JSON API 
+implementations are not allowed to add custom keys in those areas.
+
+Likewise, a profile **MAY** assign a meaning to query parameters whose behavior 
+is left up to each implementation, such as `filter` and all those that contain a 
+non a-z character. However, profiles **MUST NOT** assign a meaning to query 
+parameters that [are reserved](#query-parameters).
+
+The meaning of an element defined by a profile **MUST NOT** vary based on the 
+presence or absence of other profiles.
 
 The scope of a profile **MUST** be clearly delineated. The elements reserved by
 a profile, and the meaning assigned to those elements, **MUST NOT** change over
 time or else the profile **MUST** be considered a new profile with a new URI.
+
+Finally, a profile **MUST NOT**:
+
+1. assume that, if it is supported, then other specific profiles will be 
+supported as well.
+
+2. define fixed endpoints, HTTP headers, or header values.
+
+3. alter the JSON structure of any concept defined in this specification, 
+including to allow a superset of JSON structures.
 
 Profiles **MAY** be updated over time to add new capabilities. However, any such
 changes **MUST** be [backwards and forwards compatible](http://www.w3.org/2001/tag/doc/versioning-compatibility-strategies#terminology),

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1029,13 +1029,12 @@ example, a response to a request for `comments.author` should include `comments`
 as well as the `author` of each of those `comments`.
 
 > Note: A server may choose to expose a deeply nested relationship such as
-`comments.author` as a direct relationship with an alias such as
+`comments.author` as a direct relationship with an alternative name such as
 `comment-authors`. This would allow a client to request
 `/articles/1?include=comment-authors` instead of
-`/articles/1?include=comments.author`. By abstracting the nested
-relationship with an alias, the server can still provide full linkage in
-compound documents without including potentially unwanted intermediate
-resources.
+`/articles/1?include=comments.author`. By exposing the nested relationship with 
+an alternative name, the server can still provide full linkage in compound 
+documents without including potentially unwanted intermediate resources.
 
 Multiple related resources can be requested in a comma-separated list:
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1835,8 +1835,11 @@ The scope of a profile **MUST** be clearly delineated. The elements reserved by
 a profile, and the meaning assigned to those elements, **MUST NOT** change over 
 time or else the profile **MUST** be considered a new profile with a new URI. 
 
-However, a profile **MAY** evolve additively within the scope originally claimed 
-by the profile.
+Profiles **MAY** be updated over time to add new capabilities. However, any such 
+changes **MUST** be [backwards and forwards compatible](http://www.w3.org/2001/tag/doc/versioning-compatibility-strategies#terminology),
+in order to not break existing users of the profile. This requirement usually
+limits changes to adding optional keys within objects specified in the profile's
+original definition.
 
 For example, let's say that a profile reserves a `timestamps` member in the
 `meta` object of every resource. Originally, this profile defines the value

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1845,6 +1845,16 @@ profile could evolve to allow an optional member, `updated`, in the `timestamps`
 object. But it could not make that member required, nor could it introduce
 a new sibling to `timestamps`.
 
+Profiles **SHOULD** reserve at least one object-valued member, and **SHOULD**
+consider reserving an object-valued member anywhere they expect to potentially 
+add new features over time.
+
+> Note: hen a profile changes its URI, a huge amount of interoperability is lost.
+> Users that reference the new URI will have their messages not understood by
+> implementations still aware only of the old URI, and vice-versa. 
+> Accordingly, the advice above is aimed at allowing profifiles to grow
+> without needing to change their URI.
+
 ### <a href="#profile-keywords" id="profile-keywords" class="headerlink"></a> Profile Keywords
 
 A profile **SHOULD** explicitly declare "keywords" for any elements that it

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -562,7 +562,7 @@ Here, the `profile` key specifies an array of `profile` links:
 
 ```json
 "links": {
-  "profile": [{ "href": "http://jsonapi.org/ext/example-ext" }]
+  "profile": [{ "href": "http://jsonapi.org/profiles/example-profile" }]
 }
 ```
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1878,7 +1878,9 @@ Every resource object **MAY** include a `timestamps` member in its associated
 * `created`
 * `updated`
 
-The value of each member **MUST** comply with the ISO 8601 standard.
+The value of each member **MUST** comply with the ISO 8601 standard. Any 
+unrecognized members in this object **MUST** be ignored by the application 
+processing the document. 
 
 ## Keywords
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1879,20 +1879,25 @@ that they have applied one or more profiles to a JSON API document.
 
 A client **MAY** use the `profile` media type parameter in conjunction with the
 JSON API media type in an `Accept` header to _request_, but not _require_, that
-the server apply one or more profiles to the response. When such a request is
-received, a server **SHOULD** attempt to apply the requested profiles in
-processing a response.
+the server apply one or more profiles to the response document. When such a 
+request is received, a server **SHOULD** attempt to apply the requested profiles 
+to its response.
 
 ### <a href="#profile-query-parameter" id="profile-query-parameter" class="headerlink"></a> `profile` Query Parameter
 
-A client **MAY** use the `profile` query parameter to _require_ the application
-of one or more profiles to the JSON API media type in processing a request. The
-value of the `profile` query parameter **MUST** equal a URI-encoded
-whitespace-separated list of profile URIs.
+A client **MAY** use the `profile` query parameter to _require_ the server to
+apply one or more profiles when processing the request. The value of the `profile` 
+query parameter **MUST** equal a URI-encoded whitespace-separated list of profile URIs.
 
 If a server receives a request requiring the application of a profile or
 combination of profiles that it can not apply, it **MUST** respond with a `400
 Bad Request` status code.
+
+> Note: When a client lists a profile in the `Accept` header, it's asking the server
+> to compute its response as normal, but then send the response document with some
+> extra information, as described in the requested profile. By contrarst, when a client 
+> lists a profile in the `profile` *query parameter*, it's asking the server to *process
+> the incoming request* according to the rules of the profile.
 
 ### <a href="#profile-descriptors" id="profile-descriptors" class="headerlink"></a> Profile Descriptors
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1883,6 +1883,11 @@ the server apply one or more profiles to the response document. When such a
 request is received, a server **SHOULD** attempt to apply the requested profiles 
 to its response.
 
+Servers **MAY** add profiles to a JSON API document even if the client has not
+requested them. The recipient of a document **MUST** ignore any profile extensions 
+in that document that it does not understand. The only exception to this is profiles
+whose support is required using the `profile` query parameter, as described below.
+
 ### <a href="#profile-query-parameter" id="profile-query-parameter" class="headerlink"></a> `profile` Query Parameter
 
 A client **MAY** use the `profile` query parameter to _require_ the server to

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1883,6 +1883,17 @@ the server apply one or more profiles to the response document. When such a
 request is received, a server **SHOULD** attempt to apply the requested profiles 
 to its response.
 
+For example, in the following request, the client asks that the server apply the
+`http://jsonapi.org/extensions/last-modified` profile if it is able to.
+
+```http
+Accept: application/vnd.api+json;profile="http://jsonapi.org/extensions/last-modified", application/vnd.api+json
+```
+
+> Note: The second instance of the JSON API media type in the example above is
+  required under the [client's content negotiation responsibilities](#content-negotiation-clients).
+  It is used to support old servers that don't understand the profile parameter.
+
 Servers **MAY** add profiles to a JSON API document even if the client has not
 requested them. The recipient of a document **MUST** ignore any profile extensions 
 in that document that it does not understand. The only exception to this is profiles


### PR DESCRIPTION
_Note: Although this PR has my name attached to it, it represents a lot of hard work by @ethanresnick in particular over the past several years. Ethan, @wycats, and I have closely collaborated to reach a mutually acceptable solution in an attempt to finally push this over the finish line. This may yet be tweaked a little as some last minute adjustments have yet to be reviewed by Ethan and Yehuda. And of course we welcome feedback from the rest of the community._

-----

Profiles are a means to describe additional semantics the JSON API media type, without altering the basic semantics. In other words, a profile describes a fully-compliant, yet more opinionated, implementation of the spec. It is hoped that profiles will unlock new layers of shared conventions.

A profile can essentially turn every MAY or SHOULD in the base spec into a MUST. Profiles might describe how the `filter` or `page` params are used. They might specify that every resource contains a `self` link, or that resources should include timestamps or versions as either attributes or in `meta`.

Profiles are identified by URI, which ideally should dereference to a document that describes the semantics of the profile.

One or more profiles may be associated with the JSON API media type through the `profile` media type parameter. The application of profiles to a particular document can be specified by clients and servers  via the `Content-Type` header. The application of one or more profiles to a response can be requested by a client via the `Accept` header.

In order to _require_ the application of one or more profiles, the profile(s) must be specified with the `profile` query parameter. This allows clients to request a profile or profiles and receive a hard failure if they can't be applied. 

Any structural elements introduced by a profile can be aliased. This allows for better adaptability and composition of profiles. A new profile descriptor object is introduced which allows for declarations of aliases in a particular document.

Closes #1207
Closes #1195 
Closes #762