### PR TITLE
align wording for deleting resources with creating and updating

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -2020,7 +2020,7 @@ responses, in accordance with
 
 ### <a href="#crud-deleting" id="crud-deleting" class="headerlink"></a> Deleting Resources
 
-An individual resource can be *deleted* by making a `DELETE` request to the
+A resource can be *deleted* by seding a `DELETE` request to the
 resource's URL:
 
 ```http

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -2020,8 +2020,8 @@ responses, in accordance with
 
 ### <a href="#crud-deleting" id="crud-deleting" class="headerlink"></a> Deleting Resources
 
-A resource can be *deleted* by seding a `DELETE` request to the
-resource's URL:
+A resource can be *deleted* by seding a `DELETE` request to the URL
+that represents the resource:
 
 ```http
 DELETE /photos/1 HTTP/1.1

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -2020,7 +2020,7 @@ responses, in accordance with
 
 ### <a href="#crud-deleting" id="crud-deleting" class="headerlink"></a> Deleting Resources
 
-A resource can be deleted by seding a `DELETE` request to the URL
+A resource can be deleted by sending a `DELETE` request to the URL
 that represents the resource:
 
 ```http

--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -2020,7 +2020,7 @@ responses, in accordance with
 
 ### <a href="#crud-deleting" id="crud-deleting" class="headerlink"></a> Deleting Resources
 
-A resource can be *deleted* by seding a `DELETE` request to the URL
+A resource can be deleted by seding a `DELETE` request to the URL
 that represents the resource:
 
 ```http


### PR DESCRIPTION
This change aligns the wording for deleting a resource with wording for creating and updating a resource:

https://github.com/json-api/json-api/blob/9870d6fdef157aa8f97c6430ef0ec8bd223fa449/_format/1.1/index.md?plain=1#L1464-L1465

https://github.com/json-api/json-api/blob/9870d6fdef157aa8f97c6430ef0ec8bd223fa449/_format/1.1/index.md?plain=1#L1626-L1627

Wording for updating relationships is aligned with the others in #1650.