### PR TITLE
Clarify reserved characters don't conflict extension member rules

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -894,7 +894,7 @@ The following characters **MUST NOT** be used in implementation and
 - U+0029 RIGHT PARENTHESIS, ")"
 - U+002A ASTERISK, "&#x2a;"
 - U+002F SOLIDUS, "/"
-- U+003A COLON, ":"
+- U+003A COLON, ":" (except after the namespace in [Extension members](#extension-members))
 - U+003B SEMICOLON, ";"
 - U+003C LESS-THAN SIGN, "<"
 - U+003D EQUALS SIGN, "="


### PR DESCRIPTION
This makes a similar clarification as for `@` with @-members (see further down in the diff).