### PR TITLE
Clarify that full linkage graph must be rooted in primary data

### DIFF
--- a/_format/1.0/index.md
+++ b/_format/1.0/index.md
@@ -377,19 +377,17 @@ In a compound document, all included resources **MUST** be represented as an
 array of [resource objects] in a top-level `included` member.
 
 Compound documents require "full linkage", meaning that every included
-resource **MUST** be identified by at least one [resource identifier object] in
-the same document, representing resource linkage contained within an
-*accessible* resource object. A resource object is *accessible* if it is either
-primary data or it is identified by at least one [resource identifier object] in
-the same document, representing resource linkage contained within an
-*accessible* resource object.
+resource **MUST** be identified by at least one [resource identifier object]
+in the same document. These resource identifier objects could either be
+primary data or represent resource linkage contained within primary or
+included resources.
 
 The only exception to the full linkage requirement is when relationship fields
 that would otherwise contain linkage data are excluded via [sparse fieldsets](#fetching-sparse-fieldsets).
 
-> Note: Full linkage ensures that included resources are related (directly or
-indirectly) to the primary data (which could be [resource objects] or [resource identifier
-objects][resource identifier object]).
+> Note: Full linkage ensures that included resources are related to either
+the primary data (which could be [resource objects] or [resource identifier
+objects][resource identifier object]) or to each other.
 
 A complete example document with multiple included relationships:
 

--- a/_format/1.0/index.md
+++ b/_format/1.0/index.md
@@ -377,17 +377,19 @@ In a compound document, all included resources **MUST** be represented as an
 array of [resource objects] in a top-level `included` member.
 
 Compound documents require "full linkage", meaning that every included
-resource **MUST** be identified by at least one [resource identifier object]
-in the same document. These resource identifier objects could either be
-primary data or represent resource linkage contained within primary or
-included resources.
+resource **MUST** be identified by at least one [resource identifier object] in
+the same document, representing resource linkage contained within an
+*accessible* resource object. A resource object is *accessible* if it is either
+primary data or it is identified by at least one [resource identifier object] in
+the same document, representing resource linkage contained within an
+*accessible* resource object.
 
 The only exception to the full linkage requirement is when relationship fields
 that would otherwise contain linkage data are excluded via [sparse fieldsets](#fetching-sparse-fieldsets).
 
-> Note: Full linkage ensures that included resources are related to either
-the primary data (which could be [resource objects] or [resource identifier
-objects][resource identifier object]) or to each other.
+> Note: Full linkage ensures that included resources are related (directly or
+indirectly) to the primary data (which could be [resource objects] or [resource identifier
+objects][resource identifier object]).
 
 A complete example document with multiple included relationships:
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -609,16 +609,19 @@ array of [resource objects] in a top-level `included` member.
 
 Compound documents require "full linkage", meaning that every included
 resource **MUST** be identified by at least one [resource identifier object]
-in the same document. These resource identifier objects could either be
-primary data or represent resource linkage contained within primary or
-included resources.
+in the same document. This resource identifier object could either be
+primary data or represent resource linkage contained within an accessible
+resource. A resource is accessible if it is included in the same document
+as primary data or if it is identified by a resource identifier object
+in primary data or represents resource linkage contained within an accessible
+resource.
 
 The only exception to the full linkage requirement is when relationship fields
 that would otherwise contain linkage data are excluded via [sparse fieldsets](#fetching-sparse-fieldsets).
 
-> Note: Full linkage ensures that included resources are related to either
-the primary data (which could be [resource objects] or [resource identifier
-objects][resource identifier object]) or to each other.
+> Note: Full linkage ensures that included resources are related (directly
+or indirectly) to the primary data (which could be [resource objects] or
+[resource identifier objects][resource identifier object]).
 
 A complete example document with multiple included relationships:
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -607,21 +607,14 @@ requested primary resources. Such responses are called "compound documents".
 In a compound document, all included resources **MUST** be represented as an
 array of [resource objects] in a top-level `included` member.
 
-Compound documents require "full linkage", meaning that every included
-resource **MUST** be identified by at least one [resource identifier object]
-in the same document. This resource identifier object could either be
-primary data or represent resource linkage contained within an accessible
-resource. A resource is accessible if it is included in the same document
-as primary data or if it is identified by a resource identifier object
-in primary data or represents resource linkage contained within an accessible
-resource.
+Every included resource object **MUST** be identified via a chain of
+relationships originating in a document's primary data. This means that
+compound documents require "full linkage" and that no resource object can be
+included without a direct or indirect relationship to the document's primary
+data.
 
 The only exception to the full linkage requirement is when relationship fields
 that would otherwise contain linkage data are excluded via [sparse fieldsets](#fetching-sparse-fieldsets).
-
-> Note: Full linkage ensures that included resources are related (directly
-or indirectly) to the primary data (which could be [resource objects] or
-[resource identifier objects][resource identifier object]).
 
 A complete example document with multiple included relationships:
 


### PR DESCRIPTION
The current wording in specification does not enforce that a graph of related resources in a Compound Document is rooted in primary data. The requirement could be also interpreted as if two included resources referencing each other fulfill it. This has been very well explained by @beauby in #1035.

The original pull request created by @beauby more than four years ago got stale. But the issue is still the same in current specification.

I updated the @beauby's proposal given in #1035 to target v1.1. I also tried to slightly improve the wording.

Closes #1035 