### PR TITLE
Remove unnecessary and potential confusing alias "relationships"

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -473,7 +473,7 @@ as attributes. Instead, [relationships] **SHOULD** be used.
 ##### <a href="#document-resource-object-relationships" id="document-resource-object-relationships" class="headerlink"></a> Relationships
 
 The value of the `relationships` key **MUST** be an object (a "relationships
-object"). Each member of a relationships object ("relationships") represents
+object"). Each member of a relationships object represents
 a "relationship" from the [resource object][resource objects]
 in which it has been defined to other resource objects.
 

--- a/_format/1.2/index.md
+++ b/_format/1.2/index.md
@@ -474,7 +474,7 @@ as attributes. Instead, [relationships] **SHOULD** be used.
 ##### <a href="#document-resource-object-relationships" id="document-resource-object-relationships" class="headerlink"></a> Relationships
 
 The value of the `relationships` key **MUST** be an object (a "relationships
-object"). Each member of a relationships object ("relationships") represents
+object"). Each member of a relationships object represents
 a "relationship" from the [resource object][resource objects]
 in which it has been defined to other resource objects.
 


### PR DESCRIPTION
Introducing the term _"relationships"_ additionally to _"relationships object"_ and _"relationship"_ is unnecessary and potentially confusing. How it was introduced made it seen as an alias for "relationships object". But it is later used just as plural of "relationship". I think we could simplify by not introducing it as a special term.