### PR TITLE
Resource Versioning Profile

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -119,6 +119,7 @@ quicklinks:
 
 profile_categories:
   - Pagination
+  - Resource Versioning
   # these are some other potential categories.
   # Uncomment them if you're adding a profile in one of these categories.
   # - Filtering

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -122,11 +122,16 @@ parameter value is known as the _version identifier_.
 
 ## Server Responsibilities
 
-A server **MUST** respond with `400 Bad Request` if a version negotiator is not
-supported.
+<a id="bad-version-negotiator"></a>A server **MUST** respond with `400 Bad Request` if a version negotiator is not
+supported. In this case, an error object that includes a `type` link to
+`https://jsonapi.org/profiles/drupal/resource-versioning#bad-version-negotiator`
+**MUST** be included in the response document.
    
-If a server cannot process the given version argument for the given negotiation
-mechanism, it **MUST** respond with a `400 Bad Request`.
+<a id="bad-version-argument"></a>If a server cannot process the given version argument for the given negotiation
+mechanism, it **MUST** respond with a `400 Bad Request`. In this case, an error
+object that includes a `type` link to
+`https://jsonapi.org/profiles/drupal/resource-versioning#bad-version-argument`
+**MUST** be included in the response document.
 
 If a server is able to process the version argument but an appropriate version
 cannot be located, the server **MUST** respond with a `404 Not Found`.

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -124,13 +124,13 @@ parameter value is known as the _version identifier_.
 
 <a id="bad-version-negotiator"></a>A server **MUST** respond with `400 Bad Request` if a version negotiator is not
 supported. In this case, an error object that includes a `type` link to
-`https://jsonapi.org/profiles/drupal/resource-versioning#bad-version-negotiator`
+`https://jsonapi.org/profiles/drupal/resource-versioning/#bad-version-negotiator`
 **MUST** be included in the response document.
    
 <a id="bad-version-argument"></a>If a server cannot process the given version argument for the given negotiation
 mechanism, it **MUST** respond with a `400 Bad Request`. In this case, an error
 object that includes a `type` link to
-`https://jsonapi.org/profiles/drupal/resource-versioning#bad-version-argument`
+`https://jsonapi.org/profiles/drupal/resource-versioning/#bad-version-argument`
 **MUST** be included in the response document.
 
 If a server is able to process the version argument but an appropriate version

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -294,8 +294,8 @@ identifier, the server **MUST** respond with a `501 Not Implemented`:
   - `prior-working-copy`
   - `subsequent-working-copy`
 
-If any version argument is receieved other than the version arguments in this
-section, a server **MUST** respond appropriately for a [bad version argument](#bad-version-argument).
-
 > Note: Future versions of this profile may define the behavior of these version
 > arguments.
+
+If any version argument is receieved other than the version arguments in this
+section, a server **MUST** respond appropriately for a [bad version argument](#bad-version-argument).

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -21,17 +21,17 @@ minimum_jsonapi_version_explanation:
 discussion_url: https://www.drupal.org/project/issues/jsonapi
 
 editor_name: |
- Gabriel Sullice
- Mateu Aguiló Bosch
- Wim Leers
+  Gabriel Sullice
+  Mateu Aguiló Bosch
+  Wim Leers
 editor_email: |
- gabriel@sullice.com
- mateu.aguilo.bosch@gmail.com
- work@wimleers.com
+  gabriel@sullice.com
+  mateu.aguilo.bosch@gmail.com
+  work@wimleers.com
 editor_website:
- n/a
- http://humanbits.es/
- https://wimleers.com
+  n/a
+  http://humanbits.es/
+  https://wimleers.com
 
 categories:
   - Resource Versioning

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -87,8 +87,6 @@ it:
 
   - The server’s response **MUST** contain the most appropriate version of the
     resource requested.
-  - The server **MUST NOT** include a version of a resource inappropriate for the
-    requested version.
   - The server **MUST** respond with `404 Not Found` if an appropriate version of
     the resource requested cannot be located. 
     

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -80,7 +80,9 @@ An endpoint **MAY** support a `resourceVersion` query parameter to allow a
 client to indicate which version(s) of a resource should be returned.
 
 If an endpoint does not support the `resourceVersion` parameter, it **MUST**
-respond with `400 Bad Request` to any requests that include it.
+respond with `400 Bad Request` to any requests that include it. An error object
+detailing the source of the error **SHOULD** include a `source` member referencing
+the `resourceVersion` query parameter.
 
 If an endpoint supports the `resourceVersion` parameter and a client supplies
 it:
@@ -127,12 +129,16 @@ identifier_.
 <a id="bad-version-negotiator"></a>A server **MUST** respond with `400 Bad Request` if a version negotiator is not
 supported. An error object detailing the source of the error **SHOULD** include a
 `type` link to
-`https://jsonapi.org/profiles/drupal/resource-versioning/#bad-version-negotiator`.
+`https://jsonapi.org/profiles/drupal/resource-versioning/#bad-version-negotiator`
+and **SHOULD** include a `source` member referencing the `resourceVersion` query
+parameter.
    
 <a id="bad-version-argument"></a>If a server cannot process the given version argument for the given negotiation
 mechanism, it **MUST** respond with a `400 Bad Request`. An error object detailing the
 source of the error **SHOULD** include a `type` link to
-`https://jsonapi.org/profiles/drupal/resource-versioning/#bad-version-argument`.
+`https://jsonapi.org/profiles/drupal/resource-versioning/#bad-version-argument`
+and **SHOULD** include a `source` member referencing the `resourceVersion` query
+parameter.
 
 If a server is able to process the version argument but an appropriate version
 cannot be located, the server **MUST** respond with a `404 Not Found`.

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -96,12 +96,13 @@ it:
 ## Format
   
 The value of the `resourceVersion` parameter **MUST** be a colon-separated
-(U+003A COLON, “:”) string. The first segment of the string **SHOULD** be
-interpreted as an identifier for a _version negotiation mechanism_. A version
-negotiation mechanism defines how a server will locate an appropriate resource
-version. Subsequent segments of the string **SHOULD** be interpreted as version
-negotiation arguments for the preceding mechanism. Collectively, this query
-parameter value is known as the _version identifier_.
+(U+003A COLON, “:”) string composed of one or more segments. The first segment
+of the string **SHOULD** be interpreted as an identifier for a _version
+negotiation mechanism_. A version negotiation mechanism defines how a server will
+locate an appropriate resource version. Subsequent segments of the string
+**SHOULD** be interpreted as version negotiation arguments for the preceding
+mechanism. Collectively, this query parameter value is known as the _version
+identifier_.
 
 > Note: For example, a server may support both ID-based and time-based
 > mechanisms for requesting a resource version. The former mechanism would be

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -114,14 +114,14 @@ identifier_.
 > attempt to define every possible mechanism for versioning resources.
 
 ```
-                   version-identifier
-                   _______|_________
-                  /                \
+                 version-identifier
+                  _______|________
+                 /                \
 ?resourceVersion=rel:latest-version
-                  \_/ \____________/
-                   |        |
-         version-negotiator |
-                     version-argument
+                 \_/ \____________/
+                  |        |
+        version-negotiator |
+                    version-argument
 ```
 
 ## Server Responsibilities

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -177,7 +177,7 @@ same:
 ```
 
 A server **MAY** provide a `version-history` link in a resource object's links
-object if a [version history](version-history) endpoint is available for the context resource
+object if a [version history](#version-history) endpoint is available for the context resource
 object.
 
 A server **MAY** provide the following resource object links so that a client may
@@ -293,6 +293,9 @@ identifier, the server **MUST** respond with a `501 Not Implemented`:
   - `successor-version`
   - `prior-working-copy`
   - `subsequent-working-copy`
+
+If any version argument is receieved other than the version arguments in this
+section, a server **MUST** respond appropriately for a [bad version argument](#bad-version-argument).
 
 > Note: Future versions of this profile may define the behavior of these version
 > arguments.

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -100,8 +100,8 @@ it:
   
 The value of the `resourceVersion` parameter **MUST** be a colon-separated
 (U+003A COLON, “:”) string composed of one or more segments. The first segment
-of the string **SHOULD** be interpreted as an identifier for a _version
-negotiation mechanism_. A version negotiation mechanism defines how a server will
+of the string **MUST** be interpreted as an identifier for a _version negotiation
+mechanism_. A version negotiation mechanism defines how a server will
 locate an appropriate resource version. Subsequent segments of the string
 **SHOULD** be interpreted as version negotiation arguments for the preceding
 mechanism. Collectively, this query parameter value is known as the _version

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -63,7 +63,7 @@ would have been known as the working copy as each one was created.
 If the version is then checked out for further changes each new revision becomes
 the working copy. When the working copy is checked in and made the default
 revision, this revision becomes the latest version and the version before it is
-its _predecessor version _. If no other revisions come after the latest version,
+its _predecessor version_. If no other revisions come after the latest version,
 it may also be considered the working copy.
 
 Sophisticated servers may support multiple versions of a resource as well as

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -203,14 +203,14 @@ links could be provided:
 
 | Revision | `latest-version` | `working-copy` | `predecessor-version` | `successor-version` | `prior-working-copy` | `subsequent-working-copy` |
 | :------: | :--------------: | :------------: | :-------------------: | :-----------------: | :------------------: | :-----------------------: |
-| `a`      | `g`              | `h`            | no link               | `e`                 | no link              | `b`                       |
+| `a`      | `g`              | `h`            | no link               | `e`                 | no link              | `b`, `c`                  |
 | `b`      | `g`              | `h`            | `a`                   | `e`                 | `a`                  | `c`                       |
 | `c`      | `g`              | `h`            | `a`                   | `e`                 | `b`                  | `d`                       |
-| `d`      | `g`              | `h`            | `a`                   | `e`                 | `c`                  | `e`                       |
+| `d`      | `g`              | `h`            | `a`                   | `e`                 | `b`, `c`             | `e`                       |
 | `e`      | `g`              | `h`            | `a`                   | `g`                 | `d`                  | `f`                       |
 | `f`      | `g`              | `h`            | `e`                   | `g`                 | `e`                  | `g`                       |
 | `g`      | no link          | `h`            | `e`                   | no link             | `f`                  | `h`                       |
-| `h`      | `g`              | no link        | `e`                   | no link             | `g`                  | no link                   |
+| `h`      | `g`              | no link        | `g`                   | no link             | `g`                  | no link                   |
 
 > Note: In this example, `f` has both a `predecessor-version` and
 > `prior-working-copy` link to `e` because `e` was a version but it also was the

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -60,8 +60,11 @@ before the resource was published may have many revisions. Only the published
 revision would be considered a version. The revisions prior to first version
 would have been known as the working copy as each one was created.
 
-If the version is then checked out for further changes (which may or may not be
-published) each new revision becomes the working copy.
+If the version is then checked out for further changes each new revision becomes
+the working copy. When the working copy is checked in and made the default
+revision, this revision becomes the latest version and the version before it is
+its _predecessor version _. If no other revisions come after the latest version,
+it may also be considered the working copy.
 
 Sophisticated servers may support multiple versions of a resource as well as
 multiple working copies of a resource (e.g., to support multiple

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -131,13 +131,6 @@ mechanism, it **MUST** respond with a `400 Bad Request`.
 If a server is able to process the version argument but an appropriate version
 cannot be located, the server **MUST** respond with a `404 Not Found`.
 
-If a server knows a version argument to be invalid for the requested version
-negotiation mechanism, it **MUST** respond with a `400 Bad Request`.
-
-If the server cannot establish a version argument to be invalid for the
-requested version negotiation mechanism, it **MUST** respond with a
-`501 Not Implemented`.
-
 # Version Negotiators
 
 ## ID-Based Version Negotiator
@@ -171,3 +164,11 @@ The `rel` version negotiator has the following valid version argument strings:
   - `latest-version`: requests the latest default revision of a resource.
   - `working-copy`: requests revision of a resource to which changes can be
     made.
+
+If any of the following version arguments is received in a `rel`-based version
+identifier, the server **MUST** respond with a `501 Not Implemented`:
+
+  - `predecessor-version`
+  - `successor-version`
+  - `prior-working-copy`
+  - `subsequent-working-copy`

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -167,8 +167,8 @@ same:
 ```
 
 A server **MAY** provide a `version-history` link in a resource object's links
-object. This link must reference a collection resource providing all revisions
-of the context resource object.
+object if a [version history](version-history) endpoint is available for the context resource
+object.
 
 A server **MAY** provide the following resource object links so that a client may
 navigate a resource object's version history:
@@ -201,7 +201,8 @@ a           e       g
 No other revisions were ever the latest version. In this example, the following
 links could be provided:
 
-| revision | `latest-version` | `working-copy` | `predecessor-version` | `successor-version` | `prior-working-copy` | `subsequent-working-copy` |
+| Revision | `latest-version` | `working-copy` | `predecessor-version` | `successor-version` | `prior-working-copy` | `subsequent-working-copy` |
+| :------: | :--------------: | :------------: | :-------------------: | :-----------------: | :------------------: | :-----------------------: |
 | `a`      | `g`              | `h`            | no link               | `e`                 | no link              | `b`                       |
 | `b`      | `g`              | `h`            | `a`                   | `e`                 | `a`                  | `c`                       |
 | `c`      | `g`              | `h`            | `a`                   | `e`                 | `b`                  | `d`                       |
@@ -218,7 +219,7 @@ links could be provided:
 # Version History
 
 A server **MAY** provide a "version history" endpoint. The primary data
-of a response document from a version history endpoing must be a collection of
+of a response document from a version history endpoint must be a collection of
 resource objects.
 
 Unless an `id` contains version information, the `type` and `id` members of each

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -127,15 +127,14 @@ identifier_.
 ## Server Responsibilities
 
 <a id="bad-version-negotiator"></a>A server **MUST** respond with `400 Bad Request` if a version negotiator is not
-supported. In this case, an error object that includes a `type` link to
-`https://jsonapi.org/profiles/drupal/resource-versioning/#bad-version-negotiator`
-**MUST** be included in the response document.
+supported. An error object detailing the source of the error **SHOULD** include a
+`type` link to
+`https://jsonapi.org/profiles/drupal/resource-versioning/#bad-version-negotiator`.
    
 <a id="bad-version-argument"></a>If a server cannot process the given version argument for the given negotiation
-mechanism, it **MUST** respond with a `400 Bad Request`. In this case, an error
-object that includes a `type` link to
-`https://jsonapi.org/profiles/drupal/resource-versioning/#bad-version-argument`
-**MUST** be included in the response document.
+mechanism, it **MUST** respond with a `400 Bad Request`. An error object detailing the
+source of the error **SHOULD** include a `type` link to
+`https://jsonapi.org/profiles/drupal/resource-versioning/#bad-version-argument`.
 
 If a server is able to process the version argument but an appropriate version
 cannot be located, the server **MUST** respond with a `404 Not Found`.

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -232,6 +232,19 @@ If provided, resource objects' `self` links **MUST NOT** be the same.
 
 # Version Negotiators
 
+This profile defines a number of version negotiators which a server **MAY**
+implement. Additional version negotiator's may be added to this profile at a
+later date.
+
+Version negotiators which are not defined by this profile **MUST** adhere to the
+same constraints as [implementation-specific query parameter names](https://jsonapi.org/format/1.1/#query-parameters-custom).
+
+It is **RECOMMENDED** that any alternative version negotiators be added to this
+profile. New version negotiators may be registered by sending one, joint email
+to the profile editors with the subject line: "New JSON:API Resource Version
+Negotiator: {negotiator name}". This will begin a process of refinement and/or
+result in a determination of fitness for addition to this profile.
+
 ## ID-Based Version Negotiator
 
 This profile establishes the `id` version negotiator. An `id`-based version

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -73,13 +73,13 @@ schemes.
 
 ## Usage
 
-An endpoint **MAY** support a `resource_version` query parameter to allow a
+An endpoint **MAY** support a `resourceVersion` query parameter to allow a
 client to indicate which version(s) of a resource should be returned.
 
-If an endpoint does not support the `resource_version` parameter, it **MUST**
+If an endpoint does not support the `resourceVersion` parameter, it **MUST**
 respond with `400 Bad Request` to any requests that include it.
 
-If an endpoint supports the `resource_version` parameter and a client supplies
+If an endpoint supports the `resourceVersion` parameter and a client supplies
 it:
 
   - The server’s response **MUST** contain the most appropriate version of the
@@ -95,7 +95,7 @@ it:
 
 ## Format
   
-The value of the `resource_version` parameter **MUST** be a colon-separated
+The value of the `resourceVersion` parameter **MUST** be a colon-separated
 (U+003A COLON, “:”) string. The first segment of the string **SHOULD** be
 interpreted as an identifier for a _version negotiation mechanism_. A version
 negotiation mechanism defines how a server will locate an appropriate resource
@@ -113,7 +113,7 @@ parameter value is known as the _version identifier_.
                    version-identifier
                    _______|_________
                   /                \
-?resource_version=rel:latest-version
+?resourceVersion=rel:latest-version
                   \_/ \____________/
                    |        |
          version-negotiator |
@@ -138,13 +138,13 @@ cannot be located, the server **MUST** respond with a `404 Not Found`.
 
 # Links
 
-When a server processes a request with a `resource_version` query parameter and
+When a server processes a request with a `resourceVersion` query parameter and
 a `self` link is provided for a top-level links object, the link's `href`
-**MUST** include the `resource_version` query parameter with the same version
+**MUST** include the `resourceVersion` query parameter with the same version
 identifier that was requested.
 
-When a server processes a request with a `resource_version` query parameter
-all resource object `self` links **SHOULD** contain a `resource_version` query
+When a server processes a request with a `resourceVersion` query parameter
+all resource object `self` links **SHOULD** contain a `resourceVersion` query
 parameter which identifies the specific revision represented by that resource
 object.
 
@@ -157,11 +157,11 @@ same:
     "type": "article",
     "id": 1,
     "links": {
-      "self": "/article/1?resource_version=id:42"
+      "self": "/article/1?resourceVersion=id:42"
     }
   },
   "links": {
-    "self": "/article/1?resource_version=rel:latest-version"
+    "self": "/article/1?resourceVersion=rel:latest-version"
   }
 }
 ```

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -143,7 +143,7 @@ a `self` link is provided for a top-level links object, the link's `href`
 **MUST** include the `resource_version` query parameter with the same version
 identifier that was requested.
 
-When a server processes a request with a `resource_version` query parameter and
+When a server processes a request with a `resource_version` query parameter
 all resource object `self` links **SHOULD** contain a `resource_version` query
 parameter which identifies the specific revision represented by that resource
 object.
@@ -213,8 +213,8 @@ links could be provided:
 | `h`      | `g`              | no link        | `g`                   | no link             | `g`                  | no link                   |
 
 > Note: In this example, `f` has both a `predecessor-version` and
-> `prior-working-copy` link to `e` because `e` was a version but it also was the
-> revision to which changes could be applied before `f` was created.
+> `prior-working-copy` link to `e` because `e` was a version and `e` was also the
+> revision to which changes could be applied prior to `f`'s creation.
 
 # Version History
 
@@ -268,3 +268,6 @@ identifier, the server **MUST** respond with a `501 Not Implemented`:
   - `successor-version`
   - `prior-working-copy`
   - `subsequent-working-copy`
+
+> Note: Future versions of this profile may define the behavior of these version
+> arguments.

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -136,6 +136,96 @@ object that includes a `type` link to
 If a server is able to process the version argument but an appropriate version
 cannot be located, the server **MUST** respond with a `404 Not Found`.
 
+# Links
+
+When a server processes a request with a `resource_version` query parameter and
+a `self` link is provided for a top-level links object, the link's `href`
+**MUST** include the `resource_version` query parameter with the same version
+identifier that was requested.
+
+When a server processes a request with a `resource_version` query parameter and
+all resource object `self` links **SHOULD** contain a `resource_version` query
+parameter which identifies the specific revision represented by that resource
+object.
+
+For example, in the following response document the `self` links are not the
+same:
+
+```json
+{
+  "data": {
+    "type": "article",
+    "id": 1,
+    "links": {
+      "self": "/article/1?resource_version=id:42"
+    }
+  },
+  "links": {
+    "self": "/article/1?resource_version=rel:latest-version"
+  }
+}
+```
+
+A server **MAY** provide a `version-history` link in a resource object's links
+object. This link must reference a collection resource providing all revisions
+of the context resource object.
+
+A server **MAY** provide the following resource object links so that a client may
+navigate a resource object's version history:
+
+  - `latest-version`: links to the latest version of the context resource
+    object.
+  - `working-copy`: links to the working copy of the context resource object.
+  - `predecessor-version`: links to the version which immediately preceded the
+    context resource object.
+  - `successor-version`: links to the version which immediately succeeded the
+    context resource object.
+  - `prior-working-copy`: links to the working copy which immediately preceded
+    the context resource object.
+  - `subsequent-working-copy`: links to the working copy which immediately
+    preceded the context resource object.
+
+A server **MAY** provide an array of any of these links to support branching.
+
+For example, in the following version history:
+
+```
+    _c_
+   /   \
+  /__b__d__   __f__   __h
+ /         \ /     \ /
+a           e       g
+```
+
+`g` is the latest version. Both `a` and `e` were previously the latest version.
+No other revisions were ever the latest version. In this example, the following
+links could be provided:
+
+| revision | `latest-version` | `working-copy` | `predecessor-version` | `successor-version` | `prior-working-copy` | `subsequent-working-copy` |
+| `a`      | `g`              | `h`            | no link               | `e`                 | no link              | `b`                       |
+| `b`      | `g`              | `h`            | `a`                   | `e`                 | `a`                  | `c`                       |
+| `c`      | `g`              | `h`            | `a`                   | `e`                 | `b`                  | `d`                       |
+| `d`      | `g`              | `h`            | `a`                   | `e`                 | `c`                  | `e`                       |
+| `e`      | `g`              | `h`            | `a`                   | `g`                 | `d`                  | `f`                       |
+| `f`      | `g`              | `h`            | `e`                   | `g`                 | `e`                  | `g`                       |
+| `g`      | no link          | `h`            | `e`                   | no link             | `f`                  | `h`                       |
+| `h`      | `g`              | no link        | `e`                   | no link             | `g`                  | no link                   |
+
+> Note: In this example, `f` has both a `predecessor-version` and
+> `prior-working-copy` link to `e` because `e` was a version but it also was the
+> revision to which changes could be applied before `f` was created.
+
+# Version History
+
+A server **MAY** provide a "version history" endpoint. The primary data
+of a response document from a version history endpoing must be a collection of
+resource objects.
+
+Unless an `id` contains version information, the `type` and `id` members of each
+resource object in the collection **MUST** be the same.
+
+If provided, resource objects' `self` links **MUST NOT** be the same.
+
 # Version Negotiators
 
 ## ID-Based Version Negotiator

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -151,6 +151,9 @@ all resource object `self` links **SHOULD** contain a `resourceVersion` query
 parameter which identifies the specific revision represented by that resource
 object.
 
+A server **MUST** use the most specific version negotiator it supports for any
+resource object `self` links that it provides.
+
 For example, in the following response document the `self` links are not the
 same:
 
@@ -267,6 +270,8 @@ This profile establishes the `rel` version negotiator. A `rel`-based version
 identifier is composed of two or more segments. The first segment **MUST** be
 `rel` and the following version arguments describe a resource version that is
 relative to the version history.
+
+The `rel` version negotiator **MUST NOT** appear in a resource object's `self` link.
 
 The resource version returned for any given version argument in a `rel`-based
 version identifier **MAY** change over time.

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -20,8 +20,18 @@ minimum_jsonapi_version_explanation:
 
 discussion_url: https://www.drupal.org/project/issues/jsonapi
 
-author_name: Gabriel SULLICE
-author_email: gabriel@sullice.com
+editor_name: |
+ Gabriel Sullice
+ Mateu Aguiló Bosch
+ Wim Leers
+editor_email: |
+ gabriel@sullice.com
+ mateu.aguilo.bosch@gmail.com
+ work@wimleers.com
+editor_website:
+ n/a
+ http://humanbits.es/
+ https://wimleers.com
 
 categories:
   - Resource Versioning

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -20,18 +20,15 @@ minimum_jsonapi_version_explanation:
 
 discussion_url: https://www.drupal.org/project/issues/jsonapi
 
-editor_name: |
-  Gabriel Sullice
-  Mateu Aguiló Bosch
-  Wim Leers
-editor_email: |
-  gabriel@sullice.com
-  mateu.aguilo.bosch@gmail.com
-  work@wimleers.com
-editor_website:
-  n/a
-  http://humanbits.es/
-  https://wimleers.com
+editors:
+  - name: Gabriel Sullice
+    email: gabriel@sullice.com
+  - name: Mateu Aguiló Bosch
+    email: mateu.aguilo.bosch@gmail.com
+    website: https://humanbits.es
+  - name: Wim Leers
+    email: work@wimleers.com
+    website: https://wimleers.com
 
 categories:
   - Resource Versioning

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -47,9 +47,9 @@ vocabulary for describing various possible states of a resource.
 A _revision_ is to be understood as an identifiable state of a resource after
 its creation or after some number of changes.
 
-A _version_ is to be understood as a revision of a resource that is available,
-or was previously available, without any version negotiation. In other words, as
-a revision that is or was the default revision of a resource.
+A _version_ is to be understood as a revision that is or was the default
+revision of a resource. In other words, as a revision of a resource that is
+available, or was previously available, without any version negotiation.
 
 A _working copy_ is the revision to which new changes can be made or to which
 they will be applied. Colloquially, a working copy is often thought of as the

--- a/_profiles/drupal/resource-versioning/index.md
+++ b/_profiles/drupal/resource-versioning/index.md
@@ -24,8 +24,8 @@ editors:
   - name: Gabriel Sullice
     email: gabriel@sullice.com
   - name: Mateu Aguiló Bosch
-    email: mateu.aguilo.bosch@gmail.com
-    website: https://humanbits.es
+    email: mateu@mateuaguilo.com
+    website: https://mateuaguilo.com
   - name: Wim Leers
     email: work@wimleers.com
     website: https://wimleers.com


### PR DESCRIPTION
First! 😁 (well, sorta... @ethanresnick submitted one first, but does that really count?)

This is a profile extracted from Drupal's JSON:API implementation.

Drupal has long had support for moderated and revisioned content. We plan to support this in our project and we hope to land [the feature quite soon](https://www.drupal.org/project/jsonapi/issues/2992833)—we're just cleaning up nitpicks and then it will land after we're out of a feature freeze (we're stabilizing a v2 right now).

We figured this would be a great way to pilot the new profile process.

<hr/>

I tried to make this profile very flexible while taking _heavy_ inspiration from [RFC 5829 - Link Relation Types for Simple Version Navigation between Web Resources](https://tools.ietf.org/html/rfc5829).

~This PR is still a work-in-progress and is not yet finalized, but I'm hoping to get a jump on any egregious oversights.~

~Before it is finalized, I would like for this profile to also include a set of recommended links and for it to include language about providing a version history endpoint. I don't think either of those things will be a requirement for adopting the profile though.~ Done!

/cc @wimleers @e0ipso