### PR TITLE
Use JSON:API instead of JSON API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 Our issue tracker can always be used to address internal inconsistencies within
 the current specification, or updates to the website. Beyond this, we try to
 limit discussions to those which focus on problems that will be dealt with in
-the next version of JSON API. A roadmap can be found on the [about] section of
+the next version of JSON:API. A roadmap can be found on the [about] section of
 our website.
 
 The ideal world we are shooting for is an empty issue tracker on release days.
@@ -12,8 +12,8 @@ The ideal world we are shooting for is an empty issue tracker on release days.
 ## Discussion Forum
 > http://discuss.jsonapi.org
 
-Our discussion forum is where general conversations about JSON API should take
+Our discussion forum is where general conversations about JSON:API should take
 place. Ideas for new extensions and questions about how to correctly implement
-or consume an API that adheres to the JSON API specification belong here.
+or consume an API that adheres to the JSON:API specification belong here.
 
 [about]: http://jsonapi.org/about

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-JSON API
+JSON:API
 ========
 
 Documentation for the [application/vnd.api+json media
@@ -38,6 +38,6 @@ when changes are pushed to the `gh-pages` branch.
 Archive
 -------
 
-older versions of the JSON-API documentations
+older versions of the JSON:API documentations
 
 * RC3 - http://jsonapi-rc3.herokuapp.com/

--- a/_format/1.0/index.md
+++ b/_format/1.0/index.md
@@ -4,14 +4,14 @@ version: 1.0
 
 ## <a href="#introduction" id="introduction" class="headerlink"></a> Introduction
 
-JSON API is a specification for how a client should request that resources be
+JSON:API is a specification for how a client should request that resources be
 fetched or modified, and how a server should respond to those requests.
 
-JSON API is designed to minimize both the number of requests and the amount of
+JSON:API is designed to minimize both the number of requests and the amount of
 data transmitted between clients and servers. This efficiency is achieved
 without compromising readability, flexibility, or discoverability.
 
-JSON API requires use of the JSON API media type
+JSON:API requires use of the JSON:API media type
 ([`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json))
 for exchanging data.
 
@@ -26,10 +26,10 @@ interpreted as described in RFC 2119
 
 ### <a href="#content-negotiation-clients" id="content-negotiation-clients" class="headerlink"></a> Client Responsibilities
 
-Clients **MUST** send all JSON API data in request documents with the header
+Clients **MUST** send all JSON:API data in request documents with the header
 `Content-Type: application/vnd.api+json` without any media type parameters.
 
-Clients that include the JSON API media type in their `Accept` header **MUST**
+Clients that include the JSON:API media type in their `Accept` header **MUST**
 specify the media type there at least once without any media type parameters.
 
 Clients **MUST** ignore any parameters for the `application/vnd.api+json`
@@ -37,7 +37,7 @@ media type received in the `Content-Type` header of response documents.
 
 ### <a href="#content-negotiation-servers" id="content-negotiation-servers" class="headerlink"></a> Server Responsibilities
 
-Servers **MUST** send all JSON API data in response documents with the header
+Servers **MUST** send all JSON:API data in response documents with the header
 `Content-Type: application/vnd.api+json` without any media type parameters.
 
 Servers **MUST** respond with a `415 Unsupported Media Type` status code if
@@ -45,7 +45,7 @@ a request specifies the header `Content-Type: application/vnd.api+json`
 with any media type parameters.
 
 Servers **MUST** respond with a `406 Not Acceptable` status code if a
-request's `Accept` header contains the JSON API media type and all instances
+request's `Accept` header contains the JSON:API media type and all instances
 of that media type are modified with media type parameters.
 
 > Note: The content negotiation requirements exist to allow future versions
@@ -54,9 +54,9 @@ and versioning.
 
 ## <a href="#document-structure" id="document-structure" class="headerlink"></a> Document Structure
 
-This section describes the structure of a JSON API document, which is identified
+This section describes the structure of a JSON:API document, which is identified
 by the media type [`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json).
-JSON API documents are defined in JavaScript Object Notation (JSON)
+JSON:API documents are defined in JavaScript Object Notation (JSON)
 [[RFC7159](http://tools.ietf.org/html/rfc7159)].
 
 Although the same media type is used for both request and response documents,
@@ -72,7 +72,7 @@ changes.
 
 ### <a href="#document-top-level" id="document-top-level" class="headerlink"></a> Top Level
 
-A JSON object **MUST** be at the root of every JSON API request and response
+A JSON object **MUST** be at the root of every JSON:API request and response
 containing data. This object defines a document's "top level".
 
 A document **MUST** contain at least one of the following top-level members:
@@ -146,7 +146,7 @@ it only contains one item or is empty.
 
 ### <a href="#document-resource-objects" id="document-resource-objects" class="headerlink"></a> Resource Objects
 
-"Resource objects" appear in a JSON API document to represent resources.
+"Resource objects" appear in a JSON:API document to represent resources.
 
 A resource object **MUST** contain at least the following top-level members:
 
@@ -160,7 +160,7 @@ In addition, a resource object **MAY** contain any of these top-level members:
 
 * `attributes`: an [attributes object][attributes] representing some of the resource's data.
 * `relationships`: a [relationships object][relationships] describing relationships between
- the resource and other JSON API resources.
+ the resource and other JSON:API resources.
 * `links`: a [links object][links] containing links related to the resource.
 * `meta`: a [meta object][meta] containing non-standard meta-information about a
   resource that can not be represented as an attribute or relationship.
@@ -397,7 +397,7 @@ A complete example document with multiple included relationships:
     "type": "articles",
     "id": "1",
     "attributes": {
-      "title": "JSON API paints my bikeshed!"
+      "title": "JSON:API paints my bikeshed!"
     },
     "links": {
       "self": "http://example.com/articles/1"
@@ -545,9 +545,9 @@ objects in the future. It is also possible that the allowed values of
 additional members will be expanded (e.g. a `collection` link may support an
 array of values, whereas a `self` link does not).
 
-### <a href="#document-jsonapi-object" id="document-jsonapi-object" class="headerlink"></a> JSON API Object
+### <a href="#document-jsonapi-object" id="document-jsonapi-object" class="headerlink"></a> JSON:API Object
 
-A JSON API document **MAY** include information about its implementation
+A JSON:API document **MAY** include information about its implementation
 under a top level `jsonapi` member. If present, the value of the `jsonapi`
 member **MUST** be an object (a "jsonapi object"). The jsonapi object **MAY**
 contain a `version` member whose value is a string indicating the highest JSON
@@ -565,12 +565,12 @@ value is a [meta] object that contains non-standard meta-information.
 If the `version` member is not present, clients should assume the server
 implements at least version 1.0 of the specification.
 
-> Note: Because JSON API is committed to making additive changes only, the
+> Note: Because JSON:API is committed to making additive changes only, the
 version string primarily indicates which new features a server may support.
 
 ### <a href="#document-member-names" id="document-member-names" class="headerlink"></a> Member Names
 
-All member names used in a JSON API document **MUST** be treated as case sensitive
+All member names used in a JSON:API document **MUST** be treated as case sensitive
 by clients and servers, and they **MUST** meet all of the following conditions:
 
 - Member names **MUST** contain at least one character.
@@ -695,7 +695,7 @@ Content-Type: application/vnd.api+json
     "type": "articles",
     "id": "1",
     "attributes": {
-      "title": "JSON API paints my bikeshed!"
+      "title": "JSON:API paints my bikeshed!"
     }
   }, {
     "type": "articles",
@@ -747,7 +747,7 @@ Content-Type: application/vnd.api+json
     "type": "articles",
     "id": "1",
     "attributes": {
-      "title": "JSON API paints my bikeshed!"
+      "title": "JSON:API paints my bikeshed!"
     },
     "relationships": {
       "author": {
@@ -1099,12 +1099,12 @@ Keys **MUST** either be omitted or have a `null` value to indicate that a
 particular link is unavailable.
 
 Concepts of order, as expressed in the naming of pagination links, **MUST**
-remain consistent with JSON API's [sorting rules](#fetching-sorting).
+remain consistent with JSON:API's [sorting rules](#fetching-sorting).
 
 The `page` query parameter is reserved for pagination. Servers and clients
 **SHOULD** use this key for pagination operations.
 
-> Note: JSON API is agnostic about the pagination strategy used by a server.
+> Note: JSON:API is agnostic about the pagination strategy used by a server.
 Effective pagination strategies include (but are not limited to):
 page-based, offset-based, and cursor-based. The `page` query parameter can
 be used as a basis for any of these strategies. For example, a page-based
@@ -1124,7 +1124,7 @@ collection as primary data, regardless of the request type.
 The `filter` query parameter is reserved for filtering data. Servers and clients
 **SHOULD** use this key for filtering operations.
 
-> Note: JSON API is agnostic about the strategies supported by a server. The
+> Note: JSON:API is agnostic about the strategies supported by a server. The
 `filter` query parameter can be used as the basis for any number of filtering
 strategies.
 
@@ -1137,7 +1137,7 @@ A request **MUST** completely succeed or fail (in a single "transaction"). No
 partial updates are allowed.
 
 > Note: The `type` member is required in every [resource object][resource objects] throughout requests and
-responses in JSON API. There are some cases, such as when `POST`ing to an
+responses in JSON:API. There are some cases, such as when `POST`ing to an
 endpoint representing heterogenous data, when the `type` could not be inferred
 from the endpoint. However, picking and choosing when it is required would be
 confusing; it would be hard to remember when it was required and when it was
@@ -1495,7 +1495,7 @@ responses, in accordance with
 ### <a href="#crud-updating-relationships" id="crud-updating-relationships" class="headerlink"></a> Updating Relationships
 
 Although relationships can be modified along with resources (as described
-above), JSON API also supports updating of relationships independently at
+above), JSON:API also supports updating of relationships independently at
 URLs from [relationship links][relationships].
 
 > Note: Relationships are updated without exposing the underlying server
@@ -1505,7 +1505,7 @@ has many authors, it is possible to remove one of the authors from the article
 without deleting the person itself. Similarly, if an article has many tags, it
 is possible to add or remove tags. Under the hood on the server, the first
 of these examples might be implemented with a foreign key, while the second
-could be implemented with a join table, but the JSON API protocol would be
+could be implemented with a join table, but the JSON:API protocol would be
 the same in both cases.
 
 > Note: A server may choose to delete the underlying resource if a
@@ -1650,7 +1650,7 @@ Accept: application/vnd.api+json
 
 > Note: RFC 7231 specifies that a DELETE request may include a body, but
 that a server may reject the request. This spec defines the semantics of a
-server, and we are defining its semantics for JSON API.
+server, and we are defining its semantics for JSON:API.
 
 #### <a href="#crud-updating-relationship-responses" id="crud-updating-relationship-responses" class="headerlink"></a> Responses
 
@@ -1754,7 +1754,7 @@ If a server encounters a query parameter that does not follow the naming
 conventions above, and the server does not know how to process it as a query
 parameter from this specification, it **MUST** return `400 Bad Request`.
 
-> Note: This is to preserve the ability of JSON API to make additive additions
+> Note: This is to preserve the ability of JSON:API to make additive additions
 to standard query parameters without conflicting with existing implementations.
 
 ## <a href="#errors" id="errors" class="headerlink"></a> Errors
@@ -1775,7 +1775,7 @@ or `500 Internal Server Error` might be appropriate for multiple 5xx errors.
 
 Error objects provide additional information about problems encountered while
 performing an operation. Error objects **MUST** be returned as an array
-keyed by `errors` in the top level of a JSON API document.
+keyed by `errors` in the top level of a JSON:API document.
 
 An error object **MAY** have the following members:
 

--- a/_format/1.0/normative-statements.json
+++ b/_format/1.0/normative-statements.json
@@ -294,7 +294,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "Clients **MUST** send all JSON API data in request documents with the header `Content-Type: application/vnd.api+json` without any media type parameters."
+        "description": "Clients **MUST** send all JSON:API data in request documents with the header `Content-Type: application/vnd.api+json` without any media type parameters."
       },
       "relationships": {
         "section": {
@@ -307,7 +307,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "Clients that include the JSON API media type in their `Accept` header **MUST** specify the media type there at least once without any media type parameters."
+        "description": "Clients that include the JSON:API media type in their `Accept` header **MUST** specify the media type there at least once without any media type parameters."
       },
       "relationships": {
         "section": {
@@ -333,7 +333,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "Servers **MUST** send all JSON API data in response documents with the header `Content-Type: application/vnd.api+json` without any media type parameters."
+        "description": "Servers **MUST** send all JSON:API data in response documents with the header `Content-Type: application/vnd.api+json` without any media type parameters."
       },
       "relationships": {
         "section": {
@@ -359,7 +359,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "Servers **MUST** respond with a `406 Not Acceptable` status code if a request's `Accept` header contains the JSON API media type and all instances of that media type are modified with media type parameters."
+        "description": "Servers **MUST** respond with a `406 Not Acceptable` status code if a request's `Accept` header contains the JSON:API media type and all instances of that media type are modified with media type parameters."
       },
       "relationships": {
         "section": {
@@ -398,7 +398,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "A JSON object MUST be at the root of every JSON API request and response containing data. This object defines a document's \"top level\"."
+        "description": "A JSON object MUST be at the root of every JSON:API request and response containing data. This object defines a document's \"top level\"."
       },
       "relationships": {
         "section": {
@@ -515,7 +515,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "In addition, a resource object MAY contain any of these top-level members:\\n\\n- `attributes`: an attributes object representing some of the resource's data.\\n- `relationships`: a relationships object describing relationships between the resource and other JSON API resources.\\n -`links`: a links object containing links related to the resource.\\n- `meta`: a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
+        "description": "In addition, a resource object MAY contain any of these top-level members:\\n\\n- `attributes`: an attributes object representing some of the resource's data.\\n- `relationships`: a relationships object describing relationships between the resource and other JSON:API resources.\\n -`links`: a links object containing links related to the resource.\\n- `meta`: a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
       },
       "relationships": {
         "section": {
@@ -866,7 +866,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MAY",
-        "description": "A JSON API document **MAY** include information about its implementation under a top level `jsonapi` member."
+        "description": "A JSON:API document **MAY** include information about its implementation under a top level `jsonapi` member."
       },
       "relationships": {
         "section": {
@@ -892,7 +892,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MAY",
-        "description": "The jsonapi object **MAY** contain a `version` member whose value is a string indicating the highest JSON API version supported."
+        "description": "The jsonapi object **MAY** contain a `version` member whose value is a string indicating the highest JSON:API version supported."
       },
       "relationships": {
         "section": {
@@ -918,7 +918,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "All member names used in a JSON API document **MUST** be treated as case sensitive by clients and servers"
+        "description": "All member names used in a JSON:API document **MUST** be treated as case sensitive by clients and servers"
       },
       "relationships": {
         "section": {
@@ -1516,7 +1516,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "Concepts of order, as expressed in the naming of pagination links, **MUST** remain consistent with JSON API's sorting rules."
+        "description": "Concepts of order, as expressed in the naming of pagination links, **MUST** remain consistent with JSON:API's sorting rules."
       },
       "relationships": {
         "section": {
@@ -2660,7 +2660,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "Error objects **MUST** be returned as an array keyed by `errors` in the top level of a JSON API document."
+        "description": "Error objects **MUST** be returned as an array keyed by `errors` in the top level of a JSON:API document."
       },
       "relationships": {
         "section": {

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -4,15 +4,15 @@ version: 1.1
 
 ## <a href="#introduction" id="introduction" class="headerlink"></a> Introduction
 
-JSON API is a specification for how a client should request that resources be
-fetched or modified, and how a server should respond to those requests. JSON API
+JSON:API is a specification for how a client should request that resources be
+fetched or modified, and how a server should respond to those requests. JSON:API
 can also be easily extended with [profiles].
 
-JSON API is designed to minimize both the number of requests and the amount of
+JSON:API is designed to minimize both the number of requests and the amount of
 data transmitted between clients and servers. This efficiency is achieved
 without compromising readability, flexibility, or discoverability.
 
-JSON API requires use of the JSON API media type
+JSON:API requires use of the JSON:API media type
 ([`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json))
 for exchanging data.
 
@@ -30,11 +30,11 @@ when, and only when, they appear in all capitals, as shown here.
 
 ### <a href="#content-negotiation-all" id="content-negotiation-all" class="headerlink"></a> Universal Responsibilities
 
-The JSON API media type is [`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json).
-Clients and servers **MUST** send all JSON API data using this media type in the
+The JSON:API media type is [`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json).
+Clients and servers **MUST** send all JSON:API data using this media type in the
 `Content-Type` header.
 
-Further, the JSON API media type **MUST** always be specified with either no
+Further, the JSON:API media type **MUST** always be specified with either no
 media type parameters or with only the `profile` parameter. This applies to both
 the `Content-Type` and `Accept` headers.
 
@@ -47,10 +47,10 @@ The `profile` parameter is used to support [profiles].
 
 ### <a href="#content-negotiation-clients" id="content-negotiation-clients" class="headerlink"></a> Client Responsibilities
 
-Clients that include the JSON API media type in their `Accept` header **MUST**
+Clients that include the JSON:API media type in their `Accept` header **MUST**
 specify the media type there at least once without any media type parameters.
 
-When processing a JSON API response document, clients **MUST** ignore any
+When processing a JSON:API response document, clients **MUST** ignore any
 parameters other than `profile` in the server's `Content-Type` header.
 
 ### <a href="#content-negotiation-servers" id="content-negotiation-servers" class="headerlink"></a> Server Responsibilities
@@ -60,7 +60,7 @@ a request specifies the header `Content-Type: application/vnd.api+json`
 with any media type parameters other than `profile`.
 
 Servers **MUST** respond with a `406 Not Acceptable` status code if a
-request's `Accept` header contains the JSON API media type and all instances
+request's `Accept` header contains the JSON:API media type and all instances
 of that media type are modified with media type parameters.
 
 > Note: These content negotiation requirements exist to allow future versions
@@ -69,9 +69,9 @@ negotiation and versioning.
 
 ## <a href="#document-structure" id="document-structure" class="headerlink"></a> Document Structure
 
-This section describes the structure of a JSON API document, which is identified
+This section describes the structure of a JSON:API document, which is identified
 by the media type [`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json).
-JSON API documents are defined in JavaScript Object Notation (JSON)
+JSON:API documents are defined in JavaScript Object Notation (JSON)
 [[RFC8259](http://tools.ietf.org/html/rfc8259)].
 
 Although the same media type is used for both request and response documents,
@@ -87,7 +87,7 @@ changes.
 
 ### <a href="#document-top-level" id="document-top-level" class="headerlink"></a> Top Level
 
-A JSON object **MUST** be at the root of every JSON API request and response
+A JSON object **MUST** be at the root of every JSON:API request and response
 containing data. This object defines a document's "top level".
 
 A document **MUST** contain at least one of the following top-level members:
@@ -163,7 +163,7 @@ it only contains one item or is empty.
 
 ### <a href="#document-resource-objects" id="document-resource-objects" class="headerlink"></a> Resource Objects
 
-"Resource objects" appear in a JSON API document to represent resources.
+"Resource objects" appear in a JSON:API document to represent resources.
 
 A resource object **MUST** contain at least the following top-level members:
 
@@ -177,7 +177,7 @@ In addition, a resource object **MAY** contain any of these top-level members:
 
 * `attributes`: an [attributes object][attributes] representing some of the resource's data.
 * `relationships`: a [relationships object][relationships] describing relationships between
- the resource and other JSON API resources.
+ the resource and other JSON:API resources.
 * `links`: a [links object][links] containing links related to the resource.
 * `meta`: a [meta object][meta] containing non-standard meta-information about a
   resource that can not be represented as an attribute or relationship.
@@ -414,7 +414,7 @@ A complete example document with multiple included relationships:
     "type": "articles",
     "id": "1",
     "attributes": {
-      "title": "JSON API paints my bikeshed!"
+      "title": "JSON:API paints my bikeshed!"
     },
     "links": {
       "self": "http://example.com/articles/1"
@@ -583,15 +583,15 @@ that includes a [profile alias][profile aliases]:
 > Note: Additional link types, similar to `profile` links, may be specified in
 the future.
 
-### <a href="#document-jsonapi-object" id="document-jsonapi-object" class="headerlink"></a> JSON API Object
+### <a href="#document-jsonapi-object" id="document-jsonapi-object" class="headerlink"></a> JSON:API Object
 
-A JSON API document **MAY** include information about its implementation
+A JSON:API document **MAY** include information about its implementation
 under a top level `jsonapi` member. If present, the value of the `jsonapi`
 member **MUST** be an object (a "jsonapi object").
 
 The jsonapi object **MAY** contain any of the following members:
 
-* `version` - whose value is a string indicating the highest JSON API version
+* `version` - whose value is a string indicating the highest JSON:API version
   supported.
 * `meta` - a [meta] object that contains non-standard meta-information.
 
@@ -608,12 +608,12 @@ A simple example appears below:
 If the `version` member is not present, clients should assume the server
 implements at least version 1.0 of the specification.
 
-> Note: Because JSON API is committed to making additive changes only, the
+> Note: Because JSON:API is committed to making additive changes only, the
 version string primarily indicates which new features a server may support.
 
 ### <a href="#document-member-names" id="document-member-names" class="headerlink"></a> Member Names
 
-All member names used in a JSON API document **MUST** be treated as case sensitive
+All member names used in a JSON:API document **MUST** be treated as case sensitive
 by clients and servers, and they **MUST** meet all of the following conditions:
 
 - Member names **MUST** contain at least one character.
@@ -681,20 +681,20 @@ The following characters **MUST NOT** be used in member names:
 
 Member names **MAY** also begin with an at sign (U+0040 COMMERCIAL AT, "@").
 Members named this way are called "@-Members". @-Members **MAY** appear
-anywhere in a JSON API document.
+anywhere in a JSON:API document.
 
-However, JSON API processors **MUST** completely ignore @-Members (i.e. not
-treat them as JSON API data).
+However, JSON:API processors **MUST** completely ignore @-Members (i.e. not
+treat them as JSON:API data).
 
 Moreover, the existence of @-Members **MUST** be ignored when interpreting all
-JSON API definitions and processing instructions given outside of this
+JSON:API definitions and processing instructions given outside of this
 subsection. For example, an [attribute][attributes] is defined above as any
 member of the attributes object. However, because @-Members must be ignored
 when interpreting that definition, an @-Member that occurs in an attributes
 object is not an attribute.
 
 > Note: Among other things, "@" members can be used to add JSON-LD data to a
-JSON API document. Such documents should be served with [an extra header](http://www.w3.org/TR/json-ld/#interpreting-json-as-json-ld)
+JSON:API document. Such documents should be served with [an extra header](http://www.w3.org/TR/json-ld/#interpreting-json-as-json-ld)
 to convey to JSON-LD clients that they contain JSON-LD data.
 
 ## <a href="#fetching" id="fetching" class="headerlink"></a> Fetching Data
@@ -758,7 +758,7 @@ Content-Type: application/vnd.api+json
     "type": "articles",
     "id": "1",
     "attributes": {
-      "title": "JSON API paints my bikeshed!"
+      "title": "JSON:API paints my bikeshed!"
     }
   }, {
     "type": "articles",
@@ -810,7 +810,7 @@ Content-Type: application/vnd.api+json
     "type": "articles",
     "id": "1",
     "attributes": {
-      "title": "JSON API paints my bikeshed!"
+      "title": "JSON:API paints my bikeshed!"
     },
     "relationships": {
       "author": {
@@ -1163,12 +1163,12 @@ Keys **MUST** either be omitted or have a `null` value to indicate that a
 particular link is unavailable.
 
 Concepts of order, as expressed in the naming of pagination links, **MUST**
-remain consistent with JSON API's [sorting rules](#fetching-sorting).
+remain consistent with JSON:API's [sorting rules](#fetching-sorting).
 
 The `page` query parameter is reserved for pagination. Servers and clients
 **SHOULD** use this key for pagination operations.
 
-> Note: JSON API is agnostic about the pagination strategy used by a server.
+> Note: JSON:API is agnostic about the pagination strategy used by a server.
 Effective pagination strategies include (but are not limited to):
 page-based, offset-based, and cursor-based. The `page` query parameter can
 be used as a basis for any of these strategies. For example, a page-based
@@ -1188,7 +1188,7 @@ collection as primary data, regardless of the request type.
 The `filter` query parameter is reserved for filtering data. Servers and clients
 **SHOULD** use this key for filtering operations.
 
-> Note: JSON API is agnostic about the strategies supported by a server. The
+> Note: JSON:API is agnostic about the strategies supported by a server. The
 `filter` query parameter can be used as the basis for any number of filtering
 strategies.
 
@@ -1201,7 +1201,7 @@ A request **MUST** completely succeed or fail (in a single "transaction"). No
 partial updates are allowed.
 
 > Note: The `type` member is required in every [resource object][resource objects] throughout requests and
-responses in JSON API. There are some cases, such as when `POST`ing to an
+responses in JSON:API. There are some cases, such as when `POST`ing to an
 endpoint representing heterogenous data, when the `type` could not be inferred
 from the endpoint. However, picking and choosing when it is required would be
 confusing; it would be hard to remember when it was required and when it was
@@ -1560,7 +1560,7 @@ responses, in accordance with
 ### <a href="#crud-updating-relationships" id="crud-updating-relationships" class="headerlink"></a> Updating Relationships
 
 Although relationships can be modified along with resources (as described
-above), JSON API also supports updating of relationships independently at
+above), JSON:API also supports updating of relationships independently at
 URLs from [relationship links][relationships].
 
 > Note: Relationships are updated without exposing the underlying server
@@ -1570,7 +1570,7 @@ has many authors, it is possible to remove one of the authors from the article
 without deleting the person itself. Similarly, if an article has many tags, it
 is possible to add or remove tags. Under the hood on the server, the first
 of these examples might be implemented with a foreign key, while the second
-could be implemented with a join table, but the JSON API protocol would be
+could be implemented with a join table, but the JSON:API protocol would be
 the same in both cases.
 
 > Note: A server may choose to delete the underlying resource if a
@@ -1715,7 +1715,7 @@ Accept: application/vnd.api+json
 
 > Note: RFC 7231 specifies that a DELETE request may include a body, but
 that a server may reject the request. This spec defines the semantics of a
-server, and we are defining its semantics for JSON API.
+server, and we are defining its semantics for JSON:API.
 
 #### <a href="#crud-updating-relationship-responses" id="crud-updating-relationship-responses" class="headerlink"></a> Responses
 
@@ -1821,12 +1821,12 @@ conventions above, and the server does not know how to process it as a query
 parameter from this specification, it **MUST** return `400 Bad Request`.
 
 > Note: By forbidding the use of query parameters that contain only the characters
-> \[a-z\], JSON API is reserving the ability to standardize additional query
+> \[a-z\], JSON:API is reserving the ability to standardize additional query
 > parameters later without conflicting with existing implementations.
 
 ## <a href="#profiles" id="profiles" class="headerlink"></a> Profiles
 
-JSON API supports the use of "profiles" as a way to indicate additional
+JSON:API supports the use of "profiles" as a way to indicate additional
 semantics that apply to a JSON:API request/document, without altering the
 basic semantics described in this specification.
 
@@ -1880,7 +1880,7 @@ This profile defines the following keywords:
 ### <a href="#profile-media-type-parameter" id="profile-media-type-parameter" class="headerlink"></a> `profile` Media Type Parameter
 
 The `profile` media type parameter is used to describe the application of
-one or more profiles to a JSON API document. The value of the `profile`
+one or more profiles to a JSON:API document. The value of the `profile`
 parameter **MUST** equal a space-separated (U+0020 SPACE, " ") list of profile URIs.
 
 > Note: When serializing the `profile` media type parameter, the HTTP
@@ -1888,7 +1888,7 @@ parameter **MUST** equal a space-separated (U+0020 SPACE, " ") list of profile U
 > (U+0022 QUOTATION MARK, "\"") if it contains more than one URI.
 
 A client **MAY** use the `profile` media type parameter in conjunction with the
-JSON API media type in an `Accept` header to _request_, but not _require_, that
+JSON:API media type in an `Accept` header to _request_, but not _require_, that
 the server apply one or more profiles to the response document. When such a
 request is received, a server **SHOULD** attempt to apply the requested profiles
 to its response.
@@ -1900,11 +1900,11 @@ For example, in the following request, the client asks that the server apply the
 Accept: application/vnd.api+json;profile="http://example.com/extensions/last-modified", application/vnd.api+json
 ```
 
-> Note: The second instance of the JSON API media type in the example above is
+> Note: The second instance of the JSON:API media type in the example above is
   required under the [client's content negotiation responsibilities](#content-negotiation-clients).
   It is used to support old servers that don't understand the profile parameter.
 
-Servers **MAY** add profiles to a JSON API document even if the client has not
+Servers **MAY** add profiles to a JSON:API document even if the client has not
 requested them. The recipient of a document **MUST** ignore any profile extensions
 in that document that it does not understand. The only exception to this is profiles
 whose support is required using the `profile` query parameter, as described later.
@@ -1912,15 +1912,15 @@ whose support is required using the `profile` query parameter, as described late
 #### <a href="#profiles-sending" id="profiles-sending" class="headerlink"></a> Sending Profiled Documents
 
 Clients and servers **MUST** include the `profile` media type parameter in
-conjunction with the JSON API media type in a `Content-Type` header to indicate
-that they have applied one or more profiles to a JSON API document.
+conjunction with the JSON:API media type in a `Content-Type` header to indicate
+that they have applied one or more profiles to a JSON:API document.
 
-Likewise, clients and servers applying profiles to a JSON API document **MUST**
+Likewise, clients and servers applying profiles to a JSON:API document **MUST**
 include a [top-level][top level] [`links` object][links] with a `profile` key,
 and that `profile` key **MUST** include a [link] to the URI of each profile
 that has been applied.
 
-When an older JSON API server that doesn't support the `profile` media type
+When an older JSON:API server that doesn't support the `profile` media type
 parameter receives a document with one or more profiles, it will respond with a
 `415 Unsupported Media Type` error.
 
@@ -1931,7 +1931,7 @@ type parameter. If this resolves the error, the client **SHOULD NOT** attempt to
 use profile extensions in subsequent interactions with the same API.
 
 > The most likely other causes of a 415 error are that the server doesn't
-support JSON API at all or that the client has failed to provide a required
+support JSON:API at all or that the client has failed to provide a required
 profile.
 
 ### <a href="#profile-query-parameter" id="profile-query-parameter" class="headerlink"></a> `profile` Query Parameter
@@ -2188,10 +2188,10 @@ requirement that the `modified` key hold a string of the form produced by
 A profile **MAY** assign meaning to elements of the document structure whose use
 is left up to each implementation, such as resource fields or members of meta
 objects. A profile **MUST NOT** define/assign a meaning to document members 
-in areas of the document reserved for future use by the JSON API specification. 
+in areas of the document reserved for future use by the JSON:API specification. 
 
 For example, it would be illegal for a profile to define a new key in a 
-document's [top-level][top level] object, or in a [links object], as JSON API 
+document's [top-level][top level] object, or in a [links object], as JSON:API 
 implementations are not allowed to add custom keys in those areas.
 
 Likewise, a profile **MAY** assign a meaning to query parameters or parameter 
@@ -2294,7 +2294,7 @@ or `500 Internal Server Error` might be appropriate for multiple 5xx errors.
 
 Error objects provide additional information about problems encountered while
 performing an operation. Error objects **MUST** be returned as an array
-keyed by `errors` in the top level of a JSON API document.
+keyed by `errors` in the top level of a JSON:API document.
 
 An error object **MAY** have the following members:
 

--- a/_format/1.1/normative-statements.json
+++ b/_format/1.1/normative-statements.json
@@ -298,7 +298,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "Clients **MUST** send all JSON API data in request documents with the header `Content-Type: application/vnd.api+json` without any media type parameters."
+        "description": "Clients **MUST** send all JSON:API data in request documents with the header `Content-Type: application/vnd.api+json` without any media type parameters."
       },
       "relationships": {
         "section": {
@@ -311,7 +311,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "Clients that include the JSON API media type in their `Accept` header **MUST** specify the media type there at least once without any media type parameters."
+        "description": "Clients that include the JSON:API media type in their `Accept` header **MUST** specify the media type there at least once without any media type parameters."
       },
       "relationships": {
         "section": {
@@ -337,7 +337,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "Servers **MUST** send all JSON API data in response documents with the header `Content-Type: application/vnd.api+json` without any media type parameters."
+        "description": "Servers **MUST** send all JSON:API data in response documents with the header `Content-Type: application/vnd.api+json` without any media type parameters."
       },
       "relationships": {
         "section": {
@@ -363,7 +363,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "Servers **MUST** respond with a `406 Not Acceptable` status code if a request's `Accept` header contains the JSON API media type and all instances of that media type are modified with media type parameters."
+        "description": "Servers **MUST** respond with a `406 Not Acceptable` status code if a request's `Accept` header contains the JSON:API media type and all instances of that media type are modified with media type parameters."
       },
       "relationships": {
         "section": {
@@ -402,7 +402,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "A JSON object MUST be at the root of every JSON API request and response containing data. This object defines a document's \"top level\"."
+        "description": "A JSON object MUST be at the root of every JSON:API request and response containing data. This object defines a document's \"top level\"."
       },
       "relationships": {
         "section": {
@@ -519,7 +519,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "In addition, a resource object MAY contain any of these top-level members:\\n\\n- `attributes`: an attributes object representing some of the resource's data.\\n- `relationships`: a relationships object describing relationships between the resource and other JSON API resources.\\n -`links`: a links object containing links related to the resource.\\n- `meta`: a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
+        "description": "In addition, a resource object MAY contain any of these top-level members:\\n\\n- `attributes`: an attributes object representing some of the resource's data.\\n- `relationships`: a relationships object describing relationships between the resource and other JSON:API resources.\\n -`links`: a links object containing links related to the resource.\\n- `meta`: a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
       },
       "relationships": {
         "section": {
@@ -870,7 +870,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MAY",
-        "description": "A JSON API document **MAY** include information about its implementation under a top level `jsonapi` member."
+        "description": "A JSON:API document **MAY** include information about its implementation under a top level `jsonapi` member."
       },
       "relationships": {
         "section": {
@@ -896,7 +896,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MAY",
-        "description": "The jsonapi object **MAY** contain a `version` member whose value is a string indicating the highest JSON API version supported."
+        "description": "The jsonapi object **MAY** contain a `version` member whose value is a string indicating the highest JSON:API version supported."
       },
       "relationships": {
         "section": {
@@ -922,7 +922,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "All member names used in a JSON API document **MUST** be treated as case sensitive by clients and servers"
+        "description": "All member names used in a JSON:API document **MUST** be treated as case sensitive by clients and servers"
       },
       "relationships": {
         "section": {
@@ -1026,7 +1026,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MAY",
-        "description": "@-Members **MAY** appear anywhere in a JSON API document."
+        "description": "@-Members **MAY** appear anywhere in a JSON:API document."
       },
       "relationships": {
         "section": {
@@ -1039,7 +1039,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "JSON API processors **MUST** completely ignore @-Members (i.e. not treat them as JSON API data)."
+        "description": "JSON:API processors **MUST** completely ignore @-Members (i.e. not treat them as JSON:API data)."
       },
       "relationships": {
         "section": {
@@ -1052,7 +1052,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "Moreover, the existence of @-Members **MUST** be ignored when interpreting all JSON API definitions and processing instructions given outside of the @-Members subsection."
+        "description": "Moreover, the existence of @-Members **MUST** be ignored when interpreting all JSON:API definitions and processing instructions given outside of the @-Members subsection."
       },
       "relationships": {
         "section": {
@@ -1572,7 +1572,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "Concepts of order, as expressed in the naming of pagination links, **MUST** remain consistent with JSON API's sorting rules."
+        "description": "Concepts of order, as expressed in the naming of pagination links, **MUST** remain consistent with JSON:API's sorting rules."
       },
       "relationships": {
         "section": {
@@ -2716,7 +2716,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "Error objects **MUST** be returned as an array keyed by `errors` in the top level of a JSON API document."
+        "description": "Error objects **MUST** be returned as an array keyed by `errors` in the top level of a JSON:API document."
       },
       "relationships": {
         "section": {

--- a/_includes/status.md
+++ b/_includes/status.md
@@ -18,32 +18,32 @@
 {% endcomment %}
 
 {% if is_latest_version_page %}
-  This page represents the latest published version of JSON API, which is
-  currently version {{ site.latest_version }}. New versions of JSON API **will
+  This page represents the latest published version of JSON:API, which is
+  currently version {{ site.latest_version }}. New versions of JSON:API **will
   always be backwards compatible** using a _never remove, only add_ strategy.
   Additions can be proposed in our [discussion forum](http://discuss.jsonapi.org/).
 
 {% elsif is_upcoming_version_page %}
-  This page represents the **working draft** for the next version of JSON API,
+  This page represents the **working draft** for the next version of JSON:API,
   which is currently expected to be {{ site.latest_version|plus:0.1 }}.
 
 {% elsif version and version > site.latest_version %}
-  This page will always present the most recent text for JSON API
+  This page will always present the most recent text for JSON:API
   v{{ site.latest_version|plus:0.1 }}. Currently, version
   {{ site.latest_version|plus:0.1 }} is **still a draft**, so this text is
   provisional.
 
 {% elsif version and version == site.latest_version %}
-  This page presents an archived copy of JSON API version {{ version }}. None
+  This page presents an archived copy of JSON:API version {{ version }}. None
   of the normative text on this page will change. **Subsequent versions of
-  JSON API will remain compatible with this one**, as JSON API uses a _never
+  JSON:API will remain compatible with this one**, as JSON:API uses a _never
   remove, only add_ strategy.
 
 {% else %}
-  This page presents an archived copy of JSON API version {{ version }}. None
+  This page presents an archived copy of JSON:API version {{ version }}. None
   of the normative text on this page will change. While {{ version }} is no
-  longer the [latest version](/format/) of JSON API, **new versions will remain
-  compatible with this one**, as JSON API uses a _never remove, only add_ strategy.
+  longer the [latest version](/format/) of JSON:API, **new versions will remain
+  compatible with this one**, as JSON:API uses a _never remove, only add_ strategy.
 
 {% endif %}
 
@@ -63,7 +63,7 @@
   specification&rsquo;s text, or write an implementation, please let us know by
   opening an issue or pull request at our [GitHub repository](https://github.com/json-api/json-api).
 
-  You can also propose additions to JSON API in our [discussion forum](http://discuss.jsonapi.org/).
-  Keep in mind, though, that all new versions of JSON API **must be backwards
+  You can also propose additions to JSON:API in our [discussion forum](http://discuss.jsonapi.org/).
+  Keep in mind, though, that all new versions of JSON:API **must be backwards
   compatible** using a _never remove, only add_ strategy.
 {% endif %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -20,7 +20,7 @@
     {% else %}
       {% assign page_title = page.title %}
     {% endif %}
-    <title>JSON API &mdash; {{page_title|strip }}</title>
+    <title>JSON:API &mdash; {{page_title|strip }}</title>
 
     <link href="/stylesheets/normalize.css" rel="stylesheet" type="text/css" />
     <link href="/stylesheets/all.css" rel="stylesheet" type="text/css" />
@@ -70,7 +70,7 @@
     {% if page.show_masthead %}
       <header>
         <div class="content">
-          <h1>JSON API</h1>
+          <h1>JSON:API</h1>
           <h2>A specification for building APIs in JSON</h2>
           <div class="quicklinks">
             {% for link in site.quicklinks %}

--- a/about/index.md
+++ b/about/index.md
@@ -5,7 +5,7 @@ title: About
 
 ## <a href="#channels" id="channels" class="headerlink"></a> Channels
 
-JSON API is:
+JSON:API is:
 
   * [@jsonapi](http://twitter.com/jsonapi) on
 [Twitter](http://twitter.com)
@@ -31,7 +31,7 @@ There are five primary editors of this specification:
 
 ## <a href="#history" id="history" class="headerlink"></a> History
 
-JSON API was originally drafted by [Yehuda Katz](http://twitter.com/wycats)
+JSON:API was originally drafted by [Yehuda Katz](http://twitter.com/wycats)
 in May 2013. This first draft was extracted from the JSON transport
 implicitly defined by [Ember](http://emberjs.com/) Data's REST adapter.
 

--- a/examples/index.md
+++ b/examples/index.md
@@ -25,7 +25,7 @@ Content-Type: application/vnd.api+json
     "type": "articles",
     "id": "1",
     "attributes": {
-      "title": "JSON API paints my bikeshed!",
+      "title": "JSON:API paints my bikeshed!",
       "body": "The shortest article. Ever.",
       "created": "2015-05-22T14:56:29.000Z",
       "updated": "2015-05-22T14:56:28.000Z"
@@ -71,7 +71,7 @@ Content-Type: application/vnd.api+json
     "type": "articles",
     "id": "1",
     "attributes": {
-      "title": "JSON API paints my bikeshed!",
+      "title": "JSON:API paints my bikeshed!",
       "body": "The shortest article. Ever."
     },
     "relationships": {
@@ -107,7 +107,7 @@ Content-Type: application/vnd.api+json
     "type": "articles",
     "id": "1",
     "attributes": {
-      "title": "JSON API paints my bikeshed!",
+      "title": "JSON:API paints my bikeshed!",
       "body": "The shortest article. Ever."
     }
   }],
@@ -150,7 +150,7 @@ Content-Type: application/vnd.api+json
       "type": "articles",
       "id": "3",
       "attributes": {
-        "title": "JSON API paints my bikeshed!",
+        "title": "JSON:API paints my bikeshed!",
         "body": "The shortest article. Ever.",
         "created": "2015-05-22T14:56:29.000Z",
         "updated": "2015-05-22T14:56:28.000Z"
@@ -216,7 +216,7 @@ The `status` member represents the HTTP status code associated with the problem.
 It's very helpful when multiple errors are returned at once (see below), as the
 HTTP response itself can only have one status code. However, it can also be
 useful for single errors, to save clients the trouble of consulting the HTTP
-headers, or for using JSON API over non-HTTP protocols, which may be officially
+headers, or for using JSON:API over non-HTTP protocols, which may be officially
 supported in the near future.
 
 ### <a href="#error-objects-multiple-errors" id="error-objects-multiple-errors" class="headerlink"></a> Multiple Errors
@@ -276,7 +276,7 @@ Content-Type: application/vnd.api+json
 
 > Note: in the responses above with a 422 status code, `400 Bad Request` would
 also be acceptable. ([More details.](http://stackoverflow.com/a/20215807/1261879))
-JSON API doesn't take a position on 400 vs. 422.
+JSON:API doesn't take a position on 400 vs. 422.
 
 ### <a href="#error-objects-error-codes" id="error-objects-error-codes" class="headerlink"></a> Error Codes
 
@@ -329,14 +329,14 @@ Content-Type: application/vnd.api+json
 Notice that this response includes not only the `errors` top-level member,
 but the `jsonapi` top-level member. Error responses may not contain the
 top-level `data` member, but can include all the other top-level members
-JSON API defines.
+JSON:API defines.
 
 Also, notice that the third error object lacks a `detail` member (perhaps
 for security). Again, all error object members are optional.
 
 ### <a href="#error-objects-source-usage" id="error-objects-source-usage" class="headerlink"></a> Advanced `source` Usage
 
-In the example below, the user is sending an invalid JSON API
+In the example below, the user is sending an invalid JSON:API
 request, because it's missing the `data` member:
 
 ```http
@@ -407,9 +407,9 @@ Content-Type: application/vnd.api+json
 }
 ```
 
-In most cases, JSON API requires the server to return an error when it encounters
-an invalid value for a JSON API–defined query parameter. However, for API-specific
-query parameters (i.e. those not defined by JSON API), a server may choose to
+In most cases, JSON:API requires the server to return an error when it encounters
+an invalid value for a JSON:API–defined query parameter. However, for API-specific
+query parameters (i.e. those not defined by JSON:API), a server may choose to
 ignore an invalid parameter and have the request succeed, rather than respond with
 an error. [API-specific query parameters must contain one non a-z
 character.](http://jsonapi.org/format/#query-parameters)

--- a/extensions/index.md
+++ b/extensions/index.md
@@ -8,11 +8,11 @@ show_sidebar: true
 
 **An extension system is currently under development,** and you can view the
 latest work [here](https://github.com/json-api/json-api/tree/profile-extensions).
-There is no official support for extensions in the base JSON API specification.
+There is no official support for extensions in the base JSON:API specification.
 
 ## <a href="#prior-extensions" id="prior-extensions" class="headerlink"></a> Prior Extensions
 
-JSON API previously offered experimental support for a different extension
+JSON:API previously offered experimental support for a different extension
 negotiation system than the one now being discussed, and it provided a number of
 extensions for use with that old negotiation system. However, this system was
 always experimental and has now been deprecated.

--- a/faq/index.md
+++ b/faq/index.md
@@ -4,9 +4,9 @@ title: Frequently Asked Questions
 show_sidebar: true
 ---
 
-## <a href="#what-is-the-meaning-of-json-apis-version" id="what-is-the-meaning-of-json-apis-version" class="headerlink"></a> What is the meaning of JSON API's version?
+## <a href="#what-is-the-meaning-of-json-apis-version" id="what-is-the-meaning-of-json-apis-version" class="headerlink"></a> What is the meaning of JSON:API's version?
 
-Now that JSON API has reached a stable version 1.0, it will always be
+Now that JSON:API has reached a stable version 1.0, it will always be
 backwards compatible using a _never remove, only add_ strategy.
 
 A version is maintained in order to:
@@ -18,22 +18,22 @@ A version is maintained in order to:
 
 There are several reasons:
 
-* HAL embeds child documents recursively, while JSON API flattens the entire
+* HAL embeds child documents recursively, while JSON:API flattens the entire
 graph of objects at the top level. This means that if the same "people" are
 referenced from different kinds of objects (say, the author of both posts and
 comments), this format ensures that there is only a single representation of
 each person document in the payload.
-* Similarly, JSON API uses IDs for linkage, which makes it possible to cache
+* Similarly, JSON:API uses IDs for linkage, which makes it possible to cache
 documents from compound responses and then limit subsequent requests to only
 the documents that aren't already present locally. If you're lucky, this can
 even completely eliminate HTTP requests.
 * HAL is a serialization format, but says nothing about how to update
-documents. JSON API thinks through how to update existing records (leaning on
+documents. JSON:API thinks through how to update existing records (leaning on
 PATCH and JSON Patch), and how those updates interact with compound documents
 returned from GET requests. It also describes how to create and delete
 documents, and what 200 and 204 responses from those updates mean.
 
-In short, JSON API is an attempt to formalize similar ad hoc client-server
+In short, JSON:API is an attempt to formalize similar ad hoc client-server
 interfaces that use JSON as an interchange format. It is specifically focused
 around using those APIs with a smart client that knows how to cache documents it
 has already seen and avoid asking for them again.
@@ -54,7 +54,7 @@ For instance, a client might request `HEAD /articles`, and the response could
 contain the header `Allow: GET,POST`, indicating that the client can GET the
 collection and also POST to it to create new resources.
 
-JSON API is still working on a way to for resources to advertise and detail
+JSON:API is still working on a way to for resources to advertise and detail
 non-standard actions they support. Feel free to
 [join that discussion](https://github.com/json-api/json-api/issues/745)!
 
@@ -71,15 +71,15 @@ Instead, PUT is supposed to completely replace the state of a resource:
   target resource will result in an equivalent representation being sent…”
 
 The correct method for partial updates, therefore, is [PATCH](http://tools.ietf.org/html/rfc5789),
-which is what JSON API uses. And because PATCH can also be used compliantly for
-full resource replacement, JSON API hasn't needed to define any behavior for
+which is what JSON:API uses. And because PATCH can also be used compliantly for
+full resource replacement, JSON:API hasn't needed to define any behavior for
 PUT so far. However, it may define PUT semantics in the future.
 
 In the past, many APIs used PUT for partial updates because PATCH wasn’t yet
 well-supported. However, almost all clients now support PATCH, and those that
 don’t can be easily [worked around](/recommendations/#patchless-clients).
 
-## <a href="#is-there-a-json-schema-describing-json-api" id="is-there-a-json-schema-describing-json-api" class="headerlink"></a> Is there a JSON Schema describing JSON API?
+## <a href="#is-there-a-json-schema-describing-json-api" id="is-there-a-json-schema-describing-json-api" class="headerlink"></a> Is there a JSON Schema describing JSON:API?
 
 Yes, you can find the JSON Schema definition at
 [http://jsonapi.org/schema](http://jsonapi.org/schema). This schema is as
@@ -104,6 +104,6 @@ than type because it's possible that a primary resource may have related
 resources of the same type (e.g. the "parents" of a "person"). Nesting related
 resources in `included` prevents this possible conflict.
 
-## <a href="#position-uri-structure-custom-endpoints" id="position-uri-structure-custom-endpoints" class="headerlink"></a> Does JSON API take any position on URI structure, on rules for custom endpoints, which do not fit the paradigm of GET/POST/PATCH/DELETE on the resource URI, etc.?
+## <a href="#position-uri-structure-custom-endpoints" id="position-uri-structure-custom-endpoints" class="headerlink"></a> Does JSON:API take any position on URI structure, on rules for custom endpoints, which do not fit the paradigm of GET/POST/PATCH/DELETE on the resource URI, etc.?
 
-JSON API has no requirements about URI structure, implementations are free to use whatever form they wish.
+JSON:API has no requirements about URI structure, implementations are free to use whatever form they wish.

--- a/implementations/index.md
+++ b/implementations/index.md
@@ -4,7 +4,7 @@ title: Implementations
 show_sidebar: true
 ---
 
-The following are projects implementing JSON API. If you'd like your project listed, [send a
+The following are projects implementing JSON:API. If you'd like your project listed, [send a
 pull request](https://github.com/json-api/json-api).
 
 > Note: This specification marked 1.0 on May 29th, 2015. The implementations
@@ -16,49 +16,49 @@ assembled to vet them.
 ### <a href="#client-libraries-javascript" id="client-libraries-javascript" class="headerlink"></a> JavaScript
 
 * [ember-data](https://github.com/emberjs/data) is one of the original exemplar implementations. There is now an [offical adapter](https://emberjs.com/api/ember-data/release/classes/DS.JSONAPIAdapter) to support json-api.
-* [backbone-jsonapi](https://github.com/guillaumervls/backbone-jsonapi) is a Backbone adapter for JSON API. Supports fetching Models & Collections from a JSON API source.
-* [backbone-relational-jsonapi](https://github.com/xbill82/backbone-relational-jsonapi) is a parsing layer for Backbone.Relational. Entities specified in JSON API are automatically parsed to be injected into Backbone.Relational relations.
+* [backbone-jsonapi](https://github.com/guillaumervls/backbone-jsonapi) is a Backbone adapter for JSON:API. Supports fetching Models & Collections from a JSON:API source.
+* [backbone-relational-jsonapi](https://github.com/xbill82/backbone-relational-jsonapi) is a parsing layer for Backbone.Relational. Entities specified in JSON:API are automatically parsed to be injected into Backbone.Relational relations.
 * [orbit.js](https://github.com/orbitjs/orbit.js) is a standalone library for
   coordinating access to data sources and keeping their contents synchronized.
   Orbit's Common Library includes
   [JSONAPISource](https://github.com/orbitjs/orbit.js/blob/master/lib/orbit-common/jsonapi-source.js)
-  for accessing JSON API servers. Orbit can be used
+  for accessing JSON:API servers. Orbit can be used
   independently or with Ember.js through the
   [ember-orbit](https://github.com/orbitjs/ember-orbit) integration library.
-* [YAYSON](https://github.com/confetti/yayson) is an isomorphic library for serializing and reading JSON API data. Extend it to fit your models or just use it with plain objects.
+* [YAYSON](https://github.com/confetti/yayson) is an isomorphic library for serializing and reading JSON:API data. Extend it to fit your models or just use it with plain objects.
 * [Ember JSON API Resources](https://github.com/pixelhandler/ember-jsonapi-resources) is an [Ember CLI](http://www.ember-cli.com) Addon for a lightweight solution for data persistence in an [Ember.js](http://emberjs.com) application.
 * [hapi-json-api](https://github.com/wraithgar/hapi-json-api) Plugin for the hapi framework; enforces Accept/Content-type rules and rewrites Boom errors to be spec compliant.
-* [jsonapi-datastore](https://github.com/beauby/jsonapi-datastore) is a lightweight standalone library for reading, serializing, and synchronizing relational JSON API data.
-* [json-api-store](https://github.com/haydn/json-api-store) A lightweight JavaScript library for using JSON API in the browser.
+* [jsonapi-datastore](https://github.com/beauby/jsonapi-datastore) is a lightweight standalone library for reading, serializing, and synchronizing relational JSON:API data.
+* [json-api-store](https://github.com/haydn/json-api-store) A lightweight JavaScript library for using JSON:API in the browser.
 * [superagent-jsonapify](https://github.com/alex94puchades/superagent-jsonapify) A really lightweight (50 lines) JSON-API client addon for [superagent](https://github.com/visionmedia/superagent), the isomorphic ajax client.
-* [angular-jsonapi](https://github.com/jakubrohleder/angular-jsonapi) An AngularJS JSON API client
-* [redux-json-api](https://github.com/dixieio/redux-json-api) A library which integrated JSON APIs with Redux store
-* [devour-client](https://github.com/twg/devour) A lightweight, framework agnostic, highly flexible JSON API client
-* [json-api-normalizer](https://github.com/yury-dymov/json-api-normalizer) Normalizes JSON API documents for state management solutions like Redux and Mobx
+* [angular-jsonapi](https://github.com/jakubrohleder/angular-jsonapi) An AngularJS JSON:API client
+* [redux-json-api](https://github.com/dixieio/redux-json-api) A library which integrated JSON:APIs with Redux store
+* [devour-client](https://github.com/twg/devour) A lightweight, framework agnostic, highly flexible JSON:API client
+* [json-api-normalizer](https://github.com/yury-dymov/json-api-normalizer) Normalizes JSON:API documents for state management solutions like Redux and Mobx
 * [jsona](https://github.com/olosegres/jsona) Data formatter that creates customizable, simplified objects from JSON or stored reduxObject (result object of [json-api-normalizer](https://github.com/yury-dymov/json-api-normalizer)), and creates correct JSON from the same simplified objects.
-* [active-resource](https://github.com/nicklandgrebe/activeresource.js) A standalone, convention-driven JavaScript ORM that maps to your JSON API server and allows for advanced queries and relational management through a smooth interface.
-* [redux-bees](https://github.com/cantierecreativo/redux-bees) A nice, short and declarative way to interact with JSON APIs in React+Redux
-* [Coloquent](https://github.com/DavidDuwaer/Coloquent) Javascript/Typescript library mapping objects and their interrelations to JSON API, with a clean, fluent ActiveRecord-like (e.g. similar to Laravel's Eloquent) syntax  for creating, retrieving, updating and deleting model objects.
-* [kitsu](https://github.com/wopian/kitsu) A simple, lightweight & framework agnostic JSON API client
-* [Sarala JSON API data formatter](https://github.com/milroyfraser/sarala-json-api-data-formatter) is a simple and fluent framework agnostic javascript library to transform standard JSON API responses to simple JSON objects and vice versa.
-* [Sarala](https://github.com/milroyfraser/sarala) is a javascript package which gives you a [Laravel Eloquent](https://laravel.com/docs/5.6/eloquent) like syntax to perform CRUD operations against an JSON API built according to [JSON API specification](http://jsonapi.org/format/).
+* [active-resource](https://github.com/nicklandgrebe/activeresource.js) A standalone, convention-driven JavaScript ORM that maps to your JSON:API server and allows for advanced queries and relational management through a smooth interface.
+* [redux-bees](https://github.com/cantierecreativo/redux-bees) A nice, short and declarative way to interact with JSON:APIs in React+Redux
+* [Coloquent](https://github.com/DavidDuwaer/Coloquent) Javascript/Typescript library mapping objects and their interrelations to JSON:API, with a clean, fluent ActiveRecord-like (e.g. similar to Laravel's Eloquent) syntax  for creating, retrieving, updating and deleting model objects.
+* [kitsu](https://github.com/wopian/kitsu) A simple, lightweight & framework agnostic JSON:API client
+* [Sarala JSON API data formatter](https://github.com/milroyfraser/sarala-json-api-data-formatter) is a simple and fluent framework agnostic javascript library to transform standard JSON:API responses to simple JSON objects and vice versa.
+* [Sarala](https://github.com/milroyfraser/sarala) is a javascript package which gives you a [Laravel Eloquent](https://laravel.com/docs/5.6/eloquent) like syntax to perform CRUD operations against an JSON:API built according to [JSON:API specification](http://jsonapi.org/format/).
 * [jsonapi-client](https://github.com/itsfadnis/jsonapi-client) A convenient module to consume a jsonapi service
 * [JSORM](https://jsonapi-suite.github.io/jsonapi_suite/js/home) is an
-isomorphic ActiveRecord clone that issues JSON API requests instead of SQL and is part of the larger [JSONAPI Suite](https://jsonapi-suite.github.io/jsonapi_suite).
+isomorphic ActiveRecord clone that issues JSON:API requests instead of SQL and is part of the larger [JSONAPI Suite](https://jsonapi-suite.github.io/jsonapi_suite).
 * [jsonapi-vuex](https://github.com/mrichar1/jsonapi-vuex) A module for interacting with a jsonapi service using a Vuex store, restructuring/normalizing records to make life easier.
 
 ### <a href="#client-libraries-typescript" id="client-libraries-typescript" class="headerlink"></a> Typescript
-* [ts-angular-jsonapi](https://github.com/reyesoft/ts-angular-jsonapi) A JSON API library developed for AngularJS in Typescript
-* [ngrx-json-api](https://github.com/abdulhaq-e/ngrx-json-api) A JSON API client for Angular 2 ngrx toolset
-* [ts-jsonapi](https://github.com/mohuk/ts-jsonapi) JSON API (De)Serializer in Typescript
-* [ngx-jsonapi](https://github.com/reyesoft/ngx-jsonapi) A JSON API fast client library for Angular with storage+memory cache.
+* [ts-angular-jsonapi](https://github.com/reyesoft/ts-angular-jsonapi) A JSON:API library developed for AngularJS in Typescript
+* [ngrx-json-api](https://github.com/abdulhaq-e/ngrx-json-api) A JSON:API client for Angular 2 ngrx toolset
+* [ts-jsonapi](https://github.com/mohuk/ts-jsonapi) JSON:API (De)Serializer in Typescript
+* [ngx-jsonapi](https://github.com/reyesoft/ngx-jsonapi) A JSON:API fast client library for Angular with storage+memory cache.
 * [@crnk/angular-ngrx](https://www.npmjs.com/package/@crnk/angular-ngrx) Angular helper library for ngrx-json-api and (optionally) crnk. Facilitates the binding of UI components to ngrx-json-api, most notably tables and forms.
 
 ### <a href="#client-libraries-ios" id="client-libraries-ios" class="headerlink"></a> iOS
 
-* [jsonapi-ios](https://github.com/joshdholtz/jsonapi-ios) is a library for loading data from a JSON API datasource. Parses JSON API data into models with support for auto-linking of resources and custom model classes.
-* [Spine](https://github.com/wvteijlingen/spine) is a Swift library for working with JSON API APIs. It supports mapping to custom model classes, fetching, advanced querying, linking and persisting.
-* [Vox](https://github.com/aronbalog/Vox) is a Swift JSON API client framework with custom model classes support and nice networking interface.
+* [jsonapi-ios](https://github.com/joshdholtz/jsonapi-ios) is a library for loading data from a JSON:API datasource. Parses JSON:API data into models with support for auto-linking of resources and custom model classes.
+* [Spine](https://github.com/wvteijlingen/spine) is a Swift library for working with JSON:API APIs. It supports mapping to custom model classes, fetching, advanced querying, linking and persisting.
+* [Vox](https://github.com/aronbalog/Vox) is a Swift JSON:API client framework with custom model classes support and nice networking interface.
 
 ### <a href="#client-libraries-ruby" id="client-libraries-ruby" class="headerlink"></a> Ruby
 
@@ -75,31 +75,31 @@ isomorphic ActiveRecord clone that issues JSON API requests instead of SQL and i
 
 * [Art4 / json-api-client](https://github.com/Art4/json-api-client) is a library for validating and handling the response body in a simple OOP way.
 * [woohoolabs / yang](https://github.com/woohoolabs/yang) is a PSR-7 compatible library that is able to build and send requests, and handle responses.
-* [enm/json-api-client](https://eosnewmedia.github.io/JSON-API-Client/) is an abstract client-side PHP implementation of the json api specification which is based on [enm/json-api-common](https://eosnewmedia.github.io/JSON-API-Common/). It allows you to send json api requests via your own http client implementation or via a buzz or guzzle client.
-* [pz/doctrine-rest](https://github.com/R3VoLuT1OneR/doctrine-rest) library provides basic tools for implementation of JSON API with Doctrine 2
+* [enm/json-api-client](https://eosnewmedia.github.io/JSON-API-Client/) is an abstract client-side PHP implementation of the json:api specification which is based on [enm/json-api-common](https://eosnewmedia.github.io/JSON-API-Common/). It allows you to send json:api requests via your own http client implementation or via a buzz or guzzle client.
+* [pz/doctrine-rest](https://github.com/R3VoLuT1OneR/doctrine-rest) library provides basic tools for implementation of JSON:API with Doctrine 2
 * [swisnl/json-api-client](https://github.com/swisnl/json-api-client) Is a package for mapping remote {json:api} resources to Eloquent like models and collections.
-* [jsonapi](https://www.drupal.org/project/jsonapi) is a Drupal module that exposes all data managed by Drupal (entities) according to the JSON API specification. [jsonapi_extras](https://www.drupal.org/project/jsonapi_extras) is an optional extra module to change resource type names, field names and more. And [openapi](https://www.drupal.org/project/openapi) is another optional module, that is able to generate an OpenAPI/Swagger representation of the API provided by the `jsonapi` module with a ReDoc-powered UI.
+* [jsonapi](https://www.drupal.org/project/jsonapi) is a Drupal module that exposes all data managed by Drupal (entities) according to the JSON:API specification. [jsonapi_extras](https://www.drupal.org/project/jsonapi_extras) is an optional extra module to change resource type names, field names and more. And [openapi](https://www.drupal.org/project/openapi) is another optional module, that is able to generate an OpenAPI/Swagger representation of the API provided by the `jsonapi` module with a ReDoc-powered UI.
 
 ### <a href="#client-libraries-dart" id="client-libraries-dart" class="headerlink"></a> Dart
 
-* [jsonapi_client](https://pub.dartlang.org/packages/jsonapi_client) is a simple JSON API v1.0 client written in Dart.
-* [json_api_document](https://pub.dartlang.org/packages/json_api_document) is a JSON API Document model/parser implemented in Dart.
+* [jsonapi_client](https://pub.dartlang.org/packages/jsonapi_client) is a simple JSON:API v1.0 client written in Dart.
+* [json_api_document](https://pub.dartlang.org/packages/json_api_document) is a JSON:API Document model/parser implemented in Dart.
 
 ### <a href="#client-libraries-perl" id="client-libraries-perl" class="headerlink"></a> Perl
 
-* [PONAPI::Client](https://metacpan.org/pod/PONAPI::Client) is a simple/extensible JSON API v1.0 client.
+* [PONAPI::Client](https://metacpan.org/pod/PONAPI::Client) is a simple/extensible JSON:API v1.0 client.
 
 ### <a href="#client-libraries-java" id="client-libraries-java" class="headerlink"></a> Java
 
-* [jsonapi-converter](https://github.com/jasminb/jsonapi-converter) is a Java JSON API v1.0 client. Besides providing means for serialisation/deserialisation, client comes with Retrofit plugin.
-* [crnk.io](http://www.crnk.io) is a JSON API framework for clients and servers. On the client-side it targets
+* [jsonapi-converter](https://github.com/jasminb/jsonapi-converter) is a Java JSON:API v1.0 client. Besides providing means for serialisation/deserialisation, client comes with Retrofit plugin.
+* [crnk.io](http://www.crnk.io) is a JSON:API framework for clients and servers. On the client-side it targets
   both Java and Android development. As for the backend side a rich set of modules helps with the integration of various
   Java frameworks.
 
 
 ### <a href="#client-libraries-android" id="client-libraries-android" class="headerlink"></a> Android
 * [faogustavo/JSONApi](https://github.com/faogustavo/JSONApi) library for deserializing automatic. It can be integrated with retrofit. It has some ideas from Morpheus and jsonapi-converter but has some aditionals.
-* [moshi-jsonapi](https://github.com/kamikat/moshi-jsonapi) serialize/deserialize JSON API v1.0 using fantistic Moshi API! With friendly Java interface and easy integration with Retrofit.
+* [moshi-jsonapi](https://github.com/kamikat/moshi-jsonapi) serialize/deserialize JSON:API v1.0 using fantistic Moshi API! With friendly Java interface and easy integration with Retrofit.
 * [Morpheus](https://github.com/xamoom/Morpheus) library for deserializing your resources with automatic mapping for relationships. Uses gson to map objects in attributes.
 
 ### <a href="#client-libraries-r" id="client-libraries-r" class="headerlink"></a> R
@@ -108,59 +108,59 @@ isomorphic ActiveRecord clone that issues JSON API requests instead of SQL and i
 
 ### <a href="#client-libraries-elm" id="client-libraries-elm" class="headerlink"></a> Elm
 
-* [elm-jsonapi](https://github.com/noahzgordon/elm-jsonapi) provides decoders and helper functions for clients receiving JSON API payloads.
-* [elm-jsonapi-http](https://github.com/noahzgordon/elm-jsonapi-http) wraps `elm-jsonapi` and handles the details of content negotiation with JSON API-compliant servers, providing a smoother inteface for consumers.
+* [elm-jsonapi](https://github.com/noahzgordon/elm-jsonapi) provides decoders and helper functions for clients receiving JSON:API payloads.
+* [elm-jsonapi-http](https://github.com/noahzgordon/elm-jsonapi-http) wraps `elm-jsonapi` and handles the details of content negotiation with JSON:API-compliant servers, providing a smoother inteface for consumers.
 
 ### <a href="#client-libraries-net" id="client-libraries-net" class="headerlink"></a> .NET
 
 * [Hypermedia.JsonApi.Client](https://github.com/cosullivan/Hypermedia/) is a set of extension methods to the HttpClient which allow for reading
-and writing of JSON API documents.
-* [JsonApiSerializer](https://github.com/codecutout/JsonApiSerializer) is a configurationless JSON API serialization and deserialization library implemented as a Json.NET `JsonSerializerSetting`. It leverages the existing power and flexiability of Json.NET while providing a sensible default mapping between JSON API and CLR objects.
-* [JsonApiFramework.Client](https://github.com/scott-mcdonald/JsonApiFramework) is a *portable* .NET Standard/Core client-side framework where developers define the domain model of the resources of a hypermedia API server either through configuration and/or conventions called a *service model*. With a *service model* developers can use a *document context* that represents a session with a JSON API compound *document* for reading or writing of various JSON API abstractions such as resources, resource identifiers, relationships, links, meta information, error objects, and version information all serialized/deserialized as high level CLR objects.
+and writing of JSON:API documents.
+* [JsonApiSerializer](https://github.com/codecutout/JsonApiSerializer) is a configurationless JSON:API serialization and deserialization library implemented as a Json.NET `JsonSerializerSetting`. It leverages the existing power and flexiability of Json.NET while providing a sensible default mapping between JSON:API and CLR objects.
+* [JsonApiFramework.Client](https://github.com/scott-mcdonald/JsonApiFramework) is a *portable* .NET Standard/Core client-side framework where developers define the domain model of the resources of a hypermedia API server either through configuration and/or conventions called a *service model*. With a *service model* developers can use a *document context* that represents a session with a JSON:API compound *document* for reading or writing of various JSON:API abstractions such as resources, resource identifiers, relationships, links, meta information, error objects, and version information all serialized/deserialized as high level CLR objects.
 
 ### <a href="#client-libraries-python" id="client-libraries-python" class="headerlink"></a> Python
 
 * [jsonapi-requests](https://github.com/socialwifi/jsonapi-requests/) Simple and fun high-level JSONAPI client for Python. Contains ORM which makes consuming the API even easier, in a DRY manner. It has a low-level API similiar to requests as well, which gives you all the flexibility that you may need.
-* [jsonapi-client](https://github.com/qvantel/jsonapi-client) Comprehensive yet easy-to-use, pythonic, ORM-like access to JSON API services
-* [json-api-doc](https://github.com/noplay/json-api-doc) JSON API parser returning a simple Python dictionary
+* [jsonapi-client](https://github.com/qvantel/jsonapi-client) Comprehensive yet easy-to-use, pythonic, ORM-like access to JSON:API services
+* [json-api-doc](https://github.com/noplay/json-api-doc) JSON:API parser returning a simple Python dictionary
 
 ### <a href="#client-libraries-elixir" id="client-libraries-elixir" class="headerlink"></a> Elixir
 
-* [JsonApiClient](https://github.com/Decisiv/json_api_client) JSON API Client Library For Elixir
+* [JsonApiClient](https://github.com/Decisiv/json_api_client) JSON:API Client Library For Elixir
 
 ## <a href="#server-libraries" id="server-libraries" class="headerlink"></a> Server libraries
 
 ### <a href="#server-libraries-swift" id="server-libraries-swift" class="headerlink"></a> Swift
-* [aonawale / JSONAPISerializer](https://github.com/aonawale/JSONAPISerializer) is a server side swift framework agnostic library that implements JSON API v1.0.
+* [aonawale / JSONAPISerializer](https://github.com/aonawale/JSONAPISerializer) is a server side swift framework agnostic library that implements JSON:API v1.0.
 
 ### <a href="#server-libraries-php" id="server-libraries-php" class="headerlink"></a> PHP
 
 * [tobscure / json-api](https://github.com/tobscure/json-api)
-* [neomerx / json-api](https://github.com/neomerx/json-api) is a framework agnostic library that fully implements JSON API v1.0.
-* [limoncello-php / app](https://github.com/limoncello-php/app) is a JSON API v1.0 quick start server application for [neomerx / json-api](https://github.com/neomerx/json-api).
+* [neomerx / json-api](https://github.com/neomerx/json-api) is a framework agnostic library that fully implements JSON:API v1.0.
+* [limoncello-php / app](https://github.com/limoncello-php/app) is a JSON:API v1.0 quick start server application for [neomerx / json-api](https://github.com/neomerx/json-api).
 * [lode / jsonapi](https://github.com/lode/jsonapi) a simple and friendly library, easy to understand for people without knowledge of the specification.
 * [woohoolabs / yin](https://github.com/woohoolabs/yin) is a library for advanced users aiming for efficiency and elegance.
-* [nilportugues / json-api](https://github.com/nilportugues/json-api) Serializer transformers outputting valid API responses in JSON and JSON API formats.
-* [nilportugues / symfony2-jsonapi-transformer](https://github.com/nilportugues/symfony2-jsonapi-transformer) Symfony 2 JSON API Transformer Bundle outputting valid API responses in JSON and JSON API formats.
-* [nilportugues / laravel5-jsonapi-transformer](https://github.com/nilportugues/laravel5-jsonapi-transformer) Laravel 5 JSON API Transformer Package outputting valid API responses in JSON and JSON API formats.
-* [tuyakhov / yii2-json-api](https://github.com/tuyakhov/yii2-json-api) Implementation of JSON API specification for the Yii framework.
-* [json-api-php/json-api](https://github.com/json-api-php/json-api) An attempt to translate the JSON API specification into a set of high quality unit/functional tests and implement it in PHP 7 strictly following TDD and SOLID OOP principles.
-* [cloudcreativity/laravel-json-api](https://github.com/cloudcreativity/laravel-json-api) JSON API (jsonapi.org) package for Laravel applications. This project extends cloudcreativity/json-api, adding in framework-specific features.
-* [FriendsOfCake/crud-json-api](https://github.com/FriendsOfCake/crud-json-api) CakePHP Crud Listener for building maintainable JSON API compliant APIs.
-* [thephpleague/fractal](http://fractal.thephpleague.com/) A partial implementation of the JSON API spec allowing for an easy drop in JSON rendering solution.
-* [oligus/jad](https://github.com/oligus/jad) A library that turns doctrine entities into json api resource, or collection of resources, automagically.
-* [enm/json-api-server](https://eosnewmedia.github.io/JSON-API-Server/) is an abstract server-side PHP (>= 7.2) implementation of the json api specification, based on [enm/json-api-common](https://eosnewmedia.github.io/JSON-API-Common/). It handles json api requests via request handlers through a centralized handle-method. It can be used with psr-7-request/response or your own request and response logic.
+* [nilportugues / json-api](https://github.com/nilportugues/json-api) Serializer transformers outputting valid API responses in JSON and JSON:API formats.
+* [nilportugues / symfony2-jsonapi-transformer](https://github.com/nilportugues/symfony2-jsonapi-transformer) Symfony 2 JSON:API Transformer Bundle outputting valid API responses in JSON and JSON:API formats.
+* [nilportugues / laravel5-jsonapi-transformer](https://github.com/nilportugues/laravel5-jsonapi-transformer) Laravel 5 JSON:API Transformer Package outputting valid API responses in JSON and JSON:API formats.
+* [tuyakhov / yii2-json-api](https://github.com/tuyakhov/yii2-json-api) Implementation of JSON:API specification for the Yii framework.
+* [json-api-php/json-api](https://github.com/json-api-php/json-api) An attempt to translate the JSON:API specification into a set of high quality unit/functional tests and implement it in PHP 7 strictly following TDD and SOLID OOP principles.
+* [cloudcreativity/laravel-json-api](https://github.com/cloudcreativity/laravel-json-api) JSON:API (jsonapi.org) package for Laravel applications. This project extends cloudcreativity/json-api, adding in framework-specific features.
+* [FriendsOfCake/crud-json-api](https://github.com/FriendsOfCake/crud-json-api) CakePHP Crud Listener for building maintainable JSON:API compliant APIs.
+* [thephpleague/fractal](http://fractal.thephpleague.com/) A partial implementation of the JSON:API spec allowing for an easy drop in JSON rendering solution.
+* [oligus/jad](https://github.com/oligus/jad) A library that turns doctrine entities into json:api resource, or collection of resources, automagically.
+* [enm/json-api-server](https://eosnewmedia.github.io/JSON-API-Server/) is an abstract server-side PHP (>= 7.2) implementation of the json:api specification, based on [enm/json-api-common](https://eosnewmedia.github.io/JSON-API-Common/). It handles json:api requests via request handlers through a centralized handle-method. It can be used with psr-7-request/response or your own request and response logic.
 * [enm/json-api-server-bundle](https://eosnewmedia.github.io/JSON-API-Server-Bundle/) is a symfony bundle which integrates [enm/json-api-server](https://eosnewmedia.github.io/JSON-API-Server/) into your symfony application (symfony version ^4.0).
-* [raml-json-api](https://github.com/RJAPI/raml-json-api) RAML based JSON API code generator for Laravel. Generates controllers, middlewares, models, routes, migrations and serves JSON API.
+* [raml-json-api](https://github.com/RJAPI/raml-json-api) RAML based JSON:API code generator for Laravel. Generates controllers, middlewares, models, routes, migrations and serves JSON:API.
 * [paknahad/jsonapi-bundle](https://github.com/paknahad/jsonapi-bundle) is a Symfony bundle. It is the fastest way to generate API.
 * [swisnl/json-api-server](https://github.com/swisnl/json-api-server) is a Laravel package to get a JSON:API up and running in minutes.
 
 ### <a href="#server-libraries-node-js" id="server-libraries-node-js" class="headerlink"></a> Node.js
-* [Fortune.js](http://fortune.js.org/) is a library that includes a [comprehensive implementation of JSON API](https://github.com/fortunejs/fortune-json-api).
+* [Fortune.js](http://fortune.js.org/) is a library that includes a [comprehensive implementation of JSON:API](https://github.com/fortunejs/fortune-json-api).
 * [json-api](https://www.npmjs.org/package/json-api) turns an Express + Mongoose app into a JSON-API server.
-* [endpoints](https://github.com/endpoints) is an implementation of JSON API using [Bookshelf](http://bookshelfjs.org).
-* [YAYSON](https://github.com/confetti/yayson) is an isomorphic library for serializing and reading JSON API data. Simply use it with plain objects or extend it to fit your ORM (currently it has an adapter for [Sequelize](http://sequelizejs.com)).
-* [jsonapi-serializer](https://github.com/SeyZ/jsonapi-serializer) is a Node.js framework agnostic library for serializing your data to JSON API.
+* [endpoints](https://github.com/endpoints) is an implementation of JSON:API using [Bookshelf](http://bookshelfjs.org).
+* [YAYSON](https://github.com/confetti/yayson) is an isomorphic library for serializing and reading JSON:API data. Simply use it with plain objects or extend it to fit your ORM (currently it has an adapter for [Sequelize](http://sequelizejs.com)).
+* [jsonapi-serializer](https://github.com/SeyZ/jsonapi-serializer) is a Node.js framework agnostic library for serializing your data to JSON:API.
 * [jsonapi-server](https://github.com/holidayextras/jsonapi-server) A feature-rich config-driven json:api framework.
   * [jsonapi-store-memoryhandler](https://github.com/holidayextras/jsonapi-server/blob/master/documentation/resources.md) An in-memory data store for rapid prototyping.
   * [jsonapi-store-relationaldb](https://github.com/holidayextras/jsonapi-store-relationaldb) A relational database handler for jsonapi-server.
@@ -168,26 +168,26 @@ and writing of JSON API documents.
   * [jsonapi-store-elasticsearch](https://github.com/holidayextras/jsonapi-store-elasticsearch) An elasticsearch handler for jsonapi-server.
 * [jagql](https://jagql.github.io) A resource driven framework to set up a {json:api} + GraphQL endpoint in record time.
   * [jagql/store-sequelize](https://npmjs.com/@jagql/store-sequelize) persist jagql resources to Postgres/MySQL/MSSQL/SQLite
-* [loopback-component-jsonapi](https://github.com/digitalsadhu/loopback-component-jsonapi) JSON API support for [loopback](https://github.com/strongloop/loopback) highly-extensible, open-source Node.js framework
-* [loopback-jsonapi-model-serializer](https://www.npmjs.com/package/loopback-jsonapi-model-serializer) JSON API serializer for loopback models.
-* [jsonapi-mapper](https://github.com/scoutforpets/jsonapi-mapper) JSON API-Compliant Serialization for your Node ORM.
-* [jaysonapi](https://github.com/digia/jaysonapi) jaysonapi is a framework agnostic JSON API v1.0.0 serializer. jaysonapi provides more of a functional approach to serializing your data. Define a serializer with a type and schema, and call serialize on it passing in the data, included, meta, errors, etc. as a plain object.
-* [json-api-ify](https://github.com/kutlerskaggs/json-api-ify) serialize the **** out of your data. json api v1.0 complaint.
-* [bookshelf-jsonapi-params](https://github.com/scoutforpets/bookshelf-jsonapi-params) automatically apply JSON API filtering, pagination, sparse fieldsets, includes, and sorting to your Bookshelf.js queries.
-* [Lux](https://github.com/postlight/lux) is a MVC style Node.js framework for building lightning fast JSON APIs.
-* [transformalizer](https://github.com/GaiamTV/transformalizer) a bare bones node module for transforming raw data into JSON API compliant payloads that makes no assumption regarding the shape of your data and sdks used, supports the full v1.0 specification, and supports dynamic transformations, links, and meta at all levels of a document.
+* [loopback-component-jsonapi](https://github.com/digitalsadhu/loopback-component-jsonapi) JSON:API support for [loopback](https://github.com/strongloop/loopback) highly-extensible, open-source Node.js framework
+* [loopback-jsonapi-model-serializer](https://www.npmjs.com/package/loopback-jsonapi-model-serializer) JSON:API serializer for loopback models.
+* [jsonapi-mapper](https://github.com/scoutforpets/jsonapi-mapper) JSON:API-Compliant Serialization for your Node ORM.
+* [jaysonapi](https://github.com/digia/jaysonapi) jaysonapi is a framework agnostic JSON:API v1.0.0 serializer. jaysonapi provides more of a functional approach to serializing your data. Define a serializer with a type and schema, and call serialize on it passing in the data, included, meta, errors, etc. as a plain object.
+* [json-api-ify](https://github.com/kutlerskaggs/json-api-ify) serialize the **** out of your data. json:api v1.0 complaint.
+* [bookshelf-jsonapi-params](https://github.com/scoutforpets/bookshelf-jsonapi-params) automatically apply JSON:API filtering, pagination, sparse fieldsets, includes, and sorting to your Bookshelf.js queries.
+* [Lux](https://github.com/postlight/lux) is a MVC style Node.js framework for building lightning fast JSON:APIs.
+* [transformalizer](https://github.com/GaiamTV/transformalizer) a bare bones node module for transforming raw data into JSON:API compliant payloads that makes no assumption regarding the shape of your data and sdks used, supports the full v1.0 specification, and supports dynamic transformations, links, and meta at all levels of a document.
 * [jsonapi-mock](https://github.com/Thomas-X/jsonapi-mock) A [json-server](https://github.com/typicode/json-server) inspired jsonapi mock server. Setup a jsonapi mock server in almost no time, uses lowdb.
 * [DenaliJS](http://denalijs.org) A layered-conventions framework for building ambitious APIs. Includes a powerful addon system, best-in-class developer experience, and extensive documentation.
 
 ### <a href="#server-libraries-ruby" id="server-libraries-ruby" class="headerlink"></a> Ruby
 
 * Plain Ruby
-  * [Yaks](https://github.com/plexus/yaks) Library for building hypermedia APIs, contains a JSON API output format.
+  * [Yaks](https://github.com/plexus/yaks) Library for building hypermedia APIs, contains a JSON:API output format.
   * [JSONAPI::Serializers](https://github.com/fotinakis/jsonapi-serializers) provides a pure Ruby, readonly serializer implementation.
   * [JSONAPI::Realizer](https://github.com/krainboltgreene/jsonapi-realizer) provides a pure Ruby pattern for turning JSON:API requests into models (has active record support and rails instructions)
   * [Roar](https://github.com/apotonick/roar) Renders and parses represenations of Ruby objects
   * [Jbuilder::JsonAPI](https://github.com/vladfaust/jbuilder-json_api) Simple & lightweight extension for Jbuilder
-  * [jsonapi-rb](http://jsonapi-rb.org) Ruby library for efficiently building and consuming JSON API documents - with Rails and Hanami integrations.
+  * [jsonapi-rb](http://jsonapi-rb.org) Ruby library for efficiently building and consuming JSON:API documents - with Rails and Hanami integrations.
   * [fast_jsonapi](https://github.com/Netflix/fast_jsonapi) A lightning fast JSON:API serializer for Ruby Objects.
 
 * Ruby on Rails
@@ -196,66 +196,66 @@ empowers your JSONAPI compliant [Rails](http://rubyonrails.org/) APIs. Implement
   * [ActiveModel::Serializers](https://github.com/rails-api/active_model_serializers)
 is one of the original exemplar implementations, but is slightly out of date at
 the moment.
-  * [JSONAPI::Resources](https://github.com/cerebris/jsonapi-resources) provides a complete framework for developing a JSON API server. It is designed to work with Rails, and provides routes, controllers, and serializers.
+  * [JSONAPI::Resources](https://github.com/cerebris/jsonapi-resources) provides a complete framework for developing a JSON:API server. It is designed to work with Rails, and provides routes, controllers, and serializers.
   * [JSONAPI::Utils](https://github.com/b2beauty/jsonapi-utils) works on top of [JSONAPI::Resources](https://github.com/cerebris/jsonapi-resources) taking advantage of its resource-driven style and bringing a Rails way to build modern APIs with no or less learning curve.
-  * [Caprese](https://github.com/nicklandgrebe/caprese) An opinionated Rails library for creating JSON API servers that lets you focus on customizing the behavior of your endpoints rather than the dirty work of setting them up. Leverages the power of [ActiveModel::Serializer](https://github.com/rails-api/active_model_serializers).
+  * [Caprese](https://github.com/nicklandgrebe/caprese) An opinionated Rails library for creating JSON:API servers that lets you focus on customizing the behavior of your endpoints rather than the dirty work of setting them up. Leverages the power of [ActiveModel::Serializer](https://github.com/rails-api/active_model_serializers).
   * [JSONAPI Suite](https://jsonapi-suite.github.io/jsonapi_suite)
   facilitates a server capable of deep querying and nested writes. Works
   with any ORM or datastore; comes with integration test helpers and
   automatic swagger documentation.
 
 * Sinatra
-  * [Sinja](https://github.com/mwpastore/sinja) extends [Sinatra](http://www.sinatrarb.com) and leverages [JSONAPI::Serializers](https://github.com/fotinakis/jsonapi-serializers) to enable rapid development of comprehensive, read-and-write, and JSON API v1.0-compliant web services using the DAL/ORM of your choice. It includes a simple role-based authorization scheme, support for client-generated IDs, patchless clients, and coalesced find requests, exception handling, and more.
+  * [Sinja](https://github.com/mwpastore/sinja) extends [Sinatra](http://www.sinatrarb.com) and leverages [JSONAPI::Serializers](https://github.com/fotinakis/jsonapi-serializers) to enable rapid development of comprehensive, read-and-write, and JSON:API v1.0-compliant web services using the DAL/ORM of your choice. It includes a simple role-based authorization scheme, support for client-generated IDs, patchless clients, and coalesced find requests, exception handling, and more.
 
 ### <a href="#server-libraries-python" id="server-libraries-python" class="headerlink"></a> Python
 
 * [Hyp](https://github.com/kalasjocke/hyp) is a library for creating json-api responses.
-* [SQLAlchemy-JSONAPI](https://github.com/coltonprovias/sqlalchemy-jsonapi) provides JSON API serialization for SQLAlchemy models.
-* [django-rest-framework-json-api](https://github.com/django-json-api/django-rest-framework-json-api) provides JSON API parsing and rendering for the Django REST Framework
-* [jsonapi](https://github.com/pavlov99/jsonapi) is a Django module with JSON API implementation.
-* [jsoongia](https://github.com/digia/jsoongia) is a framework agnostic JSON API implementation.
-* [ripozo](https://github.com/vertical-knowledge/ripozo/) provides a framework for serving JSON API content (among other Hypermedia formats) in Flask, Django and more.
-* [marshmallow-jsonapi](https://github.com/marshmallow-code/marshmallow-jsonapi) provides JSON API data formatting for any Python web framework.
-* [neoapi](https://pypi.python.org/pypi/neoapi/) serializes JSON API–compliant responses from neomodel StructuredNodes for Neo4j data
+* [SQLAlchemy-JSONAPI](https://github.com/coltonprovias/sqlalchemy-jsonapi) provides JSON:API serialization for SQLAlchemy models.
+* [django-rest-framework-json-api](https://github.com/django-json-api/django-rest-framework-json-api) provides JSON:API parsing and rendering for the Django REST Framework
+* [jsonapi](https://github.com/pavlov99/jsonapi) is a Django module with JSON:API implementation.
+* [jsoongia](https://github.com/digia/jsoongia) is a framework agnostic JSON:API implementation.
+* [ripozo](https://github.com/vertical-knowledge/ripozo/) provides a framework for serving JSON:API content (among other Hypermedia formats) in Flask, Django and more.
+* [marshmallow-jsonapi](https://github.com/marshmallow-code/marshmallow-jsonapi) provides JSON:API data formatting for any Python web framework.
+* [neoapi](https://pypi.python.org/pypi/neoapi/) serializes JSON:API–compliant responses from neomodel StructuredNodes for Neo4j data
 * [xamoom-janus](https://github.com/xamoom/xamoom-janus) is a Python module to easily and fast extend Python web frameworks like Flask or BottlyPy with json:api functionality. Also offers a flexible mechanism for data mapping and hooks to intercept and extend its functionality according to your projects needs.
-* [pyramid-jsonapi](https://github.com/colinhiggs/pyramid-jsonapi) Auto-build a JSON API from sqlalchemy models using the pyramid framework.
+* [pyramid-jsonapi](https://github.com/colinhiggs/pyramid-jsonapi) Auto-build a JSON:API from sqlalchemy models using the pyramid framework.
 * [Flask-REST-JSONAPI](https://github.com/miLibris/flask-rest-jsonapi) Flask extension to create web api according to jsonapi specification with Flask, Marshmallow and data provider of your choice (SQLAlchemy, MongoDB, ...)
-* [Flump](https://github.com/rolepoint/flump) Database agnostic JSON API builder which depends on Flask and Marshmallow.
+* [Flump](https://github.com/rolepoint/flump) Database agnostic JSON:API builder which depends on Flask and Marshmallow.
 * [SAFRS JSON API Framework](https://github.com/thomaxxl/safrs) Flask-SQLAlchemy jsonapi implementation with auto-generated openapi (fka swagger) interface.
 
 ### <a href="#server-libraries-go" id="server-libraries-go" class="headerlink"></a> Go
 
-* [api2go](https://github.com/manyminds/api2go) is a full-fledged library to make it simple to provide a JSON API with your Golang project.
+* [api2go](https://github.com/manyminds/api2go) is a full-fledged library to make it simple to provide a JSON:API with your Golang project.
 * [jsonapi](https://github.com/google/jsonapi) serializes and deserializes jsonapi formatted payloads using struct tags to annotate the structs that you already have in your Golang project. [Godoc](http://godoc.org/github.com/google/jsonapi)
 * [go-json-spec-handler](https://github.com/derekdowling/go-json-spec-handler) drop-in library for handling requests and sending responses in an existing API.
-* [jsh-api](https://github.com/derekdowling/go-json-spec-handler/tree/master/jsh-api) deals with the dirty work of building JSON API resource endpoints. Built on top of [jsh](https://github.com/derekdowling/go-json-spec-handler)
+* [jsh-api](https://github.com/derekdowling/go-json-spec-handler/tree/master/jsh-api) deals with the dirty work of building JSON:API resource endpoints. Built on top of [jsh](https://github.com/derekdowling/go-json-spec-handler)
 
 ### <a href="#server-libraries-net" id="server-libraries-net" class="headerlink"></a> .NET
 
-* [JsonApiNet](https://github.com/l8nite/JsonApiNet) lets you quickly deserialize JSON API documents into C# entities. Supports compound documents, complex type mapping from attributes, attribute mapping, and more. [See the README](https://github.com/l8nite/JsonApiNet/blob/master/README.md) for full details.
+* [JsonApiNet](https://github.com/l8nite/JsonApiNet) lets you quickly deserialize JSON:API documents into C# entities. Supports compound documents, complex type mapping from attributes, attribute mapping, and more. [See the README](https://github.com/l8nite/JsonApiNet/blob/master/README.md) for full details.
 * [NJsonApi](https://github.com/jacek-gorgon/NJsonApi) is a .NET server implementation of the standard. It aims at good extensibility and performance while maintaining developer-friendliness with interchangable convenions and builder-style configuration.
-* [Migrap.AspNet.Mvc.Jsonapi](https://github.com/migrap/Migrap.AspNet.Mvc.Jsonapi) is an ASP.NET 5 (vNext) library that allows for existing code to build JSON API responses through output formatters.
-* [Saule](https://github.com/joukevandermaas/saule/) is a small JSON API 1.0 compatible library that integrates well with established Web API conventions. It has complete documentation and near 100% test coverage.
+* [Migrap.AspNet.Mvc.Jsonapi](https://github.com/migrap/Migrap.AspNet.Mvc.Jsonapi) is an ASP.NET 5 (vNext) library that allows for existing code to build JSON:API responses through output formatters.
+* [Saule](https://github.com/joukevandermaas/saule/) is a small JSON:API 1.0 compatible library that integrates well with established Web API conventions. It has complete documentation and near 100% test coverage.
 * [JsonApiDotNetCore](https://github.com/json-api-dotnet/JsonApiDotNetCore) is an ASP.Net Core server implementation targeting .Net Standard. Based on the [JR](https://github.com/cerebris/jsonapi-resources) implementation, it provides all the required controllers and middleware to get your application up and running with as little boilerplate as possible.
-* [Hypermedia.JsonApi.WebApi](https://github.com/cosullivan/Hypermedia/) is a Web API media type formatter for reading and writing JSON API. It supports an external resource model definition and natively
+* [Hypermedia.JsonApi.WebApi](https://github.com/cosullivan/Hypermedia/) is a Web API media type formatter for reading and writing JSON:API. It supports an external resource model definition and natively
 includes related resources.
-* [JsonApiSerializer](https://github.com/codecutout/JsonApiSerializer) is a configurationless JSON API serialization and deserialization library implemented as a Json.NET `JsonSerializerSetting`. It leverages the existing power and flexiability of Json.NET while providing a sensible default mapping between JSON API and CLR objects.
-* [JsonApiFramework.Server](https://github.com/scott-mcdonald/JsonApiFramework) is a *portable* .NET Standard/Core server-side framework where developers define the domain model of the resources of a hypermedia API server either through configuration and/or conventions called a *service model*. With a *service model* developers can use a *document context* that represents a session with a JSON API compound *document* for reading or writing of various JSON API abstractions such as resources, resource identifiers, relationships, links, meta information, error objects, and version information all serialized/deserialized as high level CLR objects with automatic generation of JSON API hypermedia.
+* [JsonApiSerializer](https://github.com/codecutout/JsonApiSerializer) is a configurationless JSON:API serialization and deserialization library implemented as a Json.NET `JsonSerializerSetting`. It leverages the existing power and flexiability of Json.NET while providing a sensible default mapping between JSON:API and CLR objects.
+* [JsonApiFramework.Server](https://github.com/scott-mcdonald/JsonApiFramework) is a *portable* .NET Standard/Core server-side framework where developers define the domain model of the resources of a hypermedia API server either through configuration and/or conventions called a *service model*. With a *service model* developers can use a *document context* that represents a session with a JSON:API compound *document* for reading or writing of various JSON:API abstractions such as resources, resource identifiers, relationships, links, meta information, error objects, and version information all serialized/deserialized as high level CLR objects with automatic generation of JSON:API hypermedia.
 
 ### <a href="#server-libraries-java" id="server-libraries-java" class="headerlink"></a> Java
 
 * [katharsis](http://katharsis.io) has comprehensive coverage of standard allowing to create JSON:API compatible resources with dynamic relation based routing. Library consist of several integrations:
-  * katharsis-core - Java based core library for Katharsis allowing to manage RESTful endpoints compliant with JSON API standard.
+  * katharsis-core - Java based core library for Katharsis allowing to manage RESTful endpoints compliant with JSON:API standard.
   * katharsis-rs - adapter for Katharsis core module for all compatible JAX-RS based frameworks.
   * katharsis-spring - adapter for Katharsis core module for Spring and Spring Boot framoworks.
   * katharsis-servlet - generic servlet/filter adapter for Katharsis core module. This module can be used in traditional servlet or filter based Java web applications, or even non-Servlet-API-based web applications such as Portal/Portlet, Wicket, etc.
-* [Elide](http://elide.io) is a web framework supporting JSON API. Through annotation-based JSON API endpoint generation, Elide enables you to focus on your data model, security model, and business logic while avoiding unnecessary boilerplate. Moreover, through use of the JSON API Patch extension, [Elide](http://elide.io) provides full support for database transactions.
-* [crnk.io](http://www.crnk.io) is a JSON API framework for clients and servers. On the server-side it comes, among others,
+* [Elide](http://elide.io) is a web framework supporting JSON:API. Through annotation-based JSON:API endpoint generation, Elide enables you to focus on your data model, security model, and business logic while avoiding unnecessary boilerplate. Moreover, through use of the JSON:API Patch extension, [Elide](http://elide.io) provides full support for database transactions.
+* [crnk.io](http://www.crnk.io) is a JSON:API framework for clients and servers. On the server-side it comes, among others,
   with a rich set of integrations (Servlet, JAX-RS, Spring, JPA, Bean Validation, Zipkin and more), bulk updates with JSON Patch,
   a meta-model for automation purposes, client stub generation for TypeScript and a module API for third-party contributions.
 
 ### <a href="#server-libraries-scala" id="server-libraries-scala" class="headerlink"></a> Scala
-* [scala-jsonapi](https://github.com/scala-jsonapi/scala-jsonapi) A Scala library for producing JSON output (and deserializing JSON input) based on JSON API specification.
+* [scala-jsonapi](https://github.com/scala-jsonapi/scala-jsonapi) A Scala library for producing JSON output (and deserializing JSON input) based on JSON:API specification.
 
 ### <a href="#server-libraries-elixir" id="server-libraries-elixir" class="headerlink"></a> Elixir
 
@@ -289,8 +289,8 @@ includes related resources.
 
 * [json-api-document-viewer](https://tadast.github.io/json-api-document-viewer) the flat json:api structure is a good way to express complex relationships between objects. However the same flatness makes it difficult for humans to "parse" these relationships. This tool visualises object relationships by visually nesting them.
 * [jsonapi-validator](https://jsonapi-validator.herokuapp.com) is a playground service for quick prototyping and validating JSON responses with jsonapi.org specification.
-* [corroborate](http://corroborate.arenpatel.com/) JSON API request/response payload validator. It warns when there is a specification violation and also informs when a recommendation has not been followed.
-* [JSON API Playground](http://jsonapiplayground.reyesoft.com/) Fake online JSON API server for testing and prototyping. It's great for tutorials, faking a server, sharing code examples, etc.
+* [corroborate](http://corroborate.arenpatel.com/) JSON:API request/response payload validator. It warns when there is a specification violation and also informs when a recommendation has not been followed.
+* [JSON API Playground](http://jsonapiplayground.reyesoft.com/) Fake online JSON:API server for testing and prototyping. It's great for tutorials, faking a server, sharing code examples, etc.
 
 ### <a href="#related-tools-ruby" id="related-tools-ruby" class="headerlink"></a> Ruby
 

--- a/index.md
+++ b/index.md
@@ -5,17 +5,17 @@ show_masthead: true
 ---
 
 If you've ever argued with your team about the way your JSON responses
-should be formatted, JSON API can be your anti-[bikeshedding](http://bikeshed.org) tool.
+should be formatted, JSON:API can be your anti-[bikeshedding](http://bikeshed.org) tool.
 
 By following shared conventions, you can increase productivity,
 take advantage of generalized tooling, and focus on what
 matters: your application.
 
-Clients built around JSON API are able to take
+Clients built around JSON:API are able to take
 advantage of its features around efficiently caching responses,
 sometimes eliminating network requests entirely.
 
-Here's an example response from a blog that implements JSON API:
+Here's an example response from a blog that implements JSON:API:
 
 ```json
 {
@@ -28,7 +28,7 @@ Here's an example response from a blog that implements JSON API:
     "type": "articles",
     "id": "1",
     "attributes": {
-      "title": "JSON API paints my bikeshed!"
+      "title": "JSON:API paints my bikeshed!"
     },
     "relationships": {
       "author": {
@@ -102,21 +102,21 @@ linked to the article, including its author and comments. Last but not least,
 links are provided that can be used to fetch or update any of these
 resources.
 
-JSON API covers creating and updating resources as well, not just responses.
+JSON:API covers creating and updating resources as well, not just responses.
 
 ## <a href="#mime-types" id="mime-types" class="headerlink"></a> MIME Types
 
-JSON API has been properly registered with the IANA. Its media
+JSON:API has been properly registered with the IANA. Its media
 type designation is [`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json).
 
 ## <a href="#format-documentation" id="format-documentation" class="headerlink"></a> Format documentation
 
-To get started with JSON API, check out [documentation for the base
+To get started with JSON:API, check out [documentation for the base
 specification](/format).
 
 ## <a href="#extensions" id="extensions" class="headerlink"></a> Extensions
 
-JSON API has [experimental support for extensions](/extensions).
+JSON:API has [experimental support for extensions](/extensions).
 
 Official extensions are being developed for [Bulk](/extensions/bulk/) and
 [JSON Patch](/extensions/jsonpatch/) operations.

--- a/recommendations/index.md
+++ b/recommendations/index.md
@@ -4,9 +4,9 @@ title: "Recommendations"
 show_sidebar: true
 ---
 
-This section contains recommendations for JSON API implementations. These
+This section contains recommendations for JSON:API implementations. These
 recommendations are intended to establish a level of consistency in areas that
-are beyond the scope of the base JSON API specification.
+are beyond the scope of the base JSON:API specification.
 
 ## <a href="#naming" id="naming" class="headerlink"></a> Naming
 
@@ -193,7 +193,7 @@ requests honored, simply by adding the header.
 
 ## <a href="#date-and-time-fields" id="date-and-time-fields" class="headerlink"></a> Formatting Date and Time Fields
 
-Although JSON API does not specify the format of date and time fields, it is
+Although JSON:API does not specify the format of date and time fields, it is
 recommended that servers align with ISO 8601. [This W3C
 NOTE](http://www.w3.org/TR/NOTE-datetime) provides an overview of the
 recommended formats.

--- a/schema
+++ b/schema
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "JSON API Schema",
-  "description": "This is a schema for responses in the JSON API format. For more, see http://jsonapi.org",
+  "title": "JSON:API Schema",
+  "description": "This is a schema for responses in the JSON:API format. For more, see http://jsonapi.org",
   "oneOf": [
     {
       "$ref": "#/definitions/success"
@@ -122,7 +122,7 @@
       ]
     },
     "resource": {
-      "description": "\"Resource objects\" appear in a JSON API document to represent resources.",
+      "description": "\"Resource objects\" appear in a JSON:API document to represent resources.",
       "type": "object",
       "required": [
         "type",


### PR DESCRIPTION
As mentioned in https://github.com/json-api/json-api/issues/1317, I changed "JSON API" to "JSON:API" everywhere I could. Do you see any part where we should just stay with "JSON API"? E.g. I was unsure if I can change it in the description of the implementations (but I didn't touch their names).