### PR TITLE
only client-requested sparse fieldsets are exception to full linkage requirement

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -623,7 +623,8 @@ included without a direct or indirect relationship to the document's primary
 data.
 
 The only exception to the full linkage requirement is when relationship fields
-that would otherwise contain linkage data are excluded via [sparse fieldsets](#fetching-sparse-fieldsets).
+that would otherwise contain linkage data are excluded due to
+[sparse fieldsets](#fetching-sparse-fieldsets) requested by the client.
 
 A complete example document with multiple included relationships:
 


### PR DESCRIPTION
The current wording could be misunderstood that also fields excluded by the server if client does _not_ request a sparse fieldset are an exception for full linkage requirement. This changes clarifies that only exception is if a client _explicilty_ requested a sparse fieldset, which does not include a relationship required for full linkage.

Closes #1614 