### PR TITLE
docs: be more specific about behavior of empty value for sparse fieldsets

### DIFF
--- a/_format/1.0/index.md
+++ b/_format/1.0/index.md
@@ -1000,7 +1000,8 @@ response on a per-type basis by including a `fields[TYPE]` parameter.
 
 The value of the `fields` parameter **MUST** be a comma-separated (U+002C
 COMMA, ",") list that refers to the name(s) of the fields to be returned.
-An empty value indicates that no fields should be returned.
+An empty value indicates that an endpoint **MUST NOT** return any [fields] 
+in resource objects of that type in its response.
 
 If a client requests a restricted set of [fields] for a given resource type,
 an endpoint **MUST NOT** include additional [fields] in resource objects of

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1318,7 +1318,8 @@ response on a per-type basis by including a `fields[TYPE]` query parameter.
 
 The value of any `fields[TYPE]` parameter **MUST** be a comma-separated (U+002C
 COMMA, ",") list that refers to the name(s) of the fields to be returned.
-An empty value indicates that no fields should be returned.
+An empty value indicates that an endpoint **MUST NOT** return any [fields] 
+in resource objects of that type in its response.
 
 If a client requests a restricted set of [fields] for a given resource type,
 an endpoint **MUST NOT** include additional [fields] in resource objects of


### PR DESCRIPTION
The wording for the use case that a client submits the `fields[TYPE]`-parameter with an empty value is a little bit fuzzy given the availability of the key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document, indicated by a bold font and uppercase spelling.

If an empty value is understood as advising the endpoint to not include any fields at all for the resource object with the given type, I'd propose to use the key word **MUST NOT** in this section. 
Or is the lowercased `should not` to be interpreted as the keyword **SHOULD NOT**, which would mean that - in the end - this is just a recommendation for the endpoint's behavior and equally to omitting the `fields[TYPE]` parameter at all?


