### PR TITLE
fix(json-schema): Validate document's links according to the JSONAPI specification

### DIFF
--- a/schema
+++ b/schema
@@ -35,16 +35,8 @@
         "meta": {
           "$ref": "#/definitions/meta"
         },
-        "links": {
-          "description": "Link members related to the primary data.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/links"
-            },
-            {
-              "$ref": "#/definitions/pagination"
-            }
-          ]
+        "links": { 
+          "$ref": "#/definitions/linksWithPagination" 
         },
         "jsonapi": {
           "$ref": "#/definitions/jsonapi"
@@ -299,38 +291,39 @@
       },
       "additionalProperties": false
     },
-    "pagination": {
+    "linksWithPagination": {
       "type": "object",
       "properties": {
         "first": {
           "description": "The first page of data",
           "oneOf": [
-            { "type": "string", "format": "uri-reference" },
+            { "$ref": "#/definitions/link" },
             { "type": "null" }
           ]
         },
         "last": {
           "description": "The last page of data",
           "oneOf": [
-            { "type": "string", "format": "uri-reference" },
+            { "$ref": "#/definitions/link" },
             { "type": "null" }
           ]
         },
         "prev": {
           "description": "The previous page of data",
           "oneOf": [
-            { "type": "string", "format": "uri-reference" },
+            { "$ref": "#/definitions/link" },
             { "type": "null" }
           ]
         },
         "next": {
           "description": "The next page of data",
           "oneOf": [
-            { "type": "string", "format": "uri-reference" },
+            { "$ref": "#/definitions/link" },
             { "type": "null" }
           ]
         }
-      }
+      },
+      "additionalProperties": { "$ref": "#/definitions/link" }
     },
 
     "jsonapi": {


### PR DESCRIPTION
Hi,

I believe that the current JSON Schema do not reflect the written specification regarding [document's links](https://jsonapi.org/format/#document-links) and [pagination links](https://jsonapi.org/format/#fetching-pagination).

1. It seems that the `allOf` keyword is misused in [`#/definitions/success/properties/links`](https://github.com/json-api/json-api/blob/gh-pages/schema#L38-L48).

According to the JSON Schema spec:
> An instance validates successfully against this keyword if it validates successfully against **all schemas** defined by this keyword's value. ([see in context](https://json-schema.org/draft/2019-09/json-schema-core.html#allOf))

2. Pagination links  (`next`, `prev`, `last`, `first`) **MAY** be either a `#/definitions/link` or `null`

 
I tested the fix against various examples provided on the JSONAPI website such as:

A resource with links:

```json
{
    "data": {
        "type": "articles",
        "id": "1",
        "attributes": {
            "title": "Rails is Omakase"
        },
        "relationships": {
            "author": {
                "links": {
                    "self": "/articles/1/relationships/author",
                    "related": "/articles/1/author"
                },
                "data": {
                    "type": "people",
                    "id": "9"
                }
            }
        }
    }
}
```

A collection with pagination links as `string`

```json
{
  "meta": {
    "totalPages": 13
  },
  "data": [
    {
      "type": "articles",
      "id": "3",
      "attributes": {
        "title": "JSON:API paints my bikeshed!",
        "body": "The shortest article. Ever.",
        "created": "2015-05-22T14:56:29.000Z",
        "updated": "2015-05-22T14:56:28.000Z"
      }
    }
  ],
  "links": {
    "self": "http://example.com/articles?page%5Bnumber%5D=3&page%5Bsize%5D=1",
    "first": "http://example.com/articles?page%5Bnumber%5D=1&page%5Bsize%5D=1",
    "prev": "http://example.com/articles?page%5Bnumber%5D=2&page%5Bsize%5D=1",
    "next": "http://example.com/articles?page%5Bnumber%5D=4&page%5Bsize%5D=1",
    "last": "http://example.com/articles?page%5Bnumber%5D=13&page%5Bsize%5D=1"
  }
}
```

A collection with pagination links as `link` objects:

```json
{
  "meta": {
    "totalPages": 13
  },
  "data": [
    {
      "type": "articles",
      "id": "3",
      "attributes": {
        "title": "JSON:API paints my bikeshed!",
        "body": "The shortest article. Ever.",
        "created": "2015-05-22T14:56:29.000Z",
        "updated": "2015-05-22T14:56:28.000Z"
      }
    }
  ],
  "links": {
    "self": { "href": "http://example.com/articles?page%5Bnumber%5D=3&page%5Bsize%5D=1"},
    "first": { "href": "http://example.com/articles?page%5Bnumber%5D=1&page%5Bsize%5D=1"},
    "prev": { "href": "http://example.com/articles?page%5Bnumber%5D=2&page%5Bsize%5D=1"},
    "next": { "href": "http://example.com/articles?page%5Bnumber%5D=4&page%5Bsize%5D=1"},
    "last": { "href": "http://example.com/articles?page%5Bnumber%5D=13&page%5Bsize%5D=1"}
  }
}
```

A collection with a `null` pagination links:

```json
{
  "meta": {
    "totalPages": 13
  },
  "data": [
    {
      "type": "articles",
      "id": "3",
      "attributes": {
        "title": "JSON:API paints my bikeshed!",
        "body": "The shortest article. Ever.",
        "created": "2015-05-22T14:56:29.000Z",
        "updated": "2015-05-22T14:56:28.000Z"
      }
    }
  ],
  "links": {
    "first": null,
    "prev": null,
    "next":null,
    "last": null
  }
}
```

A collection with mixed links (standard links and pagination links)

```json
{
  "meta": {
    "totalPages": 13
  },
  "data": [
    {
      "type": "articles",
      "id": "3",
      "attributes": {
        "title": "JSON:API paints my bikeshed!",
        "body": "The shortest article. Ever.",
        "created": "2015-05-22T14:56:29.000Z",
        "updated": "2015-05-22T14:56:28.000Z"
      }
    }
  ],
  "links": {
    "foo": {
        "href": "https://foo.com/bar",
        "mata": {
            "bar": "baz"
        }
    },
    "self": "http://example.com/articles?page%5Bnumber%5D=13&page%5Bsize%5D=1",
    "first": "http://example.com/articles?page%5Bnumber%5D=1&page%5Bsize%5D=1",
    "prev": "http://example.com/articles?page%5Bnumber%5D=12&page%5Bsize%5D=1",
    "next": null,
    "last": "http://example.com/articles?page%5Bnumber%5D=13&page%5Bsize%5D=1"
  }
}
```
