### PR TITLE
state that the server may send a subset of fields by default

### DIFF
--- a/_format/1.0/index.md
+++ b/_format/1.0/index.md
@@ -1007,7 +1007,8 @@ an endpoint **MUST NOT** include additional [fields] in resource objects of
 that type in its response.
 
 If a client does not specify the set of [fields] for a given resource type,
-the server **MAY** send all fields, a subset of fields, or no fields for that resource type.
+the server **MAY** send all fields, a subset of fields, or no fields for that
+resource type.
 
 ```http
 GET /articles?include=author&fields[articles]=title,body&fields[people]=name HTTP/1.1

--- a/_format/1.0/index.md
+++ b/_format/1.0/index.md
@@ -1000,10 +1000,15 @@ response on a per-type basis by including a `fields[TYPE]` parameter.
 
 The value of the `fields` parameter **MUST** be a comma-separated (U+002C
 COMMA, ",") list that refers to the name(s) of the fields to be returned.
+An empty value indicates that no fields should be returned.
 
 If a client requests a restricted set of [fields] for a given resource type,
 an endpoint **MUST NOT** include additional [fields] in resource objects of
 that type in its response.
+
+If a client does not specify the set of [fields] for a given resource type,
+the server **MAY** send a subset of the set of fields defined for the resource
+type; an empty set is acceptable.
 
 ```http
 GET /articles?include=author&fields[articles]=title,body&fields[people]=name HTTP/1.1

--- a/_format/1.0/index.md
+++ b/_format/1.0/index.md
@@ -1007,8 +1007,7 @@ an endpoint **MUST NOT** include additional [fields] in resource objects of
 that type in its response.
 
 If a client does not specify the set of [fields] for a given resource type,
-the server **MAY** send a subset of the set of fields defined for the resource
-type; an empty set is acceptable.
+the server **MAY** send all fields, a subset of fields, or no fields for that resource type.
 
 ```http
 GET /articles?include=author&fields[articles]=title,body&fields[people]=name HTTP/1.1

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1157,8 +1157,9 @@ If a client requests a restricted set of [fields] for a given resource type,
 an endpoint **MUST NOT** include additional [fields] in resource objects of
 that type in its response.
 
-If a client does not specify the set of [fields] for a given resource type,
-the server **MAY** send all fields, a subset of fields, or no fields for that resource type.
+If a client does not specify the set of [fields] for a given resource type, the
+server **MAY** send all fields, a subset of fields, or no fields for that
+resource type.
 
 ```http
 GET /articles?include=author&fields[articles]=title,body&fields[people]=name HTTP/1.1

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1158,8 +1158,7 @@ an endpoint **MUST NOT** include additional [fields] in resource objects of
 that type in its response.
 
 If a client does not specify the set of [fields] for a given resource type,
-the server **MAY** send a subset of the set of fields defined for the resource
-type; an empty set is acceptable.
+the server **MAY** send all fields, a subset of fields, or no fields for that resource type.
 
 ```http
 GET /articles?include=author&fields[articles]=title,body&fields[people]=name HTTP/1.1

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1151,10 +1151,15 @@ response on a per-type basis by including a `fields[TYPE]` query parameter.
 
 The value of any `fields[TYPE]` parameter **MUST** be a comma-separated (U+002C
 COMMA, ",") list that refers to the name(s) of the fields to be returned.
+An empty value indicates that no fields should be returned.
 
 If a client requests a restricted set of [fields] for a given resource type,
 an endpoint **MUST NOT** include additional [fields] in resource objects of
 that type in its response.
+
+If a client does not specify the set of [fields] for a given resource type,
+the server **MAY** send a subset of the set of fields defined for the resource
+type; an empty set is acceptable.
 
 ```http
 GET /articles?include=author&fields[articles]=title,body&fields[people]=name HTTP/1.1


### PR DESCRIPTION
- the subset may be empty
- fields[type]= can be used to request no fields
- see https://github.com/json-api/json-api/issues/1499