### PR TITLE
update can only target a single resource

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -1752,14 +1752,14 @@ does not want to allow deletion of records the client has not seen.
 
 ##### <a href="#crud-updating-responses-200" id="crud-updating-responses-200" class="headerlink"></a> 200 OK
 
-If a server accepts an update but also changes the targeted resource(s) in ways
+If a server accepts an update but also changes the targeted resource in ways
 other than those specified by the request (for example, updating the
 `updatedAt` attribute or a computed `sha`), it **MUST** return a `200 OK`
-response and a document that contains the updated resource(s) as primary data.
+response and a document that contains the updated resource as primary data.
 
 A server **MAY** return a `200 OK` response with a document that contains no
 primary data if an update is successful and the server does not change the
-targeted resource(s) in ways other than those specified by the request. Other
+targeted resource in ways other than those specified by the request. Other
 top-level members, such as [meta], could be included in the response document.
 
 ##### <a href="#crud-updating-responses-202" id="crud-updating-responses-202" class="headerlink"></a> 202 Accepted
@@ -1771,7 +1771,7 @@ return a `202 Accepted` status code.
 ##### <a href="#crud-updating-responses-204" id="crud-updating-responses-204" class="headerlink"></a> 204 No Content
 
 If an update is successful and the server doesn't change the targeted
-resource(s) in ways other than those specified by the request, the server
+resource in ways other than those specified by the request, the server
 **MUST** return either a `200 OK` status code and response document (as
 described above) or a `204 No Content` status code with no response document.
 


### PR DESCRIPTION
An update can only _target_ a single resource. Speaking of "targeted resource(s)" may confuse the reader therefore.

An update may _affect_ multiple resources if it has side-effects. E.g. updating a `rating` resource may indirectly update `averageRating` attribute of a related `product` resource. But nevertheless the update only _targets_ the `rating` resource.

The difference between _targeted_ and _affected_ resources is important. HTTP response status codes required by the specification only depends on _targeted_ resources. E.g. a server must include the _targeted_ resource in response if it has been changed in any other way than specified. But a server may or may not include another, non-targeted resource in response even if it has been changed due to a side-effect.

A similar issue for "targeted relationship(s)" has been fixed in https://github.com/json-api/json-api/pull/1638#discussion_r907483986.