### PR TITLE
Fix inconsitency between general processing rules and pagination links

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -754,7 +754,7 @@ Within this object, a link **MUST** be represented as either:
 * a string whose value is a URI-reference [[RFC3986 Section 4.1](https://tools.ietf.org/html/rfc3986#section-4.1)]
   pointing to the link's target,
 * a [link object] or
-* `null` if it does not exist.
+* `null` if the link does not exist.
 
 A link's relation type **SHOULD** be inferred from the name of the link unless the
 link is a [link object] and the link object has a `rel` member.

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -752,8 +752,9 @@ of this member **MUST** be an object (a "links object").
 Within this object, a link **MUST** be represented as either:
 
 * a string whose value is a URI-reference [[RFC3986 Section 4.1](https://tools.ietf.org/html/rfc3986#section-4.1)]
-  pointing to the link's target.
-* a [link object].
+  pointing to the link's target,
+* a [link object] or
+* `null` if it does not exist.
 
 A link's relation type **SHOULD** be inferred from the name of the link unless the
 link is a [link object] and the link object has a `rel` member.


### PR DESCRIPTION
`null` value was not listed as an allowed value for links in general processing rules for links objects. But it was allowed explicitly for pagination links. This change fixes that inconsitency by allowing `null` for _every_ link to indicate that it does not exist.

Closes #887 