### PR TITLE
Simplify profiles

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -559,22 +559,15 @@ related resource collection:
 #### <a href="#profile-links" id="profile-links" class="headerlink"></a> Profile Links
 
 Like all [links][link], a link in an array of `profile` links can be represented
-with a [link object]. In that case, the link object **MAY** contain an `aliases` 
-member listing any [profile aliases].
+with a [link object].
 
-Here, the `profile` key specifies an array of `profile` links, including one
-that includes a [profile alias][profile aliases]:
+Here, the `profile` key specifies an array of `profile` links:
 
 ```json
 "links": {
   "profile": [
     "http://example.com/profiles/flexible-pagination",
-    {
-      "href": "http://example.com/profiles/resource-versioning",
-      "aliases": {
-        "version": "v"
-      }
-    }
+    "http://example.com/profiles/resource-versioning"
   ]
 }
 ```
@@ -2025,7 +2018,7 @@ https://example.com/?page[cursor]=xyz&profile=https://example.com/pagination-pro
 ```
 
 
-### <a href="#profile-keywords-and-aliases" id="profile-keywords-and-aliases" class="headerlink"></a> Profile Keywords and Aliases
+### <a href="#profile-keywords" id="profile-keywords" class="headerlink"></a> Profile Keywords
 
 A profile **SHOULD** explicitly declare "keywords" for any elements that it
 introduces to the document structure. If a profile does not explicitly declare a
@@ -2033,11 +2026,10 @@ keyword for an element, then the name of the element itself (i.e., its key in
 the document) is considered to be its keyword. All profile keywords **MUST** 
 meet this specification's requirements for [member names].
 
-For the purposes of aliasing, a profile's elements are defined shallowly. 
 In other words, if a profile introduces an object-valued document member, that 
-member is an element (and so subject to aliasing), but any keys in it are not 
-themselves elements. Likewise, if the profile defines an array-valued element, 
-the keys in nested objects within that array are not elements.
+member is an element, but any keys in it are not themselves elements. Likewise,
+if the profile defines an array-valued element, the keys in nested objects
+within that array are not elements.
 
 The following example profile defines a single keyword, `version`:
 
@@ -2085,42 +2077,6 @@ This profile might be applied as follows:
 }
 ```
 
-Documents that apply a particular profile **MAY** represent each keyword with an
-alternatively named member, or "alias". An alias fully assumes any meaning
-specified for a keyword, which no longer retains that meaning. Any aliases
-associated with a profile **MUST** be represented in the profile's corresponding
-`aliases` object within its [link object][links]. The key of each alias **MUST**
-be a keyword from the profile, and the value **MUST** be an alias that applies
-to this particular representation. This aliasing mechanism allows profiles to be
-applied in a way that is both consistent with the rest of the representation and
-does not conflict with other profiles.
-
-For instance, the following document provides an alias for `version`: `v`.
-Interpreters of this representation should treat the key `v` as if it were the
-key `version` described in the profile:
-
-```json
-{
-  "data": {
-    "type": "contacts",
-    "id": "345",
-    "meta": {
-      "v": "2018-04-14-879976658"
-    },
-    "attributes": {
-      "name": "Ethan"
-    }
-  },
-  "links": {
-    "profile": [{
-      "href": "http://example.com/profiles/resource-versioning",
-      "aliases": {
-        "version": "v"
-      }
-    }]
-  }
-}
-```
 
 ### <a href="#profiles-processing" id="profiles-processing" class="headerlink"></a> Processing Profiled Documents/Requests
 
@@ -2284,8 +2240,7 @@ that "The elements... specified by a profile... **MUST NOT** change over time."
 
 > The practical issue with adding a sibling element is that another profile 
 > in use on the document might already define a sibling element of the same 
-> name, and existing documents would not have any aliases defined to resolve 
-> this conflict.
+> name.
 
 However, the timestamps profile could evolve to allow other optional members, 
 such as `deleted`, in the `timestamps` object. This is possible because the 
@@ -2432,7 +2387,7 @@ request as equivalent to one in which the square brackets were percent-encoded.
 [link object]: #document-links-link-object
 [profiles]: #profiles
 [timestamps profile]: #profiles-timestamp-profile
-[profile aliases]: #profile-keywords-and-aliases
+[profile keywords]: #profile-keywords
 [error details]: #errors
 [error object]: #error-objects
 [error objects]: #errror-objects

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -565,15 +565,22 @@ related resource collection:
 #### <a href="#profile-links" id="profile-links" class="headerlink"></a> Profile Links
 
 Like all [links][link], a link in an array of `profile` links can be represented
-with a [link object].
+with a [link object]. In that case, the link object **MAY** contain an `aliases` 
+member listing any [profile aliases].
 
-Here, the `profile` key specifies an array of `profile` links:
+Here, the `profile` key specifies an array of `profile` links, including one
+that includes a [profile alias][profile aliases]:
 
 ```json
 "links": {
   "profile": [
     "http://example.com/profiles/flexible-pagination",
-    "http://example.com/profiles/resource-versioning"
+    {
+      "href": "http://example.com/profiles/resource-versioning",
+      "aliases": {
+        "version": "v"
+      }
+    }
   ]
 }
 ```
@@ -1973,7 +1980,7 @@ profile.
 > server's response.
 
 
-### <a href="#profile-keywords" id="profile-keywords" class="headerlink"></a> Profile Keywords
+### <a href="#profile-keywords-and-aliases" id="profile-keywords-and-aliases" class="headerlink"></a> Profile Keywords and Aliases
 
 A profile **SHOULD** explicitly declare "keywords" for any elements that it
 introduces to the document structure. If a profile does not explicitly declare a
@@ -1981,10 +1988,11 @@ keyword for an element, then the name of the element itself (i.e., its key in
 the document) is considered to be its keyword. All profile keywords **MUST** 
 meet this specification's requirements for [member names].
 
+For the purposes of aliasing, a profile's elements are defined shallowly. 
 In other words, if a profile introduces an object-valued document member, that 
-member is an element, but any keys in it are not themselves elements. Likewise,
-if the profile defines an array-valued element, the keys in nested objects
-within that array are not elements.
+member is an element (and so subject to aliasing), but any keys in it are not 
+themselves elements. Likewise, if the profile defines an array-valued element, 
+the keys in nested objects within that array are not elements.
 
 The following example profile defines a single keyword, `version`:
 
@@ -2032,6 +2040,42 @@ This profile might be applied as follows:
 }
 ```
 
+Documents that apply a particular profile **MAY** represent each keyword with an
+alternatively named member, or "alias". An alias fully assumes any meaning
+specified for a keyword, which no longer retains that meaning. Any aliases
+associated with a profile **MUST** be represented in the profile's corresponding
+`aliases` object within its [link object][links]. The key of each alias **MUST**
+be a keyword from the profile, and the value **MUST** be an alias that applies
+to this particular representation. This aliasing mechanism allows profiles to be
+applied in a way that is both consistent with the rest of the representation and
+does not conflict with other profiles.
+
+For instance, the following document provides an alias for `version`: `v`.
+Interpreters of this representation should treat the key `v` as if it were the
+key `version` described in the profile:
+
+```json
+{
+  "data": {
+    "type": "contacts",
+    "id": "345",
+    "meta": {
+      "v": "2018-04-14-879976658"
+    },
+    "attributes": {
+      "name": "Ethan"
+    }
+  },
+  "links": {
+    "profile": [{
+      "href": "http://example.com/profiles/resource-versioning",
+      "aliases": {
+        "version": "v"
+      }
+    }]
+  }
+}
+```
 
 ### <a href="#profiles-processing" id="profiles-processing" class="headerlink"></a> Processing Profiled Documents/Requests
 
@@ -2195,7 +2239,8 @@ that "The elements... specified by a profile... **MUST NOT** change over time."
 
 > The practical issue with adding a sibling element is that another profile 
 > in use on the document might already define a sibling element of the same 
-> name.
+> name, and existing documents would not have any aliases defined to resolve 
+> this conflict.
 
 However, the timestamps profile could evolve to allow other optional members, 
 such as `deleted`, in the `timestamps` object. This is possible because the 
@@ -2344,7 +2389,7 @@ request as equivalent to one in which the square brackets were percent-encoded.
 [link object]: #document-links-link-object
 [profiles]: #profiles
 [timestamps profile]: #profiles-timestamp-profile
-[profile keywords]: #profile-keywords
+[profile aliases]: #profile-keywords-and-aliases
 [error details]: #errors
 [error object]: #error-objects
 [error objects]: #errror-objects

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -49,9 +49,6 @@ The `profile` parameter is used to support [profiles].
 
 ### <a href="#content-negotiation-clients" id="content-negotiation-clients" class="headerlink"></a> Client Responsibilities
 
-Clients that include the JSON:API media type in their `Accept` header **MUST**
-specify the media type there at least once without any media type parameters.
-
 When processing a JSON:API response document, clients **MUST** ignore any
 parameters other than `profile` in the server's `Content-Type` header.
 
@@ -62,8 +59,8 @@ a request specifies the header `Content-Type: application/vnd.api+json`
 with any media type parameters other than `profile`.
 
 Servers **MUST** respond with a `406 Not Acceptable` status code if a
-request's `Accept` header contains the JSON:API media type and all instances
-of that media type are modified with media type parameters.
+request's `Accept` header contains the JSON:API media type and the server is
+unable to respond with an acceptable representation.
 
 > Note: These content negotiation requirements exist to allow future versions
 of this specification to add other media type parameters for extension


### PR DESCRIPTION
JSON:API is already burdened by a high number of concepts. JSON:API 1.1 introduces an entirely new concept, profiles, which itself has a number of new concepts.

This is an attempt to simplify the profiles with the intention of lowering the burden of their implementation.

<hr>

I think the two biggest sources of complexity introduced with profiles are:

1. Aliasing
2. Separate and competing negotiation mechanisms (`Accept`-based and query parameter based)

#### Aliasing
The first, aliasing, anticipates a problem that I'm not yet convinced we'll encounter. That is, it attempts to make it possible for a server to support profiles with conflicting keywords. 

Unfortunately, aliasing is not a trivial thing to implement on the client or the server. A global dictionary must be computed for every HTTP message by either the client or the server. There is no guarantee that two implementations will use the same aliases, nor that they will even use the same aliases between requests. In systems that have hierarchical (de)serialization components, that global dictionary must be shared between them and that can be a cumbersome process. Even after deserialization, every processor must also know about the aliases too, since processors will be looking for specific keywords.

I propose we remove aliasing from v1.1 of the spec. If they really do become necessary, it shouldn't be too difficult to add them to a subsequent version of the spec.

#### Competing negotiation mechanisms
The second, competing negotiation mechanisms, is hard to interpret and creates complex interactions when used in conjunction with one another.

I see the strict correctness of using the `Accept` parameter for profiled documents and the `profile` query parameter for profiles which establish new query parameters and/or further define the `sort`, `filter` and `page` query parameters. However, it doesn't seem worth the complexity it adds. However, the spec does not limit which kinds of profiles are allowed in one of the negotiation mechanisms vs. the other (f.e. only profiles that register new query parameters are permitted in the `profiles` query parameter).

The biggest distinction between the two mechanism is that the `profile` query parameter permits a client to _require_ a profile while the `Accept` header does not. That's because, the `Accept` header based profiling mechanism requires that the client sends at least two media type values if it desires a profiled response document. One of these *must* be the bare JSON:API media type. Consequently, the spec forces the client to be to accept and process both responses. That adds complexity to the client implementation that I doubt many clients will adopt.

It seems far more likely that most clients will be written to accept a specific set of profiles which it knows a specific server will support. Even generalized clients that can may be able to support many different profiles, probably won't be written to dynamically negotiate profiles, rather, they'll probably make the profiles to request a configuration option or some kind of middleware.

Furthermore, the fact that the `profiles` query parameter can be omitted and implied by other query parameters suggests that the we already recognize that most clients are written with a specific server implementation in mind.

Given all that, I propose that we simplify the profile negotiation mechanism by completely removing the `profile` query parameter and then strengthening the `Accept` header mechanism by removing the requirement that the bare JSON:API media type be present. I considered removing the `Accept` mechanism instead, but felt that since `Accept` is already the standard for negotiating over HTTP, we ought to use it.