### PR TITLE
Fix example for the 'profile' media type parameter

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1922,10 +1922,11 @@ request is received, a server **SHOULD** attempt to apply the requested profiles
 to its response.
 
 For example, in the following request, the client asks that the server apply the
-`http://example.com/last-modified` profile if it is able to.
+`http://example.com/last-modified` profile if it is able to, by assigning a higher
+quality value (implied `q=1`) to it.
 
 ```http
-Accept: application/vnd.api+json;profile="http://example.com/last-modified", application/vnd.api+json
+Accept: application/vnd.api+json;profile="http://example.com/last-modified", application/vnd.api+json;q=0.8
 ```
 
 > Note: The second instance of the JSON:API media type in the example above is


### PR DESCRIPTION
Per RFC 7231 Section 5.3.2, Accept is not an ordered list. Relative preferences are expressed with explicit quality values.