### PR TITLE
allow extension defined member as only member in links object of relationship object

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -495,6 +495,7 @@ A "relationship object" **MUST** contain at least one of the following:
     for the related resources as its primary data.
     (See [Fetching Relationships](#fetching-relationships).)
   * `related`: a [related resource link]
+  * a member defined by an applied [extension](#extensions).
 * `data`: [resource linkage]
 * `meta`: a [meta object][meta] that contains non-standard meta-information about the
   relationship.


### PR DESCRIPTION
This allows an extension defined member as the only member in a `links` object of a relationship object.

This is not a breaking change compared. Extensions are not part of v1.0. So there could not be an applied extension if implementing v1.0.

Similar changes have been landed in #1642 and #1644 for other cases.