### PR TITLE
Add entry for drupal-jsonapi-params

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -64,6 +64,7 @@ isomorphic ActiveRecord clone that issues JSON:API requests instead of SQL and i
 * [DatX](https://github.com/infinum/datx) is an opinionated data store for use with the MobX state management library that adds JSON:API support with [datx-jsonapi](https://github.com/infinum/datx/tree/master/packages/datx-jsonapi) mixin.
 * [jsonapi-fractal](https://github.com/andersondanilo/jsonapi-fractal) JSON:API Serializer inspired by Fractal (PHP)
 * [ts-japi](https://github.com/jun-sheaf/ts-japi) - A zero-dependency, highly-modular, js/ts-friendly, recursible, framework-agnostic library for serializing data to the JSON:API specification. Serializes the entire specification.
+* [drupal-jsonapi-params](https://github.com/d34dman/drupal-jsonapi-params) A library for building query parameters when connecting with Drupal CMS's JSON:API. 
 
 ### <a href="#client-libraries-ios" id="client-libraries-ios" class="headerlink"></a> iOS
 


### PR DESCRIPTION

> That's not even on the jsonapi.org page, so wouldn't have found it had I not asked.

Somebody complained in slack that they didn't find my module in json-api.org's list, so here i am trying to get it included in :)

Decoupled Drupal applications based on JSON:API is getting more popular, so might be helpful.

