### PR TITLE
drop constraints on attribute values

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -462,12 +462,8 @@ The value of the `attributes` key **MUST** be an object (an "attributes
 object"). Members of the attributes object ("attributes") represent information
 about the [resource object][resource objects] in which it's defined.
 
-Attributes may contain any valid JSON value.
-
-Complex data structures involving JSON objects and arrays are allowed as
-attribute values. However, any object that constitutes or is contained in an
-attribute **MUST NOT** contain a `relationships` or `links` member, as those
-members are reserved by this specification for future use.
+Attributes may contain any valid JSON value, including complex data structures
+involving JSON objects and arrays.
 
 Keys that reference related resources (e.g. `author_id`) **SHOULD NOT** appear
 as attributes. Instead, [relationships] **SHOULD** be used.


### PR DESCRIPTION
This drops any constraints on attribute values as proposed in #1553. Most noticeable the requirement hat an object used as attribute value (even if nested) must not have a key `links` or `relationships`.

There is no need anymore to restrict these for future usage in the specification itself. All potential use cases could be solved by using `links` or `relationships` members of the JSON:API resource object. Or by an extension registering additional members on the JSON:API resource object.

Dropping this requirement simplifies the teaching of JSON:API. We could state that the JSON:API specification is agnostic about attribute values, which wasn't true before.

I will create a complementary merge request to drop the requirement to ignore keys starting with `@` in objects used as attribute values as proposed in #1367 and #1584. It is closely related to this one. But I feel that it is easier to discuss them separately. Especially if there are discussion needs in regards to JSON-LD.