### PR TITLE
Remove deprecated package

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -144,7 +144,6 @@ and writing of JSON API documents.
 * [nilportugues / laravel5-jsonapi-transformer](https://github.com/nilportugues/laravel5-jsonapi-transformer) Laravel 5 JSON API Transformer Package outputting valid API responses in JSON and JSON API formats.
 * [tuyakhov / yii2-json-api](https://github.com/tuyakhov/yii2-json-api) Implementation of JSON API specification for the Yii framework.
 * [json-api-php/json-api](https://github.com/json-api-php/json-api) An attempt to translate the JSON API specification into a set of high quality unit/functional tests and implement it in PHP 7 strictly following TDD and SOLID OOP principles.
-* [cloudcreativity/json-api](https://github.com/cloudcreativity/json-api) Framework agnostic JSON API serialisation and deserialisation. This project extends neomerx/json-api, adding in several additional framework-agnostic features.
 * [cloudcreativity/laravel-json-api](https://github.com/cloudcreativity/laravel-json-api) JSON API (jsonapi.org) package for Laravel applications. This project extends cloudcreativity/json-api, adding in framework-specific features.
 * [FriendsOfCake/crud-json-api](https://github.com/FriendsOfCake/crud-json-api) CakePHP Crud Listener for building maintainable JSON API compliant APIs.
 * [thephpleague/fractal](http://fractal.thephpleague.com/) A partial implementation of the JSON API spec allowing for an easy drop in JSON rendering solution.


### PR DESCRIPTION
Remove the `cloudcreativity/json-api` package from the list of PHP server implementations as it is deprecated.

For info I'm the maintainer of the deprecated package!