### PR TITLE
Move v1.1 from RC to WD

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -79,10 +79,7 @@ defaults:
 
 latest_version: 1.0
 excerpt_separator: ""
-announcement: |
-  **[JSON:API v1.1 RC1](/format/1.1/) has been published!** Please review and
-  try out this upcoming version of the spec before its planned release date of
-  January 31, 2019.
+announcement: ""
 
 navigation:
 - title: JSON API

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1,7 +1,6 @@
 ---
 version: 1.1
-status: rc
-release_date: 2019-01-31
+status: wd
 ---
 
 ## <a href="#introduction" id="introduction" class="headerlink"></a> Introduction

--- a/extensions/index.md
+++ b/extensions/index.md
@@ -5,7 +5,7 @@ show_sidebar: true
 redirect_from: /profiles
 ---
 
-> Note: This page describes features from [version 1.1](/format/1.1/) of the JSON:API spec, and links to profiles that use those new features. Version 1.1 is in its release candidate stage, so there is a (very small) probability that the spec and/or these profiles could change before v1.1 is released on January 31, 2019 (provided there are two compliant implementations by that date; if not the release will wait until such implementations exist to prove its viability).
+> Note: This page describes features from [version 1.1](/format/1.1/) of the JSON:API spec, and links to profiles that use those new features. Version 1.1 is in development, so there is a chance that the spec and/or these profiles could change before v1.1 is released.
 
 JSON:API can be extended with profiles. These profiles enable an API to
 provide clients with information or functionality beyond that described


### PR DESCRIPTION
v1.1 is moving from a release candidate back to a working draft.

For details, please see: https://github.com/json-api/json-api/issues/1403#issuecomment-518263298