### PR TITLE
Fix Reststate typo

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -49,7 +49,7 @@ isomorphic ActiveRecord clone that issues JSON:API requests instead of SQL and i
 * [heather-js](https://github.com/bitex-la/heather-js) A library for parsing JSONAPI into objects from ES6 classes.
 * [@reststate/client](https://client.reststate.org/) - a stateless client providing easy access to standard JSON:API operations for a configured resource.
 * [@reststate/mobx](https://mobx.reststate.org/) - a zero-configuration way to fetch and store JSON:API data in objects implemented with the MobX state management library, for use in React or other apps.
-* [@reststate/vuex](https://vuex.reststate.org/) - a zero-configuration way to fetch and store JSON_API data in Vuex stores.
+* [@reststate/vuex](https://vuex.reststate.org/) - a zero-configuration way to fetch and store JSON:API data in Vuex stores.
 
 ### <a href="#client-libraries-typescript" id="client-libraries-typescript" class="headerlink"></a> Typescript
 * [ts-angular-jsonapi](https://github.com/reyesoft/ts-angular-jsonapi) A JSON:API library developed for AngularJS in Typescript


### PR DESCRIPTION
Fixes a typo in "JSON:API" in my newly-added implementation entries. I want to at least be consistent across the three of those! :-D