### PR TITLE
Add EntityStore.TS to TypeScript client libraries

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -66,6 +66,7 @@ isomorphic ActiveRecord clone that issues JSON:API requests instead of SQL and i
 * [jsonapi-fractal](https://github.com/andersondanilo/jsonapi-fractal) JSON:API Serializer inspired by Fractal (PHP)
 * [ts-japi](https://github.com/jun-sheaf/ts-japi) - A zero-dependency, highly-modular, js/ts-friendly, recursible, framework-agnostic library for serializing data to the JSON:API specification. Serializes the entire specification.
 * [drupal-jsonapi-params](https://github.com/d34dman/drupal-jsonapi-params) A library for building query parameters when connecting with Drupal CMS's JSON:API.
+* [EntityStore.TS](https://github.com/dipscope/EntityStore.TS) - ORM like abstraction layer for TypeScript which includes extensible [provider](https://github.com/dipscope/JsonApiEntityProvider.TS) for accessing JSON:API servers.
 
 ### <a href="#client-libraries-ios" id="client-libraries-ios" class="headerlink"></a> iOS
 


### PR DESCRIPTION
Added TypeScript [client](https://github.com/dipscope/EntityStore.TS) which has a [plugin](https://github.com/dipscope/JsonApiEntityProvider.TS) to access JSON:API servers.