### PR TITLE
Clarify handling of Accept header with media type parameter other than ext or profile

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -241,7 +241,7 @@ with a `415 Unsupported Media Type` status code.
   `profile` media type parameter is present.
 
 If a request's `Accept` header contains an instance of the JSON:API media type,
-servers **MUST** ignore instances of that media type are modified with a media
+servers **MUST** ignore instances of that media type which are modified with a media
 type parameter other than `ext` or `profile`. If all instances of that media
 type are modified with a media type parameter other than `ext` or `profile`,
 servers **MUST** respond with a `406 Not Acceptable` status code. If every

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -241,9 +241,9 @@ with a `415 Unsupported Media Type` status code.
   `profile` media type parameter is present.
 
 If a request's `Accept` header contains an instance of the JSON:API media type,
-servers **MUST** ignore instances of that media type which are modified with a media
-type parameter other than `ext` or `profile`. If all instances of that media
-type are modified with a media type parameter other than `ext` or `profile`,
+servers **MUST** ignore instances of that media type which are modified by a
+media type parameter other than `ext` or `profile`. If all instances of that
+media type are modified with a media type parameter other than `ext` or `profile`,
 servers **MUST** respond with a `406 Not Acceptable` status code. If every
 instance of that media type is modified by the `ext` parameter and each contains
 at least one unsupported extension URI, the server **MUST** also respond with a

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -241,11 +241,13 @@ with a `415 Unsupported Media Type` status code.
   `profile` media type parameter is present.
 
 If a request's `Accept` header contains an instance of the JSON:API media type,
-servers **MUST** respond with a `406 Not Acceptable` status code if all
-instances of that media type are modified with a media type parameter other
-than `ext` or `profile`. If every instance of that media type is modified by the
-`ext` parameter and each contains at least one unsupported extension URI, the
-server **MUST** also respond with a `406 Not Acceptable`.
+servers **MUST** ignore instances of that media type are modified with a media
+type parameter other than `ext` or `profile`. If all instances of that media
+type are modified with a media type parameter other than `ext` or `profile`,
+servers **MUST** respond with a `406 Not Acceptable` status code. If every
+instance of that media type is modified by the `ext` parameter and each contains
+at least one unsupported extension URI, the server **MUST** also respond with a
+`406 Not Acceptable`.
 
 If the `profile` parameter is received, a server **SHOULD** attempt to apply any
 requested profile(s) to its response. A server **MUST** ignore any profiles


### PR DESCRIPTION
This clarifies how server should handle media types in `Accept` handler, which contains other media type parameters than `ext` or `profile`. So far the specification only specified the case if _all_ media types are modified by parameters other than `ext` and `profile`. But it didn't specified how an `Accept` header should be handled if only _some_ media types contained parameters other than `ext` and `profile`.

Let's take this example:

```http
Accept: application/vnd.api+json, application/vnd.api+json; ext="https://jsonapi.org/ext/version"; other="not allowed"
```

How should it handle the `application/vnd.api+json; ext="https://jsonapi.org/ext/version"; other="not allowed"` media type? Responding with a `406 Not Acceptable` to the request would not be appreciate because the request contains one media type without any media type parameter (`application/vnd.api+json`). Should the server apply the `https://jsonapi.org/ext/version` extension? Or should it ignore the media type all together because it contains one media type parameter, which is not allowed (`other="not allowed"`)?

This change clarifies that server should ignore a media type if it is modified by parameters other than `ext` and `profile`.

This is inline with the rule to reject the entire request if _all_ media types are modified by parameter other than `ext` and `profile`. It wouldn't make much sense, to reject a media type with a parameter other than `ext` and `profile` if it is the only one but use it if there is one other.