### PR TITLE
Docs - Update examples to use lates jsonapi

### DIFF
--- a/examples/index.md
+++ b/examples/index.md
@@ -303,7 +303,7 @@ HTTP/1.1 422 Unprocessable Entity
 Content-Type: application/vnd.api+json
 
 {
-  "jsonapi": { "version": "1.0" },
+  "jsonapi": { "version": "1.1" },
   "errors": [
     {
       "code":   "123",


### PR DESCRIPTION
The example output that has a declared 'jsonapi' value is not updated to use the latest 1.1 version.