### PR TITLE
Note the need for quality values in Accept

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -218,10 +218,11 @@ to request that the server apply one or more profiles to the response document.
 > Note: A client is allowed to send more than one acceptable media type in the
 `Accept` header, including multiple instances of the JSON:API media type. This
 allows clients to request different combinations of the `ext` and `profile`
-media type parameters. If some combinations are preferred over others, this has
-to be indicated with quality values (`q=` after the media type parameters), per
-[RFC 7231 Section 5.3.2](https://tools.ietf.org/html/rfc7231#section-5.3.2);
-without quality values, all entries in `Accept` are equally preferable.
+media type parameters. A client can use [quality values](https://tools.ietf.org/html/rfc7231#section-5.3.2)
+to indicate that some combinations are less preferable than others. Media types
+specified without a qvalue are equally preferable to each other, regardless of
+their order, and are always considered more preferable than a media type with a
+qvalue less than 1.
 
 ### <a href="#content-negotiation-servers" id="content-negotiation-servers" class="headerlink"></a> Server Responsibilities
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -218,7 +218,10 @@ to request that the server apply one or more profiles to the response document.
 > Note: A client is allowed to send more than one acceptable media type in the
 `Accept` header, including multiple instances of the JSON:API media type. This
 allows clients to request different combinations of the `ext` and `profile`
-media type parameters.
+media type parameters. If some combinations are preferred over others, this has
+to be indicated with quality values (`q=` after the media type parameters), per
+[RFC 7231 Section 5.3.2](https://tools.ietf.org/html/rfc7231#section-5.3.2);
+without quality values, all entries in `Accept` are equally preferable.
 
 ### <a href="#content-negotiation-servers" id="content-negotiation-servers" class="headerlink"></a> Server Responsibilities
 


### PR DESCRIPTION
Implementors of `Accept` very often get this wrong. The spec’s own example in a previous draft got this wrong (see #1409).