### PR TITLE
Add swisnl/json-api-client to PHP client implementations

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -71,6 +71,7 @@ assembled to vet them.
 * [woohoolabs / yang](https://github.com/woohoolabs/yang) is a PSR-7 compatible library that is able to build and send requests, and handle responses.
 * [enm/json-api-client](https://eosnewmedia.github.io/JSON-API-Client/) is an abstract client-side PHP implementation of the json api specification, based on the PSR-7 HTTP message interface.
 * [pz/doctrine-rest](https://github.com/R3VoLuT1OneR/doctrine-rest) library provides basic tools for implementation of JSON API with Doctrine 2
+* [swisnl/json-api-client](https://github.com/swisnl/json-api-client) Is a package for mapping remote {json:api} resources to Eloquent like models and collections.
 
 ### <a href="#client-libraries-dart" id="client-libraries-dart" class="headerlink"></a> Dart
 


### PR DESCRIPTION
We created an implementation for PHP which helps using a JSON API as your data source for your application. The beauty is it helps you talk to the API with your own models.