### PR TITLE
define relationship object explicitly

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -475,11 +475,14 @@ as attributes. Instead, [relationships] **SHOULD** be used.
 ##### <a href="#document-resource-object-relationships" id="document-resource-object-relationships" class="headerlink"></a> Relationships
 
 The value of the `relationships` key **MUST** be an object (a "relationships
-object"). Members of the relationships object ("relationships") represent
-references from the [resource object][resource objects] in which it's defined to other resource
-objects.
+object"). Each member of the relationships object ("relationships") represents
+a "relationship", i.e., a reference from the [resource object][resource objects]
+in which they are defined to other resource objects.
 
 Relationships may be to-one or to-many.
+
+A relationship's name is given by its key. The value at that key **MUST** be an
+object ("relationship object").
 
 <a id="document-resource-object-relationships-relationship-object"></a>
 A "relationship object" **MUST** contain at least one of the following:

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -475,9 +475,9 @@ as attributes. Instead, [relationships] **SHOULD** be used.
 ##### <a href="#document-resource-object-relationships" id="document-resource-object-relationships" class="headerlink"></a> Relationships
 
 The value of the `relationships` key **MUST** be an object (a "relationships
-object"). Each member of the relationships object ("relationships") represents
-a "relationship", i.e., a reference from the [resource object][resource objects]
-in which they are defined to other resource objects.
+object"). Each member of a relationships object ("relationships") represents
+a "relationship" from the [resource object][resource objects]
+in which it has been defined to other resource objects.
 
 Relationships may be to-one or to-many.
 


### PR DESCRIPTION
The specification uses the term "relationship object" without defining it first. It also does not specify that the name of a relationship is given by its key in the relationships object. This change addresses both.

This has been discussed in length in #946. But it seems as if that merge request got stale _after_ a consensus has been reached. I'm implementing the result of that discussion here.

Closes #946 and #1521