### PR TITLE
Recommend camel cased member names

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -443,8 +443,8 @@ A complete example document with multiple included relationships:
     "type": "people",
     "id": "9",
     "attributes": {
-      "first-name": "Dan",
-      "last-name": "Gebhardt",
+      "firstName": "Dan",
+      "lastName": "Gebhardt",
       "twitter": "dgeb"
     },
     "links": {
@@ -1027,8 +1027,8 @@ as well as the `author` of each of those `comments`.
 
 > Note: A server may choose to expose a deeply nested relationship such as
 `comments.author` as a direct relationship with an alternative name such as
-`comment-authors`. This would allow a client to request
-`/articles/1?include=comment-authors` instead of
+`commentAuthors`. This would allow a client to request
+`/articles/1?include=commentAuthors` instead of
 `/articles/1?include=comments.author`. By exposing the nested relationship with 
 an alternative name, the server can still provide full linkage in compound 
 documents without including potentially unwanted intermediate resources.

--- a/examples/index.md
+++ b/examples/index.md
@@ -143,7 +143,7 @@ Content-Type: application/vnd.api+json
 
 {
   "meta": {
-    "total-pages": 13
+    "totalPages": 13
   },
   "data": [
     {
@@ -171,7 +171,7 @@ Content-Type: application/vnd.api+json
 for readability. In practice, these characters must be percent-encoded, as
 noted in the base specification.
 
-> Note: Putting a property like `"total-pages"` in `"meta"` can be a convenient way
+> Note: Putting a property like `"totalPages"` in `"meta"` can be a convenient way
 to indicate to clients the total number of pages in a collection (as opposed to
 the `"last"` link, which simply gives the URI of the last page). However, all
 `"meta"` values are implementation-specific, so you can call this member whatever
@@ -185,7 +185,7 @@ Examples of how [error objects](http://jsonapi.org/format/#error-objects) work.
 
 In the response below, the server is indicating that it encountered an error
 while creating/updating the resource, and that this error was caused
-by an invalid `"first-name"` attribute:
+by an invalid `"firstName"` attribute:
 
 ```http
 HTTP/1.1 422 Unprocessable Entity
@@ -195,7 +195,7 @@ Content-Type: application/vnd.api+json
   "errors": [
     {
       "status": "422",
-      "source": { "pointer": "/data/attributes/first-name" },
+      "source": { "pointer": "/data/attributes/firstName" },
       "title":  "Invalid Attribute",
       "detail": "First name must contain at least three characters."
     }
@@ -252,7 +252,7 @@ Content-Type: application/vnd.api+json
 
 The only uniqueness constraint on error objects is the `id` field. Thus,
 multiple errors on the same attribute can each be given their own error
-object. The example below shows multiple errors on the `"first-name"` attribute:
+object. The example below shows multiple errors on the `"firstName"` attribute:
 
 ```http
 HTTP/1.1 422 Unprocessable Entity
@@ -261,12 +261,12 @@ Content-Type: application/vnd.api+json
 {
   "errors": [
     {
-      "source": { "pointer": "/data/attributes/first-name" },
+      "source": { "pointer": "/data/attributes/firstName" },
       "title": "Invalid Attribute",
       "detail": "First name must contain at least three characters."
     },
     {
-      "source": { "pointer": "/data/attributes/first-name" },
+      "source": { "pointer": "/data/attributes/firstName" },
       "title": "Invalid Attribute",
       "detail": "First name must contain an emoji."
     }
@@ -307,7 +307,7 @@ Content-Type: application/vnd.api+json
   "errors": [
     {
       "code":   "123",
-      "source": { "pointer": "/data/attributes/first-name" },
+      "source": { "pointer": "/data/attributes/firstName" },
       "title":  "Value is too short",
       "detail": "First name must contain at least three characters."
     },

--- a/index.md
+++ b/index.md
@@ -57,8 +57,8 @@ Here's an example response from a blog that implements JSON API:
     "type": "people",
     "id": "9",
     "attributes": {
-      "first-name": "Dan",
-      "last-name": "Gebhardt",
+      "firstName": "Dan",
+      "lastName": "Gebhardt",
       "twitter": "dgeb"
     },
     "links": {

--- a/recommendations/index.md
+++ b/recommendations/index.md
@@ -10,10 +10,14 @@ are beyond the scope of the base JSON API specification.
 
 ## <a href="#naming" id="naming" class="headerlink"></a> Naming
 
-The allowed and recommended characters for an URL safe naming of members are defined in the format spec. To also standardize member names, the following (more restrictive) rules are recommended:
+The specification places certain [hard restrictions](http://jsonapi.org/format/#document-member-names) 
+on how members (i.e., keys) in a JSON:API document may named. To further 
+standardize member names, which is especially important when mixing profiles
+authored by different parties, the following rules are also recommended:
 
-- Member names **SHOULD** start and end with the characters "a-z" (U+0061 to U+007A)
-- Member names **SHOULD** contain only the characters "a-z" (U+0061 to U+007A), "0-9" (U+0030 to U+0039), and the hyphen minus (U+002D HYPHEN-MINUS, "-") as separator between multiple words.
+- Member names **SHOULD** be camel-cased (i.e., `wordWordWord`)
+- Member names **SHOULD** start and end with a character "a-z" (U+0061 to U+007A)
+- Member names **SHOULD** contain only ASCII alphanumeric characters (i.e., "a-z", "A-Z", and "0-9")
 
 ## <a href="#urls" id="urls" class="headerlink"></a> URL Design
 


### PR DESCRIPTION
@dgeb and I would like to change our current member naming recommendations from kebab-cased to camel cased. 

This recommendation is somewhat more important with the introduction of profiles, as it would be ugly if some profiles used one convention and others used another; authors would be stuck with inconsistent naming in their profiled documents.

My reasons for supporting this change to camel-case are:

- camelCased names can be used directly as identifiers in almost all programming languages, making json:api easier to get started with and to work with over time. Dasherized names are usable as identifiers pretty much only in Lisps.

- camelCased names are the most common convention in the JS community, and JS is the biggest user of JSON:API

- camelCased names are slightly shorter than dasherized (or snake-case) names, which could help with url character limits in the case of complex filters or other types of complex queries (e.g., some GraphQL like “deep querying” feature) that we might serialize into urls in the future.

Closes #1247, #1255 

Note: 1255 talked about also changing the recommendation for type names to be camel-cased, which would ripple through to URLs. I support this --- except that I couldn't find anywhere where we actually currently recommend kebab-case for `type`, so there's nothing to change. Maybe we want a new recommendation here?