### PR TITLE
Upgrade links to RFC8288-modelled web links

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -545,6 +545,10 @@ Within this object, a link **MUST** be represented as either:
   * `meta`: a meta object containing non-standard meta-information about the
     link.
 
+Link objects **MAY** also contain the members `hreflang`, `title`, and `type`.
+Each of these members **MUST** be used in accordance with their semantics as
+defined by [RFC8288 Section 3.4.1](https://tools.ietf.org/html/rfc8288#section-3.4.1).
+
 If a link is represented as a string, or the `rel` member is not present on a
 link object, the link's relation type **SHOULD** be inferred from the name of
 the link object.
@@ -577,27 +581,23 @@ and `href` members be interchanged.
 > Note: Historically, a `rev` link parameter was used for this purpose but has
 > since been deprecated by [RFC8288 Section 3.3](https://tools.ietf.org/html/rfc8288#section-3.3).
 
-#### <a href="#document-links-target-attributes" id="document-links-target-attributes" class="headerlink"></a> Target attributes
+#### <a href="#document-links-target-attributes" id="document-links-target-attributes" class="headerlink"></a> Extension target attributes
 
-A "link parameter object" is used to represent the [target attributes](https://tools.ietf.org/html/rfc8288#section-2.2)
-of the [link object][link] in which it's defined.
+A "link parameter object" is used to represent additional [target attributes](https://tools.ietf.org/html/rfc8288#section-2.2)
+of the [link object][link] in which it appears.
 
-Link parameters **MAY** contain any valid JSON value. However, target
+Link parameter objects **MUST** only contain members that have been defined by
+their accompanying link relation type. Member names **SHOULD** be valid JSON:API
+[member names][member names] and **MUST** be valid target attribute names as
+defined by [RFC8288 Section 2.2](https://tools.ietf.org/html/rfc8288#section-2.2).
+
+Link parameters objects **MAY** contain any valid JSON value. However, target
 attributes that have a cardinality greater than one **MUST** be represented as
 an array of values.
 
-> Note: this means that a target attribute with multiple values should be an
-array of values, not a whitespace-separated string as might be used in a
-[`Link` header serialization](https://tools.ietf.org/html/rfc8288#section-3.5).
-
-All member names used in a link parameter object and not defined by this
-specification **MUST** be valid JSON:API [member names][member names] and
-**MUST** be valid target attribute names as defined by [RFC8288 Section 2.2](https://tools.ietf.org/html/rfc8288#section-2.2).
-
-In addition to members that conform to the requirements above, link parameter
-objects **MAY** contain the members `hreflang`, `media`, `title`, `title`, and
-`type`. Each of these members **MUST** be used in accordance with their
-semantics meanings as defined by [RFC8288 Section 3.4.1](https://tools.ietf.org/html/rfc8288#section-3.4.1).
+> Note: This means that a target attribute with multiple string values should
+not be represented as a single concatenated string with its values separated by
+whitespace as might be the case in a [`Link` header serialization](https://tools.ietf.org/html/rfc8288#section-3.5).
 
 #### <a href="#profile-links" id="profile-links" class="headerlink"></a> Profile Links
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -708,12 +708,6 @@ implements at least version 1.0 of the specification.
 > Note: Because JSON:API is committed to making additive changes only, the
 version string primarily indicates which new features a server may support.
 
-### <a href="#document-fragment-syntax" id="document-fragment-syntax" class="headerlink"></a> URI Fragment Syntax
-
-A JSON:API URI fragment **MUST** be a JSON Pointer [[RFC6901](https://tools.ietf.org/html/rfc6901)] which points to a
-[resource object](resource objects) or [relationships object](relationships) in the response document and it **MUST NOT**
-point to any child members within it.
-
 ### <a href="#document-member-names" id="document-member-names" class="headerlink"></a> Member Names
 
 All member names used in a JSON:API document **MUST** be treated as case sensitive
@@ -2498,7 +2492,6 @@ request as equivalent to one in which the square brackets were percent-encoded.
 [link object]: #document-links-link-object
 [link relations]: #document-links-link-relations
 [link parameter object]: #document-links-link-parameter-object
-[fragments]: #document-fragment-syntax
 [profiles]: #profiles
 [timestamps profile]: #profiles-timestamp-profile
 [profile keywords]: #profile-keywords

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -533,25 +533,20 @@ Within this object, a link **MUST** be represented as either:
 * <a id="document-links-link-object"></a>an object ("link object") which can
   contain the following members:
   * `href`: a URI-reference [[RFC3986 Section 4.1](https://tools.ietf.org/html/rfc3986#section-4.1)] to the link's target.
-  * `rel`: a link relation type or an array of link relation types [[RFC8288 Section 2.1](https://tools.ietf.org/html/rfc8288#section-3.3)].
-    An array of link relationship types establishes multiple links that share
-    the same context, target, and target attributes.
+  * `rel`: a [link relation type][link relation type] defining the semantics of
+    the link.
   * `anchor`: a URI-reference [[RFC3986 Section 4.1](https://tools.ietf.org/html/rfc3986#section-4.1)]
     to the link's context. By default, the context of a link is the
     [top-level object][top level], [resource object][resource objects], or
     [relationship object][relationships] in which the link appears.
-  * `params`: a [link parameter object][target attributes] as described
-    below.
+  * `params`: a [link parameter object][link parameters] describing additional
+    information about the link or its target.
   * `meta`: a meta object containing non-standard meta-information about the
     link.
 
 Link objects **MAY** also contain the members `hreflang`, `title`, and `type`.
 Each of these members **MUST** be used in accordance with their semantics as
 defined by [RFC8288 Section 3.4.1](https://tools.ietf.org/html/rfc8288#section-3.4.1).
-
-If a link is represented as a string, or the `rel` member is not present on a
-link object, the link's relation type **SHOULD** be inferred from the name of
-the link object.
 
 Except for the `profile` key in the top-level links object and the `type` 
 key in an [error object]'s links object, each key present in a links object 
@@ -574,26 +569,41 @@ related resource collection:
 }
 ```
 
-In order to represent a link with reversed semantics, it is **RECOMMENDED** that an
-alternate link relation type be used or, less preferably, that the `anchor`
-and `href` members be interchanged.
+##### <a href="#document-links-link-relation-type" id="document-links-link-relation-type" class="headerlink"></a> Link relation type
+
+The value of the `rel` member **MUST** be a string or an array of link relation
+types. Valid link relation types are defined by [RFC8288 Section 2.1](https://tools.ietf.org/html/rfc8288#section-2.1).
+
+If a link is represented as a string, or the `rel` member is not given, the
+link's relation type **SHOULD** be inferred from the name of the link object.
+
+An array of link relationship types establishes multiple links that share the
+same context, target, and target attributes and a client **MUST** treat these
+links as separate, distinct links. A client **MUST NOT** infer additional
+semantics for the link based on a composition of link relation types alone.
+
+In order to represent a link with reversed semantics, it is **RECOMMENDED**
+that an alternate link relation type be used or, less preferably, that the
+`anchor` and `href` members be interchanged.
 
 > Note: Historically, a `rev` link parameter was used for this purpose but has
 > since been deprecated by [RFC8288 Section 3.3](https://tools.ietf.org/html/rfc8288#section-3.3).
 
-#### <a href="#document-links-target-attributes" id="document-links-target-attributes" class="headerlink"></a> Extension target attributes
+##### <a href="#document-links-link-parameters" id="document-links-link-parameters" class="headerlink"></a> Link parameters
 
-A "link parameter object" is used to represent additional [target attributes](https://tools.ietf.org/html/rfc8288#section-2.2)
-of the [link object][link] in which it appears.
+The value of the `params` member **MUST** be an object (an “link parameter
+object”). Members of the link parameter object (“link parameters”) describe
+the [link][link] on which they are defined or its target. These link parameters
+are also known as [target attributes](https://tools.ietf.org/html/rfc8288#section-2.2).
 
-Link parameter objects **MUST** only contain members that have been defined by
-their accompanying link relation type. Member names **SHOULD** be valid JSON:API
-[member names][member names] and **MUST** be valid target attribute names as
-defined by [RFC8288 Section 2.2](https://tools.ietf.org/html/rfc8288#section-2.2).
+Link parameter names **MUST** be defined by their accompanying link relation
+type. Additionally, parameter names **SHOULD** be valid JSON:API
+[member names][member names] and **MUST** be valid target attribute names as defined
+by [RFC8288 Section 2.2](https://tools.ietf.org/html/rfc8288#section-2.2).
 
-Link parameters objects **MAY** contain any valid JSON value. However, target
-attributes that have a cardinality greater than one **MUST** be represented as
-an array of values.
+Link parameters **MAY** contain any valid JSON value. However, parameters that
+have a cardinality greater than one **MUST** be represented as an array of
+values.
 
 > Note: This means that a target attribute with multiple string values should
 not be represented as a single concatenated string with its values separated by
@@ -2428,7 +2438,8 @@ request as equivalent to one in which the square brackets were percent-encoded.
 [links]: #document-links
 [link]: #document-links-link
 [link object]: #document-links-link-object
-[target attributes]: #document-links-target-attributes
+[link relation type]: #document-links-link-relation-type
+[link parameters]: #document-links-link-parameters
 [profiles]: #profiles
 [timestamps profile]: #profiles-timestamp-profile
 [profile keywords]: #profile-keywords

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -578,9 +578,8 @@ and `href` members be interchanged.
 
 #### <a href="#document-links-target-attributes" id="document-links-target-attributes" class="headerlink"></a> Target attributes
 
-A "link parameter object" is used to represent [target
-attributes](https://tools.ietf.org/html/rfc8288#section-2.2) for the [link
-object][link] in which it's defined.
+A "link parameter object" is used to represent the [target attributes](https://tools.ietf.org/html/rfc8288#section-2.2)
+of the [link object][link] in which it's defined.
 
 Link parameters **MAY** contain any valid JSON value. However, target
 attributes that have a cardinality greater than one **MUST** be represented as
@@ -594,11 +593,10 @@ All member names used in a link parameter object and not defined by this
 specification **MUST** be valid JSON:API [member names][member names] and
 **MUST** be valid target attribute names as defined by [RFC8288 Section 2.2](https://tools.ietf.org/html/rfc8288#section-2.2).
 
-In order to represent a link with reversed semantics, it is **RECOMMENDED** that an
-alternate link relation type be used or, less preferably, that the `anchor`
-and `href` members be interchanged.
-
-> Note: The `rev` link parameter was deprecated by [RFC8288 Section 3.3](https://tools.ietf.org/html/rfc8288#section-3.3)
+In addition to members that conform to the requirements above, link parameter
+objects **MAY** contain the members `hreflang`, `media`, `title`, `title`, and
+`type`. Each of these members **MUST** be used in accordance with their
+semantics meanings as defined by [RFC8288 Section 3.4.1](https://tools.ietf.org/html/rfc8288#section-3.4.1).
 
 #### <a href="#profile-links" id="profile-links" class="headerlink"></a> Profile Links
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -574,7 +574,8 @@ In order to represent a link with reversed semantics, it is **RECOMMENDED** that
 alternate link relation type be used or, less preferably, that the `anchor`
 and `href` members be interchanged.
 
-> Note: The `rev` link parameter was deprecated by [RFC8288 Section 3.3](https://tools.ietf.org/html/rfc8288#section-3.3)
+> Note: Historically, a `rev` link parameter was used for this purpose but has
+> since been deprecated by [RFC8288 Section 3.3](https://tools.ietf.org/html/rfc8288#section-3.3).
 
 #### <a href="#document-links-target-attributes" id="document-links-target-attributes" class="headerlink"></a> Target attributes
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -532,7 +532,7 @@ Within this object, a link **MUST** be represented as either:
 * a URI-reference [[RFC3986 Section 4.1](https://tools.ietf.org/html/rfc3986#section-4.1)] to the link's target.
 * <a id="document-links-link-object"></a>an object ("link object") which can
   contain the following members:
-  * `href`: a URI-reference to the link's target.
+  * `href`: a URI-reference [[RFC3986 Section 4.1](https://tools.ietf.org/html/rfc3986#section-4.1)] to the link's target.
   * `rel`: an array of link relation types [[RFC8288 Section 2.1](https://tools.ietf.org/html/rfc8288#section-3.3)]
   * `anchor`: a URI-reference [[RFC3986 Section 4.1](https://tools.ietf.org/html/rfc3986#section-4.1)] to the link's context.
   * `params`: a [link parameter object][link parameter object] as described
@@ -543,8 +543,10 @@ Within this object, a link **MUST** be represented as either:
 By default, the context of a link is the [top-level object][top level], [resource object][resource objects] or
 [relationship object][relationships] in which the link appears.
 
-If the `rel` member is not present on a link object, it **SHOULD** be interpreted to
-contain the member name of the link object.
+If the `rel` member is not present on a link object, the link's relation
+type **SHOULD** be interpreted as the name of the link object. The `rel` parameter
+can contain multiple link relation types. When this occurs, it establishes
+multiple links that share the same context, target, and target attributes.
 
 Except for the `profile` key in the top-level links object and the `type` 
 key in an [error object]'s links object, each key present in a links object 
@@ -606,9 +608,9 @@ reference resources that will process requests according to [the requirements fo
 creating, updating or deleting resources](https://jsonapi.org/format/1.1/#crud). However, this is not a strict
 limitation on their use.
 
-In the example below, a `self` link is a member of the [top-level][top level] links
-object that represents a collection of articles. In this case, the `rel` member
-of the link indicates that the client can add an article to this collection.
+In the example below, two links are established. A `self` link indicating the
+URL of the request that generated the current collection of articles and an `add`
+link indicating the that the client can add an article to this collection.
 
 ```json
 "links": {
@@ -619,17 +621,17 @@ of the link indicates that the client can add an article to this collection.
 }
 ```
 
-In the next example, an `add` link is a member of a `comments` [relationship object][relationships]
-and that relationship object is a member of an `article`'s relationships object.
-In this case, the `rel` member of the link indicates that the client can create
-a new comment at the target URL and that the server will automatically associate
-the new comment with the article's `comments` field.
+In the next example, a `comment` link is a member of a `comments` [relationship
+object][relationships] and that relationship object is a member of an `article`'s relationships
+object. In this case, the `rel` member establishes two links indicating that
+the client can create a new comment at the target URL and that requests to the
+target `href` can create a relationship to the article's `comments` field.
 
 ```json
 "links": {
   "self": "http://example.com/articles/1/relationships/comments",
   "related": "http://example.com/articles/1/comments",
-  "add": {
+  "comment": {
     "href": "http://example.com/articles/1/comments",
     "rel": ["add", "relate"]
   }
@@ -637,10 +639,10 @@ the new comment with the article's `comments` field.
 ```
 
 In this example, a `self` link is a member of an `article`'s links object. In
-this case, the `rel` member of the link indicates that the client can edit, but
-not delete, the context article (perhaps another request with different
-authentication credentials would receive a link with a `remove` link relation
-type).
+this case, the `rel` member established two links indicating that the client can
+edit, but not delete, the context article (perhaps another request with different
+authentication credentials would receive an additional link with a `remove` link
+relation type).
 
 ```json
 "links": {
@@ -661,11 +663,7 @@ A link parameter object **MAY** contain any of the following members: `hreflang`
 meanings as defined by [RFC8288 Section 3.4.1](https://tools.ietf.org/html/rfc8288#section-3.4.1).
 
 A link parameter object **MAY** contain other members as target attributes. Any
-target attribute that is in common usage in other link serialisations **SHOULD NOT**
-be used in a manner contrary to the commonly understood meaning of those
-attributes.
-
-Any additional member names **MUST** be valid target attribute names as defined by
+additional member names **MUST** be valid target attribute names as defined by
 [RFC8288 Section 2.2](https://tools.ietf.org/html/rfc8288#section-2.2).
 
 Link parameter object members with multiple values **MUST** be represented with an

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -535,7 +535,7 @@ Within this object, a link **MUST** be represented as either:
   * `href`: a URI-reference [[RFC3986 Section 4.1](https://tools.ietf.org/html/rfc3986#section-4.1)] to the link's target.
   * `rel`: an array of link relation types [[RFC8288 Section 2.1](https://tools.ietf.org/html/rfc8288#section-3.3)]
   * `anchor`: a URI-reference [[RFC3986 Section 4.1](https://tools.ietf.org/html/rfc3986#section-4.1)] to the link's context.
-  * `params`: a [link parameter object][link parameter object] as described
+  * `params`: a [link parameter object][target attributes] as described
     below.
   * `meta`: a meta object containing non-standard meta-information about the
     link.
@@ -569,6 +569,30 @@ related resource collection:
 }
 ```
 
+#### <a href="#document-links-target-attributes" id="document-links-target-attributes" class="headerlink"></a> Target attributes
+
+A "link parameter object" is used to represent [target
+attributes](https://tools.ietf.org/html/rfc8288#section-2.2) for the [link
+object][link] in which it's defined.
+
+Link parameters **MAY** contain any valid JSON value. However, target
+attributes that have a cardinality greater than one **MUST** be represented as
+an array of values.
+
+> Note: this means that a target attribute with multiple values should be an
+array of values, not a whitespace-separated string as might be used in a
+[`Link` header serialization](https://tools.ietf.org/html/rfc8288#section-3.5).
+
+All member names used in a link parameter object and not defined by this
+specification **MUST** be valid JSON:API [member names][member names] and
+**MUST** be valid target attribute names as defined by [RFC8288 Section 2.2](https://tools.ietf.org/html/rfc8288#section-2.2).
+
+In order to represent a link with reversed semantics, it is **RECOMMENDED** that an
+alternate link relation type be used or, less preferably, that the `anchor`
+and `href` members be interchanged.
+
+> Note: The `rev` link parameter was deprecated by [RFC8288 Section 3.3](https://tools.ietf.org/html/rfc8288#section-3.3)
+
 #### <a href="#profile-links" id="profile-links" class="headerlink"></a> Profile Links
 
 Like all [links][link], a link in an array of `profile` links can be represented
@@ -587,31 +611,6 @@ Here, the `profile` key specifies an array of `profile` links:
 
 > Note: Additional link types, similar to `profile` links, may be specified in
 the future.
-
-#### <a href="#document-links-link-parameter-object" id="document-links-link-parameter-object" class="headerlink"></a> Link parameter objects
-
-"Link parameter objects" appear in link objects to represent a link's target
-attributes.
-
-A link parameter object **MAY** contain any of the following members: `hreflang`,
-`media`, `title`, and `type`. The values of these members **MUST** conform to their
-meanings as defined by [RFC8288 Section 3.4.1](https://tools.ietf.org/html/rfc8288#section-3.4.1).
-
-A link parameter object **MAY** contain other members as target attributes. Any
-additional member names **MUST** be valid target attribute names as defined by
-[RFC8288 Section 2.2](https://tools.ietf.org/html/rfc8288#section-2.2).
-
-Link parameter object members with multiple values **MUST** be represented with an
-array (i.e. a target attribute with multiple values should be an array of
-values, not a whitespace-separated string).
-
-A link parameter object **SHOULD NOT** contain a `rev` member.
-
-In order to represent a link with reversed semantics, it is **RECOMMENDED** that an
-alternate link relation type be used or, less preferably, that the `anchor`
-and `href` members be interchanged.
-
-> Note: The `rev` link parameter was deprecated by [RFC8288 Section 3.3](https://tools.ietf.org/html/rfc8288#section-3.3)
 
 ### <a href="#document-jsonapi-object" id="document-jsonapi-object" class="headerlink"></a> JSON:API Object
 
@@ -2423,7 +2422,7 @@ request as equivalent to one in which the square brackets were percent-encoded.
 [links]: #document-links
 [link]: #document-links-link
 [link object]: #document-links-link-object
-[link parameter object]: #document-links-link-parameter-object
+[target attributes]: #document-links-target-attributes
 [profiles]: #profiles
 [timestamps profile]: #profiles-timestamp-profile
 [profile keywords]: #profile-keywords

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -533,20 +533,21 @@ Within this object, a link **MUST** be represented as either:
 * <a id="document-links-link-object"></a>an object ("link object") which can
   contain the following members:
   * `href`: a URI-reference [[RFC3986 Section 4.1](https://tools.ietf.org/html/rfc3986#section-4.1)] to the link's target.
-  * `rel`: an array of link relation types [[RFC8288 Section 2.1](https://tools.ietf.org/html/rfc8288#section-3.3)]
-  * `anchor`: a URI-reference [[RFC3986 Section 4.1](https://tools.ietf.org/html/rfc3986#section-4.1)] to the link's context.
+  * `rel`: a link relation type or an array of link relation types [[RFC8288 Section 2.1](https://tools.ietf.org/html/rfc8288#section-3.3)].
+    An array of link relationship types establishes multiple links that share
+    the same context, target, and target attributes.
+  * `anchor`: a URI-reference [[RFC3986 Section 4.1](https://tools.ietf.org/html/rfc3986#section-4.1)]
+    to the link's context. By default, the context of a link is the
+    [top-level object][top level], [resource object][resource objects], or
+    [relationship object][relationships] in which the link appears.
   * `params`: a [link parameter object][target attributes] as described
     below.
   * `meta`: a meta object containing non-standard meta-information about the
     link.
 
-By default, the context of a link is the [top-level object][top level], [resource object][resource objects], or
-[relationship object][relationships] in which the link appears.
-
-If the `rel` member is not present on a link object, the link's relation
-type **SHOULD** be interpreted as the name of the link object. The `rel` parameter
-can contain multiple link relation types. When this occurs, it establishes
-multiple links that share the same context, target, and target attributes.
+If a link is represented as a string, or the `rel` member is not present on a
+link object, the link's relation type **SHOULD** be inferred from the name of
+the link object.
 
 Except for the `profile` key in the top-level links object and the `type` 
 key in an [error object]'s links object, each key present in a links object 
@@ -568,6 +569,12 @@ related resource collection:
   }
 }
 ```
+
+In order to represent a link with reversed semantics, it is **RECOMMENDED** that an
+alternate link relation type be used or, less preferably, that the `anchor`
+and `href` members be interchanged.
+
+> Note: The `rev` link parameter was deprecated by [RFC8288 Section 3.3](https://tools.ietf.org/html/rfc8288#section-3.3)
 
 #### <a href="#document-links-target-attributes" id="document-links-target-attributes" class="headerlink"></a> Target attributes
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -533,9 +533,30 @@ Within this object, a link **MUST** be represented as either:
 * <a id="document-links-link-object"></a>an object ("link object") which can
   contain the following members:
   * `href`: a string containing the link's URI.
+  * `params`: a [link parameter object](link-parameter-object).
   * `meta`: a meta object containing non-standard meta-information about the
     link.
   * Any link-specific target attributes described below.
+
+A <a id="document-links-link-parameter-object"></a>link parameter object **MUST** be
+represented as an object which can contain the following members:
+
+* `rel`: a string or an array of strings. Each value **MUST** be a valid link
+  relation type as defined in [RFC8288 Section 2.1](https://tools.ietf.org/html/rfc8288#section-3.3) to include both registered
+  and extension relation types. When the `rel` member is not present, it **SHOULD** be
+  interpreted to contain the parent link object's key name.
+* `anchor`: a string containing URI reference as specified in
+  [[RFC8288 Section 3.2]](https://tools.ietf.org/html/rfc8288#section-3.2). When the `anchor` member is not present and the link belongs
+  to a resource object or relationship object, it **MUST** be interpreted to contain
+  the URI of the resource that generated the current response document with the
+  addition of the URI fragment identifying the object of which the link is a
+  member.
+* Any other valid target attribute name as explained in [RFC8288 Section 2.2](https://tools.ietf.org/html/rfc8288#section-3).
+
+A link parameter object **SHOULD NOT** contain a `rev` member.
+
+Link parameter object members with multiple values **MUST** be represented with an
+array.
 
 Except for the `profile` key in the top-level links object and the `type` 
 key in an [error object]'s links object, each key present in a links object 
@@ -604,6 +625,12 @@ implements at least version 1.0 of the specification.
 
 > Note: Because JSON:API is committed to making additive changes only, the
 version string primarily indicates which new features a server may support.
+
+### <a href="#document-fragment-syntax" id="document-fragment-syntax" class="headerlink"></a> URI Fragment Syntax
+
+A JSON:API URI fragment **MUST** be a JSON Pointer [[RFC6901](https://tools.ietf.org/html/rfc6901)] which points to a
+[resource object](resource objects) or [relationships object](relationships) in the response document and it **MUST NOT**
+point to any child members within it.
 
 ### <a href="#document-member-names" id="document-member-names" class="headerlink"></a> Member Names
 
@@ -2387,6 +2414,8 @@ request as equivalent to one in which the square brackets were percent-encoded.
 [links]: #document-links
 [link]: #document-links-link
 [link object]: #document-links-link-object
+[link parameter object]: #document-links-link-parameter-object
+[fragments]: #document-fragment-syntax
 [profiles]: #profiles
 [timestamps profile]: #profiles-timestamp-profile
 [profile keywords]: #profile-keywords

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -571,11 +571,13 @@ related resource collection:
 
 ##### <a href="#document-links-link-relation-type" id="document-links-link-relation-type" class="headerlink"></a> Link relation type
 
-The value of the `rel` member **MUST** be a string or an array of link relation
-types. Valid link relation types are defined by [RFC8288 Section 2.1](https://tools.ietf.org/html/rfc8288#section-2.1).
+The value of the `rel` member **MUST** be a string or an array of strings that
+represent link relation type(s). Valid link relation types are defined by
+[RFC8288 Section 2.1](https://tools.ietf.org/html/rfc8288#section-2.1).
 
-If a link is represented as a string, or the `rel` member is not given, the
-link's relation type **SHOULD** be inferred from the name of the link object.
+If a link is represented as a string, or the `rel` member is not given on a
+link object, the link's relation type **SHOULD** be inferred from the name of
+the link object.
 
 An array of link relationship types establishes multiple links that share the
 same context, target, and target attributes and a client **MUST** treat these

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -540,7 +540,7 @@ Within this object, a link **MUST** be represented as either:
   * `meta`: a meta object containing non-standard meta-information about the
     link.
 
-By default, the context of a link is the [top-level object][top level], [resource object][resource objects] or
+By default, the context of a link is the [top-level object][top level], [resource object][resource objects], or
 [relationship object][relationships] in which the link appears.
 
 If the `rel` member is not present on a link object, the link's relation

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -588,71 +588,6 @@ Here, the `profile` key specifies an array of `profile` links:
 > Note: Additional link types, similar to `profile` links, may be specified in
 the future.
 
-#### <a href="#document-links-link-relations" id="document-links-link-relations" class="headerlink"></a> Link relation types
-
-The following link relation types **MAY** be used as the value of the `rel` link
-parameter object member:
-
-  * `add`: The link's target points to a resource where a user agent can cause
-    an addition to the link's context.
-  * `update`: The link's target points to a resource where a user agent can cause
-    an update the link's context.
-  * `remove`: The link's target points to a resource where a user agent can cause
-    a removal of all or part of the link's context.
-  * `relate`: The link's target points to a resource where a user agent can cause
-    a direct or indirect relationship to be established with the link's context.
-
-> Note: These link relation types correspond to operations described by the
-JSON:API specification and it is expected that implementations will use them to
-reference resources that will process requests according to [the requirements for
-creating, updating or deleting resources](https://jsonapi.org/format/1.1/#crud). However, this is not a strict
-limitation on their use.
-
-In the example below, two links are established. A `self` link indicating the
-URL of the request that generated the current collection of articles and an `add`
-link indicating the that the client can add an article to this collection.
-
-```json
-"links": {
-  "self": {
-    "href": "http://example.com/articles",
-    "rel": ["self", "add"]
-  }
-}
-```
-
-In the next example, a `comment` link is a member of a `comments` [relationship
-object][relationships] and that relationship object is a member of an `article`'s relationships
-object. In this case, the `rel` member establishes two links indicating that
-the client can create a new comment at the target URL and that requests to the
-target `href` can create a relationship to the article's `comments` field.
-
-```json
-"links": {
-  "self": "http://example.com/articles/1/relationships/comments",
-  "related": "http://example.com/articles/1/comments",
-  "comment": {
-    "href": "http://example.com/articles/1/comments",
-    "rel": ["add", "relate"]
-  }
-}
-```
-
-In this example, a `self` link is a member of an `article`'s links object. In
-this case, the `rel` member established two links indicating that the client can
-edit, but not delete, the context article (perhaps another request with different
-authentication credentials would receive an additional link with a `remove` link
-relation type).
-
-```json
-"links": {
-  "self": {
-    "href": "http://example.com/articles/1",
-    "rel": ["self", "update"]
-  }
-}
-```
-
 #### <a href="#document-links-link-parameter-object" id="document-links-link-parameter-object" class="headerlink"></a> Link parameter objects
 
 "Link parameter objects" appear in link objects to represent a link's target
@@ -2488,7 +2423,6 @@ request as equivalent to one in which the square brackets were percent-encoded.
 [links]: #document-links
 [link]: #document-links-link
 [link object]: #document-links-link-object
-[link relations]: #document-links-link-relations
 [link parameter object]: #document-links-link-parameter-object
 [profiles]: #profiles
 [timestamps profile]: #profiles-timestamp-profile

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -593,7 +593,7 @@ that an alternate link relation type be used or, less preferably, that the
 
 ##### <a href="#document-links-link-parameters" id="document-links-link-parameters" class="headerlink"></a> Link parameters
 
-The value of the `params` member **MUST** be an object (an “link parameter
+The value of the `params` member **MUST** be an object (a “link parameter
 object”). Members of the link parameter object (“link parameters”) describe
 the [link][link] on which they are defined or its target. These link parameters
 are also known as [target attributes](https://tools.ietf.org/html/rfc8288#section-2.2).

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -549,7 +549,7 @@ represented as an object which can contain the following members:
   [[RFC8288 Section 3.2]](https://tools.ietf.org/html/rfc8288#section-3.2). When the `anchor` member is not present and the link belongs
   to a resource object or relationship object, it **MUST** be interpreted to contain
   the URI of the resource that generated the current response document with the
-  addition of the URI fragment identifying the object of which the link is a
+  addition of the [URI fragment](fragments) identifying the object of which the link is a
   member.
 * Any other valid target attribute name as explained in [RFC8288 Section 2.2](https://tools.ietf.org/html/rfc8288#section-3).
 


### PR DESCRIPTION
I know there has been _much_ discussion of links in this project. This PR attempts to faithfully project [RFC8288](https://tools.ietf.org/html/rfc8288) style links onto the JSON:API specification. It is very intentionally concise and _not_ feature rich—meaning that it completely avoids topics like hyper-schema, URI templating, _inter alia_.

If this proposal is not acceptable without those features, I'd ask that this PR be closed. In other words, let's not let those things derail getting a sensible start to better hypermedia support in JSON:API. Nothing here precludes those features. In essence, "a bird in hand is worth two in the bush".

<hr/>

This approach lifts the `link-param` idea from RFC8288 and serializes them in `application/vnd.api+json` format under a new `params` member<sup>[[1]](#fn1)</sup>.

The established link-params `rel`, `anchor` and `rev` have special handling, this is my reasoning:

* `rel`: inherits from the link object key to maximize backwards compatibility. I used the **SHOULD** key word for this inheritance to guard against that case that a key may not be a valid link relation type.
* `anchor`: Because JSON:API has a very well defined structure, I think anchors can be implicitly defined for the `application/vnd.api+json` media type. In other words, that they don't have to explicitly be added as an object member.

  I considered adding language to define a new `anchor` member that could be placed under any `meta` object so that custom anchors could be used, but I left that out. I think that that choice makes this easier to land and to implement for clients and for servers.

  The biggest problem I see here is that it makes it difficult for implementors to comply with [RFC3986's language about consistency of fragments between different representations](https://tools.ietf.org/html/rfc3986#section-3.5). Frankly, I think that's a really pie-in-the-sky requirement to begin with and I wouldn't feel too bad about ignoring it. The `meta.anchor` idea could
  always be added later if it becomes a real problem.

  @ethanresnick [suggested elsewhere](https://github.com/evert/ketting/issues/109) that a fragment should be defined by `type` and `id`. That would make it easier to meet the consistency requirement, but the problem I faced with that approach is that a fragment also should be able to identify a relationships object within a resource object. A fragment syntax like `{type}:{id}(:{relationship field name})?` is the naive approach, but falls down because there are no rules for valid `id` formats. I.e., it would break if a resource object's `id` contained a colon (`:`). Perhaps there are clever ways around that?
* `rev`: this is deprecated by RFC8288 so I tried to reinforce this with a **SHOULD NOT** key word.

All other valid link-params are acceptable, like `hreflang` for example, in addition to any custom ones.

To preclude any misunderstanding with how [RFC8288 Link header link parameters are parsed](https://tools.ietf.org/html/rfc8288#appendix-B.3), I added the language stipulating that multi-value parameters must be arrays so that implementors do not try to use space-delimited or comma-delimited parameter values like one would for a `Link` header.

<hr/>

<a name="fn1">1</a>: I know I said that this PR should not discuss URI templating, but I just want to step in front of any criticism of the `params` member name by saying, "adding a `vars` member would be a perfectly compatible way to support templating later" ;) And that's all I want to say about that :P