### PR TITLE
Remove Reststate implementations

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -46,9 +46,6 @@ assembled to vet them.
 isomorphic ActiveRecord clone that issues JSON:API requests instead of SQL and is part of the larger [JSONAPI Suite](https://jsonapi-suite.github.io/jsonapi_suite).
 * [jsonapi-vuex](https://github.com/mrichar1/jsonapi-vuex) A module for interacting with a jsonapi service using a Vuex store, restructuring/normalizing records to make life easier.
 * [heather-js](https://github.com/bitex-la/heather-js) A library for parsing JSONAPI into objects from ES6 classes.
-* [@reststate/client](https://client.reststate.codingitwrong.com/) - a stateless client providing easy access to standard JSON:API operations for a configured resource.
-* [@reststate/mobx](https://mobx.reststate.codingitwrong.com/) - a zero-configuration way to fetch and store JSON:API data in objects implemented with the MobX state management library, for use in React or other apps.
-* [@reststate/vuex](https://vuex.reststate.codingitwrong.com/) - a zero-configuration way to fetch and store JSON:API data in Vuex stores.
 * [@hyral/core](https://github.com/SyneticNL/Hyral) - An advanced, documented, easily extendable and lightweight (JSON:)API abstraction library with ORM-like CRUD support, automatic relationships handling and support for multiple (different) backends.
 * [@hyral/vue](https://github.com/SyneticNL/Hyral/tree/master/packages/vue) - Vue(x) integration for [@hyral/core](https://github.com/SyneticNL/Hyral) for Store-module creation and mixins
 * [jsonapi-redux-data](https://github.com/wednesday-solutions/jsonapi-redux-data) - a library that makes integration of jsonapi with react + redux effortless and easy.


### PR DESCRIPTION
I'm the maintainer of the Reststate libraries, and they will not be maintained going forward. This removes them from the implementations page so readers will be directed to maintained libraries instead.