### PR TITLE
Add mfcochauxlaberge/jsonapi to the list of implementations (Go)

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -249,6 +249,7 @@ the moment.
 * [jsonapi](https://github.com/google/jsonapi) serializes and deserializes jsonapi formatted payloads using struct tags to annotate the structs that you already have in your Golang project. [Godoc](http://godoc.org/github.com/google/jsonapi)
 * [go-json-spec-handler](https://github.com/derekdowling/go-json-spec-handler) drop-in library for handling requests and sending responses in an existing API.
 * [jsh-api](https://github.com/derekdowling/go-json-spec-handler/tree/master/jsh-api) deals with the dirty work of building JSON:API resource endpoints. Built on top of [jsh](https://github.com/derekdowling/go-json-spec-handler)
+* [mfcochauxlaberge/jsonapi](https://github.com/mfcochauxlaberge/jsonapi) offers a feature complete implementation of the specification for marshaling and unmarshaling URLS and documents. It also has many other utilities useful for building a real API service.
 
 ### <a href="#server-libraries-net" id="server-libraries-net" class="headerlink"></a> .NET
 

--- a/implementations/index.md
+++ b/implementations/index.md
@@ -249,7 +249,7 @@ the moment.
 * [jsonapi](https://github.com/google/jsonapi) serializes and deserializes jsonapi formatted payloads using struct tags to annotate the structs that you already have in your Golang project. [Godoc](http://godoc.org/github.com/google/jsonapi)
 * [go-json-spec-handler](https://github.com/derekdowling/go-json-spec-handler) drop-in library for handling requests and sending responses in an existing API.
 * [jsh-api](https://github.com/derekdowling/go-json-spec-handler/tree/master/jsh-api) deals with the dirty work of building JSON:API resource endpoints. Built on top of [jsh](https://github.com/derekdowling/go-json-spec-handler)
-* [mfcochauxlaberge/jsonapi](https://github.com/mfcochauxlaberge/jsonapi) offers a feature complete implementation of the specification for marshaling and unmarshaling URLS and documents. It also has many other utilities useful for building a real API service.
+* [mfcochauxlaberge/jsonapi](https://github.com/mfcochauxlaberge/jsonapi) offers a large set of tools to build a JSON:API compliant service.
 
 ### <a href="#server-libraries-net" id="server-libraries-net" class="headerlink"></a> .NET
 


### PR DESCRIPTION
I would like to propose my library (written in Go) for the current list of implementations.

I have been working on it since 2017. It has a complete set of features.

https://github.com/mfcochauxlaberge/jsonapi

I am waiting to gain more feedback before committing to a v1.0.0 release.