### PR TITLE
Add server responsibility to reject unsupported, extended requests.

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -61,8 +61,12 @@ parameters other than `ext` and `profile` parameters in the server's
 ### <a href="#content-negotiation-servers" id="content-negotiation-servers" class="headerlink"></a> Server Responsibilities
 
 If a request specifies the `Content-Type` header with the JSON:API media type,
-servers **MUST** respond with a `415 Unsupported Media Type` status code if that
-media type contains any media type parameters other than `ext` or `profile`.
+servers **MUST** respond with a `415 Unsupported Media Type` status code if
+that media type contains any media type parameters other than `ext` or
+`profile`. If a request specifies the `Content-Type` header with an instance of
+the JSON:API media type modified by the `ext` media type parameter and that
+parameter contains an unsupported extension URI, the server **MUST** respond
+with a `415 Unsupported Media Type` status code.
 
 > Note: Older JSON:API servers that do not support the `ext` or `profile` media
   type parameters will respond with a `415 Unsupported Media Type` client error


### PR DESCRIPTION
Thanks to an astute comment by @freddrake in #1436 ([direct link](https://github.com/json-api/json-api/pull/1436#commitcomment-37403394)), @dgeb and I realized that the recent addition of extension negotiation to the 1.1 spec (#1457) was lacking a detail to aid client-server content negotiation. Namely, that the server must respond with a client error status code if the client sends an extended media type parameter with an unsupported extension. This PR adds the needed normative statement:

> If a request specifies the `Content-Type` header with an instance of
the JSON:API media type modified by the `ext` media type parameter and that
parameter contains an unsupported extension URI, the server **MUST** respond
with a `415 Unsupported Media Type` status code.