### PR TITLE
Clarify usage of parallel relationships

### DIFF
--- a/_format/1.2/index.md
+++ b/_format/1.2/index.md
@@ -508,6 +508,25 @@ data, not the related resources.
 
 > Note: See [fields] and [member names] for more restrictions on this container.
 
+A to-many relationship **SHOULD NOT** reference the same resource object more than
+once.
+
+> Note: This recommendation does _not_ prevent parallel relationships:
+> 
+> 1. A resource object may reference another resource object on different
+> relationships. For example, an `article` resource may reference the same `user`
+> resource both on its `author` and `editors` relationship.
+> 2. A resource object may reference another resource object more than once
+> on the same relationship through an intermediate resource object. For example,
+> a `team` resource may reference the same `user` resource more than once on its
+> `members` relationship _through_ a `teamMember` resource. The `teamMember`
+> resource could present additional information as fields such as `startDate`,
+> `endDate`, and `invitedBy`.
+> 
+> Only multiple references to the same resource on a single relationship _without_
+> an intermediate resource are discouraged as it often leads to presenting additional
+> information about that relationship as [meta-information](meta).
+
 ##### <a href="#document-resource-object-related-resource-links" id="document-resource-object-related-resource-links" class="headerlink"></a> Related Resource Links
 
 A "related resource link" provides access to [resource objects][resource objects] [linked][links]

--- a/_format/1.2/index.md
+++ b/_format/1.2/index.md
@@ -514,11 +514,11 @@ once.
 > Note: This recommendation does _not_ prevent parallel relationships:
 > 
 > 1. A resource object may reference another resource object on different
-> relationships. For example, an `article` resource may reference the same `user`
+> relationships. For example, an `article` resource may reference the same `people`
 > resource both on its `author` and `editors` relationship.
 > 2. A resource object may reference another resource object more than once
 > on the same relationship through an intermediate resource object. For example,
-> a `team` resource may reference the same `user` resource more than once on its
+> a `team` resource may reference the same `people` resource more than once on its
 > `members` relationship _through_ a `teamMember` resource. The `teamMember`
 > resource could present additional information as fields such as `startDate`,
 > `endDate`, and `invitedBy`.


### PR DESCRIPTION
This PR _tries_ to implement the agreement we came up in #1361.

I struggled with the wording to be honest. I found it difficult to distinguish between the different kinds of parallel relationships. For sake of clarity let me show them in code:

1. **Different relationships**
    ```json
    {
      "data": {
        "type": "articles",
        "id": "1",
        "relationships": {
          "author": {
            "data": {
              "type": "users",
              "id": "12"
            }
          },
         "editors": {
           "data": [
             {
               "type": "users",
               "id": "12"
             }
           ]
         }
      }
    }
    ```

2. **Intermediate resource**
    ```json
    {
      "data": {
        "type": "teams",
        "id": "1",
        "relationships": {
          "members": {
            "data": {
              "type": "teamMembers",
              "id": "12"
            }
          },
         "editors": {
           "data": [
             {
               "type": "teamMembers",
               "id": "13"
             }
           ]
         }
      },
      "included": [
        {
          "type": "teamMembers",
          "id": "12",
          "attributes": {
            "startDate": "2021-01-01",
            "endDate": "2021-12-31",
          },
          "relationships": {
            "user": {
              "data": {
                "type": "users",
                "id": "23"
              }
            }
          }
        },
        {
          "type": "teamMembers",
          "id": "13",
          "attributes": {
            "startDate": "2022-06-01",
            "endDate": "2022-12-31",
          },
          "relationships": {
            "user": {
              "data": {
                "type": "users",
                "id": "23"
              }
            }
          }
        }
      ]
    }
    ```

3. **Multiple, direct reference on same relationship**
    ```json
    {
      "data": {
        "type": "teams",
        "id": "1",
        "relationships": {
          "members": {
            "data": [
              {
                "type": "users",
                "id": "23",
                "meta": {
                  "startDate": "2021-01-01",
                  "endDate": "2021-12-31",
                }
              },
             {
                "type": "users",
                "id": "23",
                "meta": {
                  "startDate": "2022-06-01",
                  "endDate": "2022-12-31",
                }
              }
            ]
          }
        }
      }
    }
    ```

We only aim to discourage using the third type of parallel relationships. We recommend to use the second type instead. I'm not sure how well this is expressed in the current wording.

Open questions:

1. Do we want to backport this recommendation to v1.1?
2. Do we need a better wording to distinguish between relationships of a resource (`author`, `editors`) and references to resource in such relationships?

Closes #1361