### PR TITLE
Clarify processing rules for malformed `ext` and `profile` members of JSON:API object

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -825,7 +825,7 @@ The jsonapi object **MAY** contain any of the following members:
 * `profile` - an array of URIs for all applied [profiles].
 * `meta` - a [meta] object that contains non-standard meta-information.
 
-Clients and servers **MUST NOT** use a `ext` or `profile` member for content
+Clients and servers **MUST NOT** use an `ext` or `profile` member for content
 negotiation. Content negotiation **MUST** only happen based on media type
 parameters in `Content-Type` header.
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -825,9 +825,9 @@ The jsonapi object **MAY** contain any of the following members:
 * `profile` - an array of URIs for all applied [profiles].
 * `meta` - a [meta] object that contains non-standard meta-information.
 
-Clients and servers **MUST** ignore a `ext` or `profile` member if its value
-conflicts with `ext` or `profile` media type parameter in the `Content-Type`
-header.
+Clients and servers **MUST NOT** use a `ext` or `profile` member for content
+negotiation. Content negotiation **MUST** only happen based on media type
+parameters in `Content-Type` header.
 
 A simple example appears below:
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -825,6 +825,10 @@ The jsonapi object **MAY** contain any of the following members:
 * `profile` - an array of URIs for all applied [profiles].
 * `meta` - a [meta] object that contains non-standard meta-information.
 
+Clients and servers **MUST** ignore a `ext` or `profile` member if its value
+conflicts with `ext` or `profile` media type parameter in the `Content-Type`
+header.
+
 A simple example appears below:
 
 ```json


### PR DESCRIPTION
The applied extension and profiles must be provided as `ext` and `profile` media type parameters of `Content-Type` header. Additionally they may be listed as `jsonapi.ext` and `jsonapi.profile` member of a JSON:API document.

This opens up the possibility of having different values in both places. So far the specification has not defined processing rules for such malformed documents.

This clarifies that a client and server must honor the `Content-Type` header in case of a conflict. Additionally it clarifies that they should not reject the document but ignore the invalid `jsonapi.ext` and/or `jsonapi.profile` members.

Ignoring them in case of a conflict rather than rejecting the document allows server and clients to _not_ process them at all - even if present. This avoids computing overhead just for the sake of validating the document.

Closes #1359 