### PR TITLE
Improve explanation for reserving brackets in member names

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -895,8 +895,8 @@ The following characters **MUST NOT** be used in implementation and
 - U+002B PLUS SIGN, "+" _(has overloaded meaning in URL query strings)_
 - U+002C COMMA, "," _(used as a separator between relationship paths)_
 - U+002E PERIOD, "." _(used as a separator within relationship paths)_
-- U+005B LEFT SQUARE BRACKET, "[" _(used in sparse fieldsets)_
-- U+005D RIGHT SQUARE BRACKET, "]" _(used in sparse fieldsets)_
+- U+005B LEFT SQUARE BRACKET, "[" _(used in query parameter families)_
+- U+005D RIGHT SQUARE BRACKET, "]" _(used in query parameter families)_
 - U+0021 EXCLAMATION MARK, "!"
 - U+0022 QUOTATION MARK, '"'
 - U+0023 NUMBER SIGN, "#"


### PR DESCRIPTION
Brackets are used in all query parameter families. Not only in sparse fieldsets.

Looks as if we missed to update this explanation when _query parameter families_ have been added as a concept.