### PR TITLE
relationship object may have extension defined member only

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -498,6 +498,7 @@ A "relationship object" **MUST** contain at least one of the following:
 * `data`: [resource linkage]
 * `meta`: a [meta object][meta] that contains non-standard meta-information about the
   relationship.
+* a member defined by an applied [extension](#extensions).
 
 A relationship object that represents a to-many relationship **MAY** also contain
 [pagination] links under the `links` member, as described below. Any


### PR DESCRIPTION
Similar as for members of the top-level object (#1642), relationship objects should be allowed to have extension defined member as the only one.

Without this change, implementations would need to add an empty `meta` object together with extension defined member to be compliant. This wouldn't provide any value.