### PR TITLE
Add PHP server implementation swisnl/json-api-server

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -150,6 +150,7 @@ and writing of JSON API documents.
 * [enm/json-api-server-bundle](https://eosnewmedia.github.io/JSON-API-Server-Bundle/) is a symfony bundle which integrates [enm/json-api-server](https://eosnewmedia.github.io/JSON-API-Server/) into your symfony application (symfony version ~2.7|~3.0).
 * [raml-json-api](https://github.com/RJAPI/raml-json-api) RAML based JSON API code generator for Laravel. Generates controllers, middlewares, models, routes, migrations and serves JSON API.
 * [paknahad/jsonapi-bundle](https://github.com/paknahad/jsonapi-bundle) is a Symfony bundle. It is the fastest way to generate API.
+* [swisnl/json-api-server](https://github.com/swisnl/json-api-server) is a Laravel package to get a JSON:API up and running in minutes.
 
 ### <a href="#server-libraries-node-js" id="server-libraries-node-js" class="headerlink"></a> Node.js
 * [Fortune.js](http://fortune.js.org/) is a library that includes a [comprehensive implementation of JSON API](https://github.com/fortunejs/fortune-json-api).


### PR DESCRIPTION
Add PHP server implementation [swisnl/json-api-server](https://github.com/swisnl/json-api-server). Set of generators and classes to get up and running with JSON:API in minutes in your own application.