### PR TITLE
cleanup(profiles): special case default handling of unrecognized query param vals

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -2147,15 +2147,20 @@ when encountering unrecognized values.
 If a profile does not define its own rules for handling unrecognized values, 
 the following rule applies by default:
 
-  1. If the unrecognized value is a JSON object, and the only thing that makes 
-     it unrecognized is that it contains one or more keys that have no meaning
-     assigned to them (in the latest revision of the profile that the application 
-     is aware of), then the application **MUST** simply ignore those unknown 
-     keys and continue processing the profile.
+  1. If the unrecognized value occurs is the value of a profile-defined query 
+     parameter, the server **MUST** fail the request and respond with a 
+     `400 Bad Request` and an [error object][error objects] indicating the 
+     problematic parameter.
+     
+  2. Otherwise, if the unrecognized value is a JSON object, and the only thing
+     that makes it unrecognized is that it contains one or more keys that have
+     no meaning assigned to them (in the latest revision of the profile that the
+     application is aware of), then the application **MUST** simply ignore those
+     unknown keys and continue processing the profile.
 
-  2. However, in all other cases, the application **MUST** assume that the 
-     profile has been applied erroneously and **MUST** totally ignore the 
-     profile (i.e., process the document as if the profile were not there).
+  3. In all other cases, the application **MUST** assume that the profile has
+     been applied erroneously and **MUST** totally ignore the profile (i.e.,
+     process the document as if the profile were not there).
 
 In the case of our example [timestamps profile], it does not define its own 
 rules, so the above defaults would apply. 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -2147,20 +2147,20 @@ when encountering unrecognized values.
 If a profile does not define its own rules for handling unrecognized values, 
 the following rule applies by default:
 
-  1. If the unrecognized value occurs is the value of a profile-defined query 
-     parameter, the server **MUST** fail the request and respond with a 
-     `400 Bad Request` and an [error object][error objects] indicating the 
-     problematic parameter.
+  1. If the value of a profile-defined query parameter is unrecognized, the 
+     server **MUST** fail the request and respond with a `400 Bad Request` and 
+     an [error object][error objects] indicating the problematic parameter.
      
-  2. Otherwise, if the unrecognized value is a JSON object, and the only thing
-     that makes it unrecognized is that it contains one or more keys that have
-     no meaning assigned to them (in the latest revision of the profile that the
-     application is aware of), then the application **MUST** simply ignore those
-     unknown keys and continue processing the profile.
+  2. Otherwise, if the unrecognized value is a JSON object in the 
+     request/response document, and the only thing that makes it unrecognized 
+     is that it contains one or more keys that have no meaning assigned to them
+     (in the latest revision of the profile that the application is aware of),
+     then the application **MUST** simply ignore those unknown keys and 
+     continue processing the profile.
 
   3. In all other cases, the application **MUST** assume that the profile has
      been applied erroneously and **MUST** totally ignore the profile (i.e.,
-     process the document as if the profile were not there).
+     process the request as if the profile were not there).
 
 In the case of our example [timestamps profile], it does not define its own 
 rules, so the above defaults would apply. 


### PR DESCRIPTION
Before, if a profile was applied with a query parameter that had an unrecognized value, the profile was ignored by default. This makes the default to fail with a 400 Bad Request instead. I think this better reflects the semantics that, when using query parameters, the client is trying to force the server to apply the profile, or fail the request.