### PR TITLE
Clarify query parameters for top-level self link

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -319,7 +319,7 @@ The top-level [links object][links] **MAY** contain the following members:
   Schema) for the current document.
 * [pagination] links for the primary data.
 
-> Note: The `self` link should contain the query parameters provided by the client
+> Note: The `self` link in the top-level `links` object must contain the query parameters provided by the client
 > to generate the current response document. This includes but is not limited to
 > query parameters used for [inclusion of related resources][fetching resources],
 > [sparse fieldsets][fetching sparse fieldsets], [sorting][fetching sorting],

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -319,9 +319,12 @@ The top-level [links object][links] **MAY** contain the following members:
   Schema) for the current document.
 * [pagination] links for the primary data.
 
-> Note: The `self` link in the top-level `links` object must contain the query parameters provided by the client
-> to generate the current response document. This includes but is not limited to
-> query parameters used for [inclusion of related resources][fetching resources],
+> Note: The `self` link in the top-level `links` object allows a client to
+> refresh the data represented by the current response document. The client
+> should be able to use the provided link without applying any additional
+> information. Therefore the link must contain the query parameters provided
+> by the client to generate the response document. This includes but is not
+> limited to query parameters used for [inclusion of related resources][fetching resources],
 > [sparse fieldsets][fetching sparse fieldsets], [sorting][fetching sorting],
 > [pagination][fetching pagination] and [filtering][fetching filtering].
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -319,6 +319,12 @@ The top-level [links object][links] **MAY** contain the following members:
   Schema) for the current document.
 * [pagination] links for the primary data.
 
+> Note: The `self` link should contain the query parameters provided by the client
+> to generate the current response document. This includes but is not limited to
+> query parameters used for [inclusion of related resources][fetching resources],
+> [sparse fieldsets][fetching sparse fieldsets], [sorting][fetching sorting],
+> [pagination][fetching pagination] and [filtering][fetching filtering].
+
 The document's "primary data" is a representation of the resource or collection
 of resources targeted by a request.
 


### PR DESCRIPTION
In the past we have seen several questions regarding the top-level `self` link and if it should contain query parameters supplied by the client, which affected the response document. Adding an explicit note about it should help to prevent such confusion in the future.

Closes #1030 #1502