### PR TITLE
Server should respond with 409 even if only type or id does not match endpoint

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1787,7 +1787,7 @@ update a resource if that update would violate other server-enforced
 constraints (such as a uniqueness constraint on a property other than `id`).
 
 A server **MUST** return `409 Conflict` when processing a `PATCH` request in
-which the resource object's `type` and `id` do not match the server's endpoint.
+which the resource object's `type` or `id` do not match the server's endpoint.
 
 A server **SHOULD** include error details and provide enough information to
 recognize the source of the conflict.


### PR DESCRIPTION
The server should respond with `409 Conflict` also of only `type` or `id` does not match the used. Using _and_ wasn't precise therefore.

General speaking the server should respond with `409 Conflict` if resource object included in a `PATCH` request is _not_ the resource represented by the used endpoint.

This issue was reported by @Relequestual in #1549. He also proposed the fix implemented here.

Closes  #1549