### PR TITLE
Fix broken link in 1.0 index.md

### DIFF
--- a/_format/1.0/index.md
+++ b/_format/1.0/index.md
@@ -20,7 +20,7 @@ for exchanging data.
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in RFC 2119
-[[RFC2119](http://tools.ietf.org/html/rfc2119)].
+[[RFC2119](https://tools.ietf.org/html/rfc2119)].
 
 ## <a href="#content-negotiation" id="content-negotiation" class="headerlink"></a> Content Negotiation
 


### PR DESCRIPTION
It looks like the `http://` link gives a 404:
![image](https://user-images.githubusercontent.com/25538840/133505031-9c09d11c-948a-4852-a9d9-e67c7327f497.png)
