### PR TITLE
Unify profile negotiation via the Accept and Content-Type headers in 1.1-rc2

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -67,6 +67,10 @@ its `source` and which has the following URI as (one of) its `type`s:
 https://jsonapi.org/errors/profile-not-supported
 ```
 
+It is **RECOMMENDED** that servers specify the `Vary` header with the `Accept`
+header as one of its header names to ensure that its responses are
+appropriately cached.
+
 > Note: These content negotiation requirements exist to allow future versions
 of this specification to add other media type parameters for extension
 negotiation and versioning.

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -52,16 +52,6 @@ negotiation and versioning.
 
 ### <a href="#content-negotiation-clients" id="content-negotiation-clients" class="headerlink"></a> Client Responsibilities
 
-Clients that include the `profile` parameter at least once in their `Accept`
-header **MUST** specify at it at least once without the `profile` media type
-parameter.
-
-For example:
-
-```http
-Accept: application/vnd.api+json;profile="http://example.com/last-modified", application/vnd.api+json
-```
-
 When processing a JSON:API response document, clients **MUST** ignore any
 parameters other than `profile` in the server's `Content-Type` header.
 
@@ -1911,7 +1901,8 @@ This profile defines the following keywords:
 
 The `profile` media type parameter is used to describe the application of
 one or more profiles to a JSON:API document. The value of the `profile`
-parameter **MUST** equal a space-separated (U+0020 SPACE, " ") list of profile URIs.
+parameter **MUST** equal a space-separated (U+0020 SPACE, " ") list of profile
+URIs.
 
 > Note: When serializing the `profile` media type parameter, the HTTP
 > specification requires that its value be surrounded by quotation marks
@@ -1924,42 +1915,25 @@ requested profiles to its response.
 
 For example, in the following request, the client asks that the server apply
 the `http://example.com/last-modified` profile and the
-`http://example.com/iso-8601` profile if it is able to.
+`http://example.com/timestamps` profile, if it is able to.
 
 ```http
 GET /articles/1 HTTP/1.1
 Accept: application/vnd.api+json; profile="http://example.com/last-modified http://example.com/iso-8601"
 ...
 
-If the server is unable to apply any of the requested profiles, it may send a
-response without any of the profiles applied:
+Servers **MAY** respond with a subset of the requested profiles applied or none
+of the requested profiles applied. Additionally, servers **MAY** respond with
+unrequested profiles applied.
 
-```
-HTTP/1.1 200 OK
-Content-Type: application/vnd.api+json
-```
-
-Additionally, servers **MAY** respond with only a subset of the requested
-profiles applied.
-
-For example, if the server supports the `http://example.com/iso-8601` profile,
-but not the `http://example.com/last-modified` profile, it may send a
-response with only the supported subset of profiles applied:
-
-```
-HTTP/1.1 200 OK
-Content-Type: application/vnd.api+json; profile="http://example.com/iso-8601"
-```
-
-Servers **MAY** respond using one or more profiles even if the client has
-not requested them. The recipient of a document to which an unknown profile
-has been applied **MUST** ignore any document members that it does not understand.
+The recipient of a document to which an unknown profile has been applied
+**MUST** ignore any document members that it does not understand.
 
 #### <a href="#profiles-sending" id="profiles-sending" class="headerlink"></a> Sending Profiled Documents
 
 Clients and servers **MUST** include the `profile` media type parameter in
-conjunction with the JSON:API media type in a `Content-Type` header to indicate
-that they have applied one or more profiles to a JSON:API document.
+conjunction with the JSON:API media type in a `Content-Type` header when they
+have applied one or more profiles to a JSON:API document.
 
 Likewise, clients and servers applying profiles to a JSON:API document **MUST**
 include a [top-level][top level] [`links` object][links] with a `profile` key,

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -2260,8 +2260,6 @@ An error object **MAY** have the following members:
     exists; if it doesn't, the client **SHOULD** simply ignore the pointer.
   * `parameter`: a string indicating which URI query parameter caused
     the error.
-  * `profiles`: an array of the requested profile URIs that the server was not
-    able to support.
 * `meta`: a [meta object][meta] containing non-standard meta-information about the
   error.
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -61,9 +61,9 @@ Servers **MUST** respond with a `415 Unsupported Media Type` status code if
 a request specifies the header `Content-Type: application/vnd.api+json` with
 any media type parameters other than `profile`.
 
-Servers **MUST** respond with a `406 Not Acceptable` status code if a request
-specifies an instance of the JSON:API media type in an `Accept` header with any
-media type parameter other than `profile`.
+Servers **MUST** respond with a `406 Not Acceptable` status code if a request's
+`Accept` header contains the JSON:API media type and all instances of that
+media type are modified with a media type parameter other than `profile`.
 
 ## <a href="#document-structure" id="document-structure" class="headerlink"></a> Document Structure
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1942,7 +1942,7 @@ has been applied **MUST** ignore any document members that it does not understan
 
 Clients and servers **MUST** include the `profile` media type parameter in
 conjunction with the JSON:API media type in a `Content-Type` header to indicate
-that they have applied one or more profiles to a JSON:API document.
+that they have applied one or more profiles to a JSON:API message.
 
 Likewise, clients and servers applying profiles to a JSON:API document **MUST**
 include a [top-level][top level] [`links` object][links] with a `profile` key,
@@ -1963,22 +1963,6 @@ apply profiles in subsequent interactions with the same API.
 support JSON:API at all or that the client has failed to provide a required
 profile.
 
-### <a href="#profile-query-parameter" id="profile-query-parameter" class="headerlink"></a> `profile` Query Parameter
-
-A client **MAY** use the `profile` query parameter to _require_ the server to
-apply one or more profiles when processing the request. The value of the `profile`
-query parameter **MUST** equal a URI-encoded whitespace-separated list of profile URIs.
-
-If a server receives a request requiring the application of a profile or
-combination of profiles that it can not apply, it **MUST** respond with a `400
-Bad Request` status code. The response **MUST** contain an [error object] that
-identifies the `profile` query parameter as the `source` and has the following
-URI as (one of) its `type`s:
-
-```
-https://jsonapi.org/errors/profile-not-supported
-```
-
 > Note: When a client lists a profile in the `Accept` header, it's asking the
 > server to compute its response as normal, but then send the response document
 > with some extra information, as described in the requested profile. By
@@ -1986,47 +1970,6 @@ https://jsonapi.org/errors/profile-not-supported
 > it's asking the server to *process the incoming request* according to the
 > rules of the profile. This can fundamentally change the meaning of the 
 > server's response.
-
-#### <a href="#profile-query-parameter-omitting" id="profile-query-parameter" class="headerlink"></a> Omitting the `profile` Query Parameter
-
-Requiring the client to specify the `profile` query parameter would be 
-cumbersome. Accordingly, JSON:API defines a way that server's may infer its 
-value in many cases.
-
-To do so, a server **MAY** define an internal mapping from query parameter names 
-to profile URIs. The profile URI for a query parameter name in this mapping 
-**MUST NOT** change over time.
-
-> Note: the server may choose to map all query parameter names from the same 
-> [family][query parameter family] to one profile URI. Or, it may choose to map
-> only specific query parameter names. 
-
-If a requested URL does not contain the `profile` query parameter and does 
-contain one or more query parameters in the server's internal mapping, the 
-server may act as though the request URL contained a `profile` query parameter 
-whose value was the URI-encoded space-separated list of each unique profile URI 
-found in the server's internal mapping for the query parameters in use on the 
-request.
-
-For example, the server might support a profile that defines a meaning for the
-values of the `page[cursor]` query parameter. Then, it could define its internal 
-param name to profile URI mapping like so:
-
-```json
-{ "page[cursor]": "https://example.com/pagination-profile" }
-```
-
-Accordingly, a request for:
-
-```
-https://example.com/?page[cursor]=xyz
-```
-
-would be interpreted by the server as:
-
-```
-https://example.com/?page[cursor]=xyz&profile=https://example.com/pagination-profile
-```
 
 
 ### <a href="#profile-keywords" id="profile-keywords" class="headerlink"></a> Profile Keywords

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -68,7 +68,7 @@ https://jsonapi.org/errors/profile-not-supported
 ```
 
 It is **RECOMMENDED** that servers specify the `Vary` header with `Accept`
-as one of its header names. This will ensure that the servers responses are
+as one of its header names. This will ensure that the server's responses are
 appropriately cached and future client/server negotiations will work as
 expected.
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1954,8 +1954,7 @@ responses with and without any profiles applied.
 > Note: Some HTTP intermediaries (e.g. CDNs) may ignore the `Vary` header
 > unless specifically configured to respect it.
 
-### <a href="#profile-keywords" id="profile-keywords" class="headerlink"></a>
-Profile Keywords
+### <a href="#profile-keywords" id="profile-keywords" class="headerlink"></a> Profile Keywords
 
 A profile **SHOULD** explicitly declare "keywords" for any elements that it
 introduces to the document structure. If a profile does not explicitly declare a

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -67,9 +67,13 @@ its `source` and which has the following URI as (one of) its `type`s:
 https://jsonapi.org/errors/profile-not-supported
 ```
 
-It is **RECOMMENDED** that servers specify the `Vary` header with the `Accept`
-header as one of its header names to ensure that its responses are
-appropriately cached.
+It is **RECOMMENDED** that servers specify the `Vary` header with `Accept`
+as one of its header names. This will ensure that the servers responses are
+appropriately cached and future client/server negotiations will work as
+expected.
+
+> Note: Some HTTP intermediaries (e.g. CDNs) may ignore the `Vary` header unless
+specifically configured to respect it.
 
 > Note: These content negotiation requirements exist to allow future versions
 of this specification to add other media type parameters for extension

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1904,7 +1904,7 @@ URIs.
 A client **MAY** use the `profile` media type parameter in an `Accept` header
 to request that the server apply one or more profiles to the response document.
 When such a request is received, a server **SHOULD** attempt to apply the
-requested profiles to its response.
+requested profile(s) to its response.
 
 For example, in the following request, the client asks that the server apply
 the `http://example.com/last-modified` profile and the

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -39,12 +39,12 @@ Further, the JSON:API media type **MUST** always be specified with either no
 media type parameters or with only the `profile` parameter. This applies to both
 the `Content-Type` and `Accept` headers whenever they are present.
 
+The `profile` parameter is used to support [profiles].
+
 > Note: A media type parameter is an extra piece of information that can
 accompany a media type. For example, in the header
 `Content-Type: text/html; charset="utf-8"`, the media type is `text/html` and
 `charset` is a parameter.
-
-The `profile` parameter is used to support [profiles].
 
 > Note: These content negotiation requirements exist to allow future versions
 of this specification to add other media type parameters for extension
@@ -58,15 +58,8 @@ parameters other than `profile` in the server's `Content-Type` header.
 ### <a href="#content-negotiation-servers" id="content-negotiation-servers" class="headerlink"></a> Server Responsibilities
 
 Servers **MUST** respond with a `415 Unsupported Media Type` status code if
-a request specifies the header `Content-Type: application/vnd.api+json`
-with any media type parameters other than `profile`.
-
-Servers **SHOULD** specify the `Vary` header with `Accept` as one of its header
-names to ensure that the server's responses can be appropriately cached and
-so that later content negotiations can take place.
-
-> Note: Some HTTP intermediaries (e.g. CDNs) may ignore the `Vary` header unless
-specifically configured to respect it.
+a request specifies the header `Content-Type: application/vnd.api+json` with
+any media type parameters other than `profile`.
 
 ## <a href="#document-structure" id="document-structure" class="headerlink"></a> Document Structure
 
@@ -1847,8 +1840,8 @@ parameter from this specification, it **MUST** return `400 Bad Request`.
 ## <a href="#profiles" id="profiles" class="headerlink"></a> Profiles
 
 JSON:API supports the use of "profiles" as a way to indicate additional
-semantics that apply to a JSON:API request/document, without altering the
-basic semantics described in this specification.
+semantics that apply to a JSON:API document, without altering the basic
+semantics described in this specification.
 
 A profile is a separate specification defining these additional semantics. 
 
@@ -1919,8 +1912,8 @@ the `http://example.com/last-modified` profile and the
 
 ```http
 GET /articles/1 HTTP/1.1
-Accept: application/vnd.api+json; profile="http://example.com/last-modified http://example.com/iso-8601"
-...
+Accept: application/vnd.api+json; profile="http://example.com/last-modified http://example.com/timestamps"
+```
 
 Servers **MAY** respond with a subset of the requested profiles applied or none
 of the requested profiles applied. Additionally, servers **MAY** respond with
@@ -1953,7 +1946,16 @@ apply profiles in subsequent interactions with the same API.
 > The most likely other causes of a 415 error are that the server doesn't
 support JSON:API at all.
 
-### <a href="#profile-keywords" id="profile-keywords" class="headerlink"></a> Profile Keywords
+Servers that support profiles **SHOULD** specify the `Vary` header with
+`Accept` as one of its header names to ensure that the server's responses can
+be cached without disrupting subsequent content negotiations. This applies to
+responses with and without any profiles applied.
+
+> Note: Some HTTP intermediaries (e.g. CDNs) may ignore the `Vary` header
+> unless specifically configured to respect it.
+
+### <a href="#profile-keywords" id="profile-keywords" class="headerlink"></a>
+Profile Keywords
 
 A profile **SHOULD** explicitly declare "keywords" for any elements that it
 introduces to the document structure. If a profile does not explicitly declare a

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -61,6 +61,10 @@ Servers **MUST** respond with a `415 Unsupported Media Type` status code if
 a request specifies the header `Content-Type: application/vnd.api+json` with
 any media type parameters other than `profile`.
 
+Servers **MUST** respond with a `406 Not Acceptable` status code if a request
+specifies an instance of the JSON:API media type in an `Accept` header with any
+media type parameter other than `profile`.
+
 ## <a href="#document-structure" id="document-structure" class="headerlink"></a> Document Structure
 
 This section describes the structure of a JSON:API document, which is identified


### PR DESCRIPTION
This supersedes #1410 as it has been split into two distinct PRs—this one, and #1412 

### Motivation
The current 1.1 release candidate contains two, competing profile negotiation mechanisms. One uses the `Accept` header and the other uses a `profile` query parameter. This is hard to interpret and create confusing interactions when one is used in conjunction with the other.

I see the strict correctness of using the `Accept` parameter for profiled documents and the `profile` query parameter for profiles which establish new query parameters and/or further define the `sort`, `filter` and `page` query parameters. However, it doesn't seem worth the complexity it adds. However, the spec does not limit which kinds of profiles are allowed in one of the negotiation mechanisms vs. the other (f.e. only profiles that register new query parameters are permitted in the `profiles` query parameter).

The biggest distinction between the two mechanism is that the `profile` query parameter permits a client to _require_ a profile while the `Accept` header does not. That's because, the `Accept` header based profiling mechanism requires that the client sends at least two media type values if it desires a profiled response document. One of these *must* be the bare JSON:API media type. Consequently, the spec forces the client to be to accept and process both responses. That adds complexity to the client implementation that I doubt many clients will adopt.

It seems far more likely that most clients will be written to accept a specific set of profiles which it knows a specific server will support. Even generalized clients that can may be able to support many different profiles, probably won't be written to dynamically negotiate profiles, rather, they'll probably make the profiles to request a configuration option or some kind of middleware.

Furthermore, the fact that the `profiles` query parameter can be omitted and implied by other query parameters suggests that the we already recognize that most clients are written with a specific server implementation in mind.

Given all that, I propose that we simplify the profile negotiation mechanism by completely removing the `profile` query parameter and then strengthening the `Accept` header mechanism by removing the requirement that the bare JSON:API media type be present. I considered removing the `Accept` mechanism instead, but felt that since `Accept` is already the standard for negotiating over HTTP, we ought to use it.