### PR TITLE
Add new Dart implementation: rest_data package

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -91,8 +91,8 @@ isomorphic ActiveRecord clone that issues JSON:API requests instead of SQL and i
 
 ### <a href="#client-libraries-dart" id="client-libraries-dart" class="headerlink"></a> Dart
 
-* [jsonapi_client](https://pub.dartlang.org/packages/jsonapi_client) is a simple JSON:API v1.0 client written in Dart.
-* [json_api](https://pub.dartlang.org/packages/json_api) is a full-fledged client for Flutter/Web/VM.
+* [jsonapi_client](https://pub.dev/packages/jsonapi_client) is a simple JSON:API v1.0 client written in Dart.
+* [json_api](https://pub.dev/packages/json_api) is a full-fledged client for Flutter/Web/VM.
 
 ### <a href="#client-libraries-perl" id="client-libraries-perl" class="headerlink"></a> Perl
 

--- a/implementations/index.md
+++ b/implementations/index.md
@@ -92,6 +92,7 @@ isomorphic ActiveRecord clone that issues JSON:API requests instead of SQL and i
 ### <a href="#client-libraries-dart" id="client-libraries-dart" class="headerlink"></a> Dart
 
 * [jsonapi_client](https://pub.dev/packages/jsonapi_client) is a simple JSON:API v1.0 client written in Dart.
+* [rest_data](https://pub.dev/packages/rest_data) is a REST API client based on `ember-data` concepts which includes a JSON:API adapter.
 * [json_api](https://pub.dev/packages/json_api) is a full-fledged client for Flutter/Web/VM.
 
 ### <a href="#client-libraries-perl" id="client-libraries-perl" class="headerlink"></a> Perl

--- a/implementations/index.md
+++ b/implementations/index.md
@@ -91,9 +91,9 @@ isomorphic ActiveRecord clone that issues JSON:API requests instead of SQL and i
 
 ### <a href="#client-libraries-dart" id="client-libraries-dart" class="headerlink"></a> Dart
 
-* [jsonapi_client](https://pub.dev/packages/jsonapi_client) is a simple JSON:API v1.0 client written in Dart.
-* [rest_data](https://pub.dev/packages/rest_data) is a REST API client based on `ember-data` concepts which includes a JSON:API adapter.
 * [json_api](https://pub.dev/packages/json_api) is a full-fledged client for Flutter/Web/VM.
+* [rest_data](https://pub.dev/packages/rest_data) is a REST API client based on `ember-data` concepts which includes a JSON:API adapter.
+* [jsonapi_client](https://pub.dev/packages/jsonapi_client) is a simple JSON:API v1.0 client written in Dart.
 
 ### <a href="#client-libraries-perl" id="client-libraries-perl" class="headerlink"></a> Perl
 


### PR DESCRIPTION
- Add [rest_data](https://pub.dev/packages/rest_data) Dart package to `/implementations` page
- Update URLs of existing Dart implementations
- Sort Dart implementations by their score on [pub.dev](https://pub.dev), descending order