### PR TITLE
Remove confusing sentence forbidding to include something in case it's not included

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1985,8 +1985,7 @@ updated relationship(s).
 
 A server **MUST** return a `200 OK` status code if an update is successful,
 the client's current data remain up to date, and the server responds
-only with top-level [meta] data. In this case the server **MUST NOT**
-include a representation of the updated relationship(s).
+only with top-level [meta] data.
 
 ##### <a href="#crud-updating-relationship-responses-403" id="crud-updating-relationship-responses-403" class="headerlink"></a> 403 Forbidden
 


### PR DESCRIPTION
The current specification for HTTP status code and response payload for successful relationship updates is confusing.

It specifies that "the server must not include a representation of the updates relationship(s)" if "the server response only with top-level meta data". But this does not make much sense.

A representation of the updates relationship(s) can only be included as primary data. If a server includes primary data, it would not only response with top-level meta data.

Unless I missed something there is no logical possible way to violate that _must not_ requirement. Therefore I don't think this is a breaking change.

The sentence was added as part of #652. The intend of that pull request was to allow response containing top-level meta data only. I don't think it's attend was to forbid including relationship data if it has not changed. Doing so would even limit some use cases as discussed in #1492.

Closes #1581 