### PR TITLE
profiles: rethink handling of missing profile query parameter

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -2005,8 +2005,8 @@ request URI ("parameter x"), the server **MUST NOT** apply a different profile
 that also defines a meaning for parameter x. 
 
 Once the server advertises that a specific profile will be automatically applied
-in certain cases, it **MUST** continue to apply that profile to those same cases 
-in the future.
+at certain URIs, it **MUST** continue to apply that profile on requests to those 
+URIs in the future.
 
 When the server applies a profile to a request on the basis of the request's 
 URI, it **MUST** indicate that it has done so in the response's `Content-Type` 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1986,47 +1986,31 @@ https://jsonapi.org/errors/profile-not-supported
 > rules of the profile. This can fundamentally change the meaning of the 
 > server's response.
 
-#### <a href="#profile-query-parameter-omitting" id="profile-query-parameter" class="headerlink"></a> Omitting the `profile` Query Parameter
+#### <a href="#profile-query-parameter-omitting" id="profile-query-parameter-omitting" class="headerlink"></a> Omitting the `profile` Query Parameter
 
-Requiring the client to specify the `profile` query parameter would be 
-cumbersome. Accordingly, JSON:API defines a way that server's may infer its 
-value in many cases.
+Requiring the client to provide the `profile` query parameter would be 
+cumbersome. Accordingly, a server **MAY** advertise in its documentation that
+certain profiles will be automatically applied to certain requests on the basis
+of the request URI.
 
-To do so, a server **MAY** define an internal mapping from query parameter names 
-to profile URIs. The profile URI for a query parameter name in this mapping 
-**MUST NOT** change over time.
+For example, the server might say:
 
-> Note: the server may choose to map all query parameter names from the same 
-> [family][query parameter family] to one profile URI. Or, it may choose to map
-> only specific query parameter names. 
+> On all requests to URLs that match the pattern `/articles/:id`, the presence 
+> of a `version` query parameter will trigger the application of the 
+> `https://example.com/resource-versioning` profile.
 
-If a requested URL does not contain the `profile` query parameter and does 
-contain one or more query parameters in the server's internal mapping, the 
-server may act as though the request URL contained a `profile` query parameter 
-whose value was the URI-encoded space-separated list of each unique profile URI 
-found in the server's internal mapping for the query parameters in use on the 
-request.
+However, if a request contains the `profile` query parameter, and that parameter 
+lists a profile that defines a meaning for one of the query parameters in the 
+request URI ("parameter x"), the server **MUST NOT** apply a different profile 
+that also defines a meaning for parameter x. 
 
-For example, the server might support a profile that defines a meaning for the
-values of the `page[cursor]` query parameter. Then, it could define its internal 
-param name to profile URI mapping like so:
+Once the server advertises that a specific profile will be automatically applied
+in certain cases, it **MUST** continue to apply that profile to those same cases 
+in the future.
 
-```json
-{ "page[cursor]": "https://example.com/pagination-profile" }
-```
-
-Accordingly, a request for:
-
-```
-https://example.com/?page[cursor]=xyz
-```
-
-would be interpreted by the server as:
-
-```
-https://example.com/?page[cursor]=xyz&profile=https://example.com/pagination-profile
-```
-
+When the server applies a profile to a request on the basis of the request's 
+URI, it **MUST** indicate that it has done so in the response's `Content-Type` 
+header and the response document's `profile` links.
 
 ### <a href="#profile-keywords-and-aliases" id="profile-keywords-and-aliases" class="headerlink"></a> Profile Keywords and Aliases
 


### PR DESCRIPTION
Right now, we say that servers may infer a value for the `profile` query parameter based on an internal mapping they maintain of query parameter names to profile URIs. 

However, we don't say what happens if inference fails/doesn't match anything (e.g., if the server's internal mapping is empty). Presumably, in that case, the request is treated as though the `profile` query parameter simply isn't provided. (For backwards compatibility, I'm pretty sure that needs to be the behavior.) And, in that case, all of the query parameters become "implementation-specific"/not governed by any profile, so the server is able to do whatever it wants with them.

The implication of this, I think, is that our section on `profile` parameter inference isn't really aimed at servers. For example, lets say the server wants to apply the profile `https://example.com/x` when the request url includes the query parameter `x`. To do that, it could use our inference algorithm and add `x` to its internal mapping. Or, it could keep its internal mapping empty, skip our inference algorithm altogether, and still do exactly what it wants, because then `x` becomes implementation-specific, and the server can simply choose to treat it exactly has `https://example.com/x` happens to dictate. (In fact, the server may prefer this approach if it wants `?x` to activate different profiles at different endpoints, which our current inference algorithm doesn't provide for.)

What I think this shows is that having rules for `profile` parameter inference is actually _for the benefit of clients_, so that they can know that the profile they expect to be applied will be applied. To be useful for clients, though, the server's rules for turning query parameters/the request URI into applied profiles needs to be exposed in the server's documentation (if not in a machine readable way).

The upshot of this is that I'd propose rewriting the inference section as shown in this PR, which does three things:

1. Clarify that all that's happening here is the server making promises to clients about which profile(s) it's going to apply.

2. Allow the server to promise to apply different profiles for the same query parameter at different endpoints, which seems very very important for adopting profiles into existing APIs.

3. Talk about the server "automatically applying specific profiles" rather than "inferring the value of the `profile` parameter". I think this new language is more correct because the server can automatically apply specific profiles based on the URI _even when the `profile` parameter *is* present_. For example, imagine a request like `GET /x?filter=yyyy&param2=zzz&profile=https://example.com/filtering`. In that case, suppose that the example.com profile defines a meaning for `filter`: `param2` is still implementation-specific, which means the server could choose to treat it according to the rules of some other profile. In practice, if the server supports two profiles for filtering but only one that defines a meaning for `param2`, it would be convenient for the server to automatically apply the profile that defines `param2`; at least this way the client doesn't have to list both profiles in the `profile` parameter.