### PR TITLE
Add new link for a Python implementation of JSON:API

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -264,6 +264,7 @@ the moment.
 * [Flump](https://github.com/rolepoint/flump) Database agnostic JSON:API builder which depends on Flask and Marshmallow.
 * [SAFRS JSON API Framework](https://github.com/thomaxxl/safrs) Flask-SQLAlchemy jsonapi implementation with auto-generated openapi (fka swagger) interface.
 * [pydantic-jsonapi](https://github.com/DeanWay/pydantic-jsonapi) JSON:api validation with python type hinting using [pydantic](https://pydantic-docs.helpmanual.io/)
+* [pydanja](https://github.com/Centurix/pydanja) JSON:API implementation for [pydantic](https://pydantic-docs.helpmanual.io/) and [FastAPI](https://fastapi.tiangolo.com/) using generic types, complete with helpers for simplifying OpenAPI docs
 * [Flask-Restless-NG](https://github.com/mrevutskyi/flask-restless-ng) Builds JSON:API from SQLAlchemy models using Flask
 * [starlette-jsonapi](https://github.com/vladmunteanu/starlette-jsonapi) Microframework on top of Starlette and marshmallow-jsonapi with support for asynchronous ORMs
 * [kt.jsonapi](https://pypi.org/project/kt.jsonapi/) JSON:API response generation using the Zope Component Architecture.


### PR DESCRIPTION
I have a new link for PyDANJA, a simple Python JSON:API implementation that uses generic types to control the output from pydantic and ultimately FastAPI. It also contains helper functions for controlling the output of FastAPIs automatic OpenAPI documentation.