### PR TITLE
Clarify potentially confusing Retry-After value

### DIFF
--- a/recommendations/index.md
+++ b/recommendations/index.md
@@ -239,7 +239,7 @@ Requests for still-pending jobs **SHOULD** return a status `200 OK`, as the serv
 ```http
 HTTP/1.1 200 OK
 Content-Type: application/vnd.api+json
-Retry-After: 1
+Retry-After: 10
 
 {
   "data": {


### PR DESCRIPTION
The description for this http request talked about retrying sooner than 1 second with Retry-After: 0. Using a Retry-After value of 1 was slightly confusing, as it wasn't clear if this was a typo, or
demonstrating the general retry case.

This commit changes Retry-After to 10 seconds to clearly delineate it from the 0s-1s range.