### PR TITLE
Introduce describedby link relation

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -556,13 +556,15 @@ key in an [error object]'s links object, each key present in a links object
 
 In the example below, the `self` link is simply a URI string, whereas the
 `related` link uses the object form to provide meta information about a
-related resource collection:
+related resource collection as well as a schema that serves as a description
+document for that collection:
 
 ```json
 "links": {
-  "self": "http://example.com/articles/1",
+  "self": "http://example.com/articles/1/relationships/comments",
   "related": {
     "href": "http://example.com/articles/1/comments",
+    "describedby": "http://example.com/schemas/article-comments",
     "meta": {
       "count": 10
     }

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -114,6 +114,8 @@ The top-level [links object][links] **MAY** contain the following members:
   resource relationship.
 * `profile`: an array of [links][link], each specifying a [profile][profiles]
   in use in the document.
+* `describedby`: a [link] to a description document (e.g. OpenAPI or JSON
+  Schema) for the current document.
 * [pagination] links for the primary data.
 
 The document's "primary data" is a representation of the resource or collection
@@ -538,6 +540,8 @@ Within this object, a link **MUST** be represented as either:
     [relationship object][relationships] in which the link appears.
   * `params`: a [link parameter object][link parameters] describing additional
     information about the link or its target.
+  * `describedby`: a [link] to a description document (e.g. OpenAPI or JSON
+    Schema) for the link target.
   * `meta`: a meta object containing non-standard meta-information about the
     link.
 


### PR DESCRIPTION
The `describedby` link relation can be used to identify a description document, which may be an [OpenAPI](https://www.openapis.org) definition, a [JSON Schema](https://json-schema.org) document, or another description format.

It's proposed that the `describedby` member can appear in two places:

* A) in the top-level `links` object, in which case it provides a description for the _current_ document.
* B) inside any link object, in which case it provides a description for the target of the link.

We could optionally allow this member inside any `links` object that can also contain a `self` link - namely, resource links and relationship links. This would be consistent with (A) but also somewhat redundant with (B). I'd like to make a decision about this explicitly prior to merging.

Another question is whether there should be a central definition of a "description document" within the JSON:API spec, or whether using parenthetical examples `(e.g. OpenAPI or JSON Schema)` is sufficient.

related: #1281 

/cc @philsturgeon @gabesullice 
