### PR TITLE
Fix misleading wording about quotation

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -83,7 +83,7 @@ values of the `ext` and `profile` parameters **MUST** equal a space-separated
 
 > Note: When serializing the `ext` or `profile` media type parameters, the HTTP
 > specification requires that parameter values be surrounded by quotation marks
-> (U+0022 QUOTATION MARK, "\"") if the value contains more than one URI.
+> (U+0022 QUOTATION MARK, "\"").
 
 #### <a href="#extension-rules" id="extension-rules" class="headerlink"></a> Rules for Extensions
 


### PR DESCRIPTION
RFC 7231 Section 5.3.2 requires quoting even a single URI
in a media range parameter, because it contains characters that 
are not allowed in an unquoted token (RFC 7230 Section 3.2.6).