### PR TITLE
Clarify intent of links member

### DIFF
--- a/_format/1.2/index.md
+++ b/_format/1.2/index.md
@@ -750,8 +750,12 @@ For example:
 
 ### <a href="#document-links" id="document-links" class="headerlink"></a> Links
 
-Where specified, a `links` member can be used to represent links. The value
-of this member **MUST** be an object (a "links object").
+Where specified, a `links` member can be used to represent links to related JSON:API
+documents. The value of this member **MUST** be an object (a "links object").
+
+> Note: The `links` member is intended to reference related JSON:API documents only.
+> Other links can be included as resource attributes, `meta` information or using
+> as members defined by an applied extension.
 
 <a href="#document-links-link" id="document-links-link"></a>
 Within this object, a link **MUST** be represented as either:

--- a/_format/1.2/index.md
+++ b/_format/1.2/index.md
@@ -755,7 +755,7 @@ documents. The value of this member **MUST** be an object (a "links object").
 
 > Note: The `links` member is intended to reference related JSON:API documents only.
 > Other links can be included as resource attributes, `meta` information or using
-> as members defined by an applied extension.
+> members defined by an applied extension.
 
 <a href="#document-links-link" id="document-links-link"></a>
 Within this object, a link **MUST** be represented as either:


### PR DESCRIPTION
There has been many confusion about the intent of the links member. People tried using it for links not pointing to other JSON:API documents. Such as related files, related resources represented in different formats or other representations of the same resource in other formats. This PR tries to clarify the intent of `links` member and pointing readers to alternative ways solving their use case.

Open questions:

- Should we backport this to v1.1?

Closes #1684 #1678