### PR TITLE
Schema should allow link objects as pagination links

### DIFF
--- a/schema
+++ b/schema
@@ -292,28 +292,28 @@
         "first": {
           "description": "The first page of data",
           "oneOf": [
-            { "type": "string", "format": "uri-reference" },
+            { "$ref": "#/definitions/linkage" },
             { "type": "null" }
           ]
         },
         "last": {
           "description": "The last page of data",
           "oneOf": [
-            { "type": "string", "format": "uri-reference" },
+            { "$ref": "#/definitions/linkage" },
             { "type": "null" }
           ]
         },
         "prev": {
           "description": "The previous page of data",
           "oneOf": [
-            { "type": "string", "format": "uri-reference" },
+            { "$ref": "#/definitions/linkage" },
             { "type": "null" }
           ]
         },
         "next": {
           "description": "The next page of data",
           "oneOf": [
-            { "type": "string", "format": "uri-reference" },
+            { "$ref": "#/definitions/linkage" },
             { "type": "null" }
           ]
         }

--- a/schema
+++ b/schema
@@ -292,28 +292,28 @@
         "first": {
           "description": "The first page of data",
           "oneOf": [
-            { "$ref": "#/definitions/linkage" },
+            { "$ref": "#/definitions/link" },
             { "type": "null" }
           ]
         },
         "last": {
           "description": "The last page of data",
           "oneOf": [
-            { "$ref": "#/definitions/linkage" },
+            { "$ref": "#/definitions/link" },
             { "type": "null" }
           ]
         },
         "prev": {
           "description": "The previous page of data",
           "oneOf": [
-            { "$ref": "#/definitions/linkage" },
+            { "$ref": "#/definitions/link" },
             { "type": "null" }
           ]
         },
         "next": {
           "description": "The next page of data",
           "oneOf": [
-            { "$ref": "#/definitions/linkage" },
+            { "$ref": "#/definitions/link" },
             { "type": "null" }
           ]
         }


### PR DESCRIPTION
As a rule, our JSON:API implementation uses link objects for every link. This ensures clients written against our implementation are maximally forward compatible (so they don't break if and when a link has metadata added to it).

We've even applied this rule to pagination links. We've recently discovered that [our responses are failing validation for this reason](https://www.drupal.org/project/jsonapi/issues/3037852#comment-13001794).

It seems like this is a small oversight in the schema and is not an intentional validation rule.

I need to validate that this schema change is correct tomorrow. However, I wanted to throw the PR out there for any initial reactions in case it actually _is_ intentional and I've missed something. Therefore, I'm leaving this as a draft (which, BTW, is a nifty new GH feature!).