### PR TITLE
clarify meaning of empty include query param

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1238,7 +1238,7 @@ section of the [compound document].
 The value of the `include` parameter **MUST** be a comma-separated (U+002C
 COMMA, ",") list of relationship paths. A relationship path is a dot-separated
 (U+002E FULL-STOP, ".") list of [relationship][relationships] names. An empty
-value indicates that no related <span class="x x-first x-last">resources</span> should be returned.
+value indicates that no related resources should be returned.
 
 If a server is unable to identify a relationship path or does not support
 inclusion of resources from a path, it **MUST** respond with 400 Bad Request.

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1237,7 +1237,8 @@ section of the [compound document].
 
 The value of the `include` parameter **MUST** be a comma-separated (U+002C
 COMMA, ",") list of relationship paths. A relationship path is a dot-separated
-(U+002E FULL-STOP, ".") list of [relationship][relationships] names.
+(U+002E FULL-STOP, ".") list of [relationship][relationships] names. An empty
+value indicates that no related resource should be returned.
 
 If a server is unable to identify a relationship path or does not support
 inclusion of resources from a path, it **MUST** respond with 400 Bad Request.

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1238,7 +1238,7 @@ section of the [compound document].
 The value of the `include` parameter **MUST** be a comma-separated (U+002C
 COMMA, ",") list of relationship paths. A relationship path is a dot-separated
 (U+002E FULL-STOP, ".") list of [relationship][relationships] names. An empty
-value indicates that no related resource should be returned.
+value indicates that no related <span class="x x-first x-last">resources</span> should be returned.
 
 If a server is unable to identify a relationship path or does not support
 inclusion of resources from a path, it **MUST** respond with 400 Bad Request.


### PR DESCRIPTION
The meaning of an empty value for the `include` query parameter was not clear yet. As @freddrake pointed out in #1530 a reader could interpret either as an empty list of relationship paths or as a single (invalid) relationship path.

The meaning of an empty value for `fields` query parameter is explicitly specified:

> The value of the fields parameter MUST be a comma-separated (U+002C COMMA, “,”) list that refers to the name(s) of the fields to be returned. An empty value indicates that no fields should be returned.

I _think_ the same applies to the `include` query parameter even though it's not mentioned explicitly yet. Otherwise a client would not be able to tell a server to not include any related resources - even if that server includes some resources by default.

I _think_ this is not a breaking change. Let's have a look at several scenarios:

1. An existing implementation may consider an empty value as a single relationship path. An empty string is not a valid relationship path. The server would be unable to identify the relationship path and response with `400 Bad Request`.
   > If a server is unable to identify a relationship path or does not support inclusion of resources from a path, it MUST respond with 400 Bad Request.

2. An existing implementation may silently ignore an `include` parameter if it's value is empty.
    1. If it does not include any related resources by default, the existing implementation would be valid.
    2. If it includes related resources by default even if an `include` parameter with an empty value is given, the implementation is not compliant with the specification even today. A server must not ignore a given `include` query parameter. It must response with a 400 if it does not support it.
        > If an endpoint does not support the include parameter, it MUST respond with 400 Bad Request to any requests that include it.
        >
        > If an endpoint supports the include parameter and a client supplies it, the server MUST NOT include unrequested resource objects in the included section of the compound document.
       > [...]
       > If a server is unable to identify a relationship path or does not support inclusion of resources from a path, it MUST respond with 400 Bad Request.

3. An existing implementation may already interpret an empty `ignore` parameter as an empty list of relationship paths and not include any related resources.

The meaning of an empty value for a Sparse Fieldset was also not explicitly specified since a few months ago. It was added in #1500. This was also _not_ considered a breaking change.

Closes #1530