### PR TITLE
Remove redirect in link to PATCH RFC

### DIFF
--- a/faq/index.md
+++ b/faq/index.md
@@ -70,7 +70,7 @@ Instead, PUT is supposed to completely replace the state of a resource:
   of a given representation would suggest that a subsequent GET on that same
   target resource will result in an equivalent representation being sent…”
 
-The correct method for partial updates, therefore, is [PATCH](https://datatracker.ietf.org/doc/html/rfc5789).
+The correct method for partial updates, therefore, is [PATCH](https://datatracker.ietf.org/doc/html/rfc5789),
 which is what JSON:API uses. And because PATCH can also be used compliantly for
 full resource replacement, JSON:API hasn't needed to define any behavior for
 PUT so far. However, it may define PUT semantics in the future.

--- a/faq/index.md
+++ b/faq/index.md
@@ -62,7 +62,7 @@ non-standard actions they support. Feel free to
 
 Using PUT to partially update a resource (i.e. to change only some of its state)
 is not allowed by the
-[HTTP specification](https://tools.ietf.org/html/rfc7231#section-4.3.4).
+[HTTP specification](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.4).
 Instead, PUT is supposed to completely replace the state of a resource:
 
 > “The PUT method requests that the state of the target resource be **created
@@ -70,7 +70,7 @@ Instead, PUT is supposed to completely replace the state of a resource:
   of a given representation would suggest that a subsequent GET on that same
   target resource will result in an equivalent representation being sent…”
 
-The correct method for partial updates, therefore, is [PATCH](http://tools.ietf.org/html/rfc5789),
+The correct method for partial updates, therefore, is [PATCH](https://datatracker.ietf.org/doc/html/rfc5789).
 which is what JSON:API uses. And because PATCH can also be used compliantly for
 full resource replacement, JSON:API hasn't needed to define any behavior for
 PUT so far. However, it may define PUT semantics in the future.


### PR DESCRIPTION
Fixes #1588 

In the FAQ, Where's PUT?, the link under PATCH points to an insecure
location, e.g., http://tools.ietf.org/html/rfc5789 and results in
two (2) redirects to the correct location.

The correct URL, after redirection, is
https://datatracker.ietf.org/doc/html/rfc5789

Moreover, this can sometimes result in a 404 from tools.ietf.org
(which appears to be intermittent, possibly due to a server
misconfiguration; the personal website for Henrik Levkowetz, and
member of the IETF Tools Team, appeared at the root several times
before starting to redirect, see response in issue 🤔 ).