### PR TITLE
Drupal's JSON:API implementation was wrongly listed under "client lib…

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -82,7 +82,6 @@ isomorphic ActiveRecord clone that issues JSON:API requests instead of SQL and i
 * [enm/json-api-client](https://eosnewmedia.github.io/JSON-API-Client/) is an abstract client-side PHP implementation of the json:api specification which is based on [enm/json-api-common](https://eosnewmedia.github.io/JSON-API-Common/). It allows you to send json:api requests via your own http client implementation or via a buzz or guzzle client.
 * [pz/doctrine-rest](https://github.com/R3VoLuT1OneR/doctrine-rest) library provides basic tools for implementation of JSON:API with Doctrine 2
 * [swisnl/json-api-client](https://github.com/swisnl/json-api-client) Is a package for mapping remote {json:api} resources to Eloquent like models and collections.
-* [jsonapi](https://www.drupal.org/project/jsonapi) is a Drupal module that exposes all data managed by Drupal (entities) according to the JSON:API specification. [jsonapi_extras](https://www.drupal.org/project/jsonapi_extras) is an optional extra module to change resource type names, field names and more. And [openapi](https://www.drupal.org/project/openapi) is another optional module, that is able to generate an OpenAPI/Swagger representation of the API provided by the `jsonapi` module with a ReDoc-powered UI.
 
 ### <a href="#client-libraries-dart" id="client-libraries-dart" class="headerlink"></a> Dart
 
@@ -159,6 +158,7 @@ and writing of JSON:API documents.
 * [paknahad/jsonapi-bundle](https://github.com/paknahad/jsonapi-bundle) is a Symfony bundle. It is the fastest way to generate API.
 * [swisnl/json-api-server](https://github.com/swisnl/json-api-server) is a Laravel package to get a JSON:API up and running in minutes.
 * [hackerboy/json-api](https://github.com/hackerboydotcom/json-api) is a lightweight library that helps you to implement JSONAPI easily
+* [`drupal/jsonapi`](https://www.drupal.org/project/jsonapi) is a Drupal module that exposes all data managed by Drupal (entities) according to the JSON:API specification. [`jsonapi_extras`](https://www.drupal.org/project/jsonapi_extras) is an optional extra module to change resource type names, field names and more. And [`openapi`](https://www.drupal.org/project/openapi) is another optional module, that is able to generate an OpenAPI/Swagger representation of the API provided by the `jsonapi` module with a ReDoc-powered UI.
 
 
 ### <a href="#server-libraries-node-js" id="server-libraries-node-js" class="headerlink"></a> Node.js


### PR DESCRIPTION
…raries"

… but it's a _server_. So "server libraries" would be a better fit, but even that would be wrong actually. It's _not_ just a library. As soon as you install it, it _works_. It exposes Drupal's entire data model.

So … a new "servers" section would be more accurate. For now, just moving it to "server libraries".

Can't believe none of us noticed this before!