### PR TITLE
'Commercial at' mentioned as reserved

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -668,7 +668,7 @@ The following characters **MUST NOT** be used in member names:
 - U+003D EQUALS SIGN, "="
 - U+003E GREATER-THAN SIGN, ">"
 - U+003F QUESTION MARK, "?"
-- U+0040 COMMERCIAL AT, "@"
+- U+0040 COMMERCIAL AT, "@" (except as first character in [@-Members](#document-member-names-at-members))
 - U+005C REVERSE SOLIDUS, "&#x5c;"
 - U+005E CIRCUMFLEX ACCENT, "^"
 - U+0060 GRAVE ACCENT, "&#x60;"


### PR DESCRIPTION
Now @-Members are in v1.1, shouldn't the [reserved characters](https://jsonapi.org/format/1.1/#document-member-names-reserved-characters) be updated? That one still mentions that the 'commercial at' (@) is not allowed anywhere.

I understand it is only for @-Members, and only as the first char, so maybe a small clarification like 'except as first character in @-Members' would be good?