### PR TITLE
Profile changelog

### DIFF
--- a/_layouts/profile.html
+++ b/_layouts/profile.html
@@ -47,6 +47,12 @@
           {% include header_offset_2.md content=content %}
         </section>
         <section>
+          <h2><a href="#profile-versions" id="profile-versions" class="headerlink"></a>Version History</h2>
+          <a href="https://github.com/json-api/json-api/commits/gh-pages/{{ page.path }}">
+            View changes to this profile over time
+          </a>
+        </section>
+        <section>
           <h2><a href="#profile-contact" id="profile-contact" class="headerlink"></a>Contact the Author</h2>
           {% if page.discussion_url %}
             <p>To discuss or ask questions about this extension, visit

--- a/_profiles/ethanresnick/cursor-pagination/index.md
+++ b/_profiles/ethanresnick/cursor-pagination/index.md
@@ -50,10 +50,6 @@ extended_description: |
 minimum_jsonapi_version: 1.0
 minimum_jsonapi_version_explanation:
 
-# Url of a Github repo or some other place where people can
-# ask questions/start discussions about your extension.
-discussion_url: http://tets.com
-
 author_name: Ethan Resnick
 author_email: ethan.resnick@gmail.com
 # Optional fields


### PR DESCRIPTION
Link to the git history for each registered profile from its profile spec page.

I realized that it might be marginally useful for implementors to know what a profile looked like at a given point in time. (E.g., so that they can choose not to implement support for specific profile features if they only care about interacting with a server that they know was built before those features existed.)

I'm not sure if this is the best way to handle this, though, compared to, e.g. a changelog whose text is directly part of the spec page. I'm interested in what others think.