### PR TITLE
Remove profile aliasing from 1.1-rc2

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -562,22 +562,15 @@ related resource collection:
 #### <a href="#profile-links" id="profile-links" class="headerlink"></a> Profile Links
 
 Like all [links][link], a link in an array of `profile` links can be represented
-with a [link object]. In that case, the link object **MAY** contain an `aliases` 
-member listing any [profile aliases].
+with a [link object].
 
-Here, the `profile` key specifies an array of `profile` links, including one
-that includes a [profile alias][profile aliases]:
+Here, the `profile` key specifies an array of `profile` links:
 
 ```json
 "links": {
   "profile": [
     "http://example.com/profiles/flexible-pagination",
-    {
-      "href": "http://example.com/profiles/resource-versioning",
-      "aliases": {
-        "version": "v"
-      }
-    }
+    "http://example.com/profiles/resource-versioning"
   ]
 }
 ```
@@ -2028,7 +2021,7 @@ https://example.com/?page[cursor]=xyz&profile=https://example.com/pagination-pro
 ```
 
 
-### <a href="#profile-keywords-and-aliases" id="profile-keywords-and-aliases" class="headerlink"></a> Profile Keywords and Aliases
+### <a href="#profile-keywords" id="profile-keywords" class="headerlink"></a> Profile Keywords
 
 A profile **SHOULD** explicitly declare "keywords" for any elements that it
 introduces to the document structure. If a profile does not explicitly declare a
@@ -2036,11 +2029,10 @@ keyword for an element, then the name of the element itself (i.e., its key in
 the document) is considered to be its keyword. All profile keywords **MUST** 
 meet this specification's requirements for [member names].
 
-For the purposes of aliasing, a profile's elements are defined shallowly. 
 In other words, if a profile introduces an object-valued document member, that 
-member is an element (and so subject to aliasing), but any keys in it are not 
-themselves elements. Likewise, if the profile defines an array-valued element, 
-the keys in nested objects within that array are not elements.
+member is an element, but any keys in it are not themselves elements. Likewise,
+if the profile defines an array-valued element, the keys in nested objects
+within that array are not elements.
 
 The following example profile defines a single keyword, `version`:
 
@@ -2088,42 +2080,6 @@ This profile might be applied as follows:
 }
 ```
 
-Documents that apply a particular profile **MAY** represent each keyword with an
-alternatively named member, or "alias". An alias fully assumes any meaning
-specified for a keyword, which no longer retains that meaning. Any aliases
-associated with a profile **MUST** be represented in the profile's corresponding
-`aliases` object within its [link object][links]. The key of each alias **MUST**
-be a keyword from the profile, and the value **MUST** be an alias that applies
-to this particular representation. This aliasing mechanism allows profiles to be
-applied in a way that is both consistent with the rest of the representation and
-does not conflict with other profiles.
-
-For instance, the following document provides an alias for `version`: `v`.
-Interpreters of this representation should treat the key `v` as if it were the
-key `version` described in the profile:
-
-```json
-{
-  "data": {
-    "type": "contacts",
-    "id": "345",
-    "meta": {
-      "v": "2018-04-14-879976658"
-    },
-    "attributes": {
-      "name": "Ethan"
-    }
-  },
-  "links": {
-    "profile": [{
-      "href": "http://example.com/profiles/resource-versioning",
-      "aliases": {
-        "version": "v"
-      }
-    }]
-  }
-}
-```
 
 ### <a href="#profiles-processing" id="profiles-processing" class="headerlink"></a> Processing Profiled Documents/Requests
 
@@ -2287,8 +2243,7 @@ that "The elements... specified by a profile... **MUST NOT** change over time."
 
 > The practical issue with adding a sibling element is that another profile 
 > in use on the document might already define a sibling element of the same 
-> name, and existing documents would not have any aliases defined to resolve 
-> this conflict.
+> name.
 
 However, the timestamps profile could evolve to allow other optional members, 
 such as `deleted`, in the `timestamps` object. This is possible because the 
@@ -2435,7 +2390,7 @@ request as equivalent to one in which the square brackets were percent-encoded.
 [link object]: #document-links-link-object
 [profiles]: #profiles
 [timestamps profile]: #profiles-timestamp-profile
-[profile aliases]: #profile-keywords-and-aliases
+[profile keywords]: #profile-keywords
 [error details]: #errors
 [error object]: #error-objects
 [error objects]: #errror-objects


### PR DESCRIPTION
This PR is derived from #1410 which included this same alias removal. Per [@dgeb' s request](https://github.com/json-api/json-api/pull/1410#issuecomment-516043765), I've broken this out into its own PR. I agree that this will make this change easier to review and consider.

This PR supersedes #1362.

### Motivation
Aliasing anticipates a problem that I'm not yet convinced we'll encounter. That is, it attempts to make it possible for a server to support profiles with conflicting keywords.

Unfortunately, aliasing is not a trivial thing to implement on the client or the server. A global dictionary must be computed for every HTTP message by either the client or the server. There is no guarantee that two implementations will use the same aliases, nor that they will even use the same aliases between requests. In systems that have hierarchical (de)serialization components, that global dictionary must be shared between them and that can be a cumbersome process. Even after deserialization, every processor must also know about the aliases too, since processors will be looking for specific keywords.

I propose we remove aliasing from v1.1 of the spec. If they really does become necessary, it shouldn't be too difficult to add them to a subsequent version of the spec.