### PR TITLE
fix broken RFC 3986 link

### DIFF
--- a/_format/1.0/index.md
+++ b/_format/1.0/index.md
@@ -579,7 +579,7 @@ by clients and servers, and they **MUST** meet all of the following conditions:
   as defined below.
 
 To enable an easy mapping of member names to URLs, it is **RECOMMENDED** that
-member names use only non-reserved, URL safe characters specified in [RFC 3986](http://tools.ietf.org/html/rfc3986#page-13).
+member names use only non-reserved, URL safe characters specified in [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-2.3).
 
 #### <a href="#document-member-names-allowed-characters" id="document-member-names-allowed-characters" class="headerlink"></a> Allowed Characters
 

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -867,7 +867,7 @@ meet all of the following conditions:
   as defined below.
 
 To enable an easy mapping of member names to URLs, it is **RECOMMENDED** that
-member names use only non-reserved, URL safe characters specified in [RFC 3986](http://tools.ietf.org/html/rfc3986#page-13).
+member names use only non-reserved, URL safe characters specified in [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-2.3).
 
 #### <a href="#document-member-names-allowed-characters" id="document-member-names-allowed-characters" class="headerlink"></a> Allowed Characters
 


### PR DESCRIPTION
The link for RFC 3986 in 5.8 Member names was broken. This PR fixes the link.