### PR TITLE
profiles: handling mismatch between `content-type` and `links.profile` list of profiles

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1948,6 +1948,11 @@ include a [top-level][top level] [`links` object][links] with a `profile` key,
 and that `profile` key **MUST** include a [link] to the URI of each profile
 that has been applied.
 
+> Beware: while senders are required to list the same profiles in the 
+> `Content-Type` header and the document's `profile` links, recipients must 
+> properly handle the case that these sets of profiles are different (because 
+> the request is malformed). See ["Identifying a Document's Profiles"](#profiles-processing-identifying-applied-profiles).
+
 When an older JSON:API server that doesn't support the `profile` media type
 parameter receives a document with one or more profiles, it will respond with a
 `415 Unsupported Media Type` error.
@@ -1958,9 +1963,8 @@ it has applied to the document and retry its request without the `profile` media
 type parameter. If this resolves the error, the client **SHOULD NOT** attempt to
 use profile extensions in subsequent interactions with the same API.
 
-> The most likely other causes of a 415 error are that the server doesn't
-support JSON:API at all or that the client has failed to provide a required
-profile.
+> The most likely other cause of a 415 error is that the server doesn't support 
+> JSON:API at all.
 
 ### <a href="#profile-query-parameter" id="profile-query-parameter" class="headerlink"></a> `profile` Query Parameter
 
@@ -2127,6 +2131,24 @@ key `version` described in the profile:
 
 ### <a href="#profiles-processing" id="profiles-processing" class="headerlink"></a> Processing Profiled Documents/Requests
 
+#### <a href="#profiles-processing-identifying-applied-profiles" id="profiles-processing-identifying-applied-profiles" class="headerlink"></a> Identifying a Document's Profiles
+Before any processing can begin, the recipient of a profiled document must 
+correctly identify which profiles have been applied to that document. 
+
+To do so, a recipient (client or server) **MUST** look only at the `profile` 
+links in the document's top-level `links` object. 
+
+In other words, recipients **MUST NOT** consider the profile URIs listed in the 
+`Content-Type` header, which may be different than those listed in the document 
+if the sender's message is malformed.
+
+> Note: the set of profiles that apply to a document is conceptually distinct 
+> from, but likely overlaps with, the set of profiles that apply to processing 
+> the request that includes/produces that document. The server identifies this 
+> latter set of profiles through the `profile` query parameter (or its internal 
+> decision to enable certain profiles automatically).
+
+#### <a href="#profiles-processing-value-handling" id="profiles-processing-value-handling" class="headerlink"></a> Handling a Profile's Data
 When a profile is applied to a request and/or document, the value used for each 
 of the profile's document members or query parameters is said to be "a 
 recognized value" if that value, including all parts of it, has a legal, defined

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1940,13 +1940,16 @@ whose support is required using the `profile` query parameter, as described late
 #### <a href="#profiles-sending" id="profiles-sending" class="headerlink"></a> Sending Profiled Documents
 
 Clients and servers **MUST** include the `profile` media type parameter in
-conjunction with the JSON:API media type in a `Content-Type` header to indicate
-that they have applied one or more profiles to a JSON:API document.
+conjunction with the JSON:API media type in the `Content-Type` header to 
+indicate that they have applied one or more profiles to a JSON:API document.
 
 Likewise, clients and servers applying profiles to a JSON:API document **MUST**
 include a [top-level][top level] [`links` object][links] with a `profile` key,
 and that `profile` key **MUST** include a [link] to the URI of each profile
 that has been applied.
+
+The profiles referenced in the top level `links` object **MUST** be exactly the
+same set of profiles listed in the `Content-Type` header's `profile` parameter.
 
 > Beware: while senders are required to list the same profiles in the 
 > `Content-Type` header and the document's `profile` links, recipients must 


### PR DESCRIPTION
As @wimleers [pointed out](https://github.com/json-api/json-api/pull/1268#discussion_r192717689) in his original review of #1268, we don't currently say what happens when a different list of profiles is specified in the document (in `links.profile`) than in the `Content-Type` header.

I've been thinking about a bunch of options and have concluded that the solution I offered in my original response to Wim's comment — i.e., making any mismatch trigger a 400 — is the wrong way to go. One issue with that solution is that it only covers documents sent to the server; i.e., it doesn't cover how the client should process documents sent from the server that have the same mismatch. (We could say that the client must entirely discard such responses... but I'm not sure clients would actually do that.) Another problem with the 400 approach — and actually any approach that requires the recipient to read both lists of profiles — is that it introduces a preprocessing step (e.g., to check that the lists match), and we have to pay the cost of that preprocessing step on every request, even though a mismatch should be a very rare event. That seems like a bad idea.

So, my preferred approach at this point, which is embodied in this PR, is simply to treat `links.profile` as the definitive list of applied profiles in the event of any mismatch. By treating one list as definitive, recipients can simply ignore the other (no comparison step required), but we can keep both in the spec, which is nice because both bring something of value. (Specifically, if we removed the parameter on `Content-Type`, profile negotiation would look pretty asymmetrical; i.e., the client would use the `profile` parameter in `Accept`, but not get it back in the response. Meanwhile, `links.profile` is offering an elegant place to list profile aliases, which have to go in the document somewhere.)

I chose to treat `links.profile` as the definitive source because recipients have to look there anyway before processing the document (to check for aliases), so making that the only place they have to look to determine the applied profiles seemed to make the most sense.

Note: one small issue with making `links.profile` definitive is that the "missing a server-required profile error" from #1354 would probably have to be a 400 rather than a 415, because the required profile actually _could_ be listed in `Content-Type` but still be "missing" if its not listed in `links.profile`. I think that's fine, but it means #1354 will have to be tweaked after this PR is merged.

Note 2: Wim also pointed out that we don't say what should happen when the client lists a profile in the `profile` query parameter that isn't in its `Accept` header. But I think that case is already covered implicitly, and the answer is that the server should pay attention to the query parameter. That's because JSON:API says that the `profile` query parameter lists _required_ profiles -- while both HTTP and JSON:API say that a profile can be applied to a response document even if it isn't in the `Accept` header.