### PR TITLE
 feat(profiles): add naming conventions req for review process

### DIFF
--- a/extensions/index.md
+++ b/extensions/index.md
@@ -84,8 +84,8 @@ Once submitted, one of JSON:API's editors will review your profile to check that
 1. follows the template above; 
 2. is specified precisely enough to enable interoperable implementations;
 3. complies with the JSON:API spec and its [requirements for profiles](/format/1.1/#profiles-authoring);
-3. follows JSON:API's [recommended naming conventions](https://jsonapi.org/recommendations/#naming); and
-4. wouldn't cause any problems were it to become widely adopted. 
+4. follows JSON:API's [recommended naming conventions](https://jsonapi.org/recommendations/#naming); and
+5. wouldn't cause any problems were it to become widely adopted. 
 
 If your profile meets these criteria, it will generally be **approved within a week**.
 

--- a/extensions/index.md
+++ b/extensions/index.md
@@ -87,7 +87,7 @@ Once submitted, one of JSON:API's editors will review your profile to check that
 3. follows JSON:API's [recommended naming conventions](https://jsonapi.org/recommendations/#naming); and
 4. wouldn't cause any problems were it to become widely adopted. 
 
-If your profile meets these three criteria, it will generally be **approved within a week**.
+If your profile meets these criteria, it will generally be **approved within a week**.
 
 In limited cases (e.g., if your profile defines a new, fundamental mechanism for
 doing something "architectural" that other profiles may need to do too), it might

--- a/extensions/index.md
+++ b/extensions/index.md
@@ -80,9 +80,14 @@ To register your profile:
    out template as the `index.md` file in that directory folder. (See [an example](https://github.com/json-api/json-api/tree/gh-pages/_profiles/ethanresnick/cursor-pagination).)
 
 Once submitted, one of JSON:API's editors will review your profile to check that
-it: 1) follows the template above; 2) complies with JSON:API's [requirements for profiles](/format/1.1/#profiles-authoring);
-and 3) wouldn't cause any problems were it to become widely adopted. If your
-profile meets these three criteria, it will generally be **approved within a week**.
+it: 
+
+1. follows the template above; 
+2. complies with JSON:API's [requirements for profiles](/format/1.1/#profiles-authoring);
+3. follows JSON:API's [recommended naming conventions](https://jsonapi.org/recommendations/#naming); and
+4. wouldn't cause any problems were it to become widely adopted. 
+
+If your profile meets these three criteria, it will generally be **approved within a week**.
 
 In limited cases (e.g., if your profile defines a new, fundamental mechanism for
 doing something "architectural" that other profiles may need to do too), it might


### PR DESCRIPTION
While we didn’t go so far as requiring all profiles use camelCasing, I think it’s probably a good idea to require that all _registered_ profiles do, to make sure they look nice when used together.

Although I can also see an argument that this requirement will annoy authors during review, so I'm not wedded to it; seems more like a "nice to have".