### PR TITLE
top-level links object is related to the document in some cases

### DIFF
--- a/_format/1.2/index.md
+++ b/_format/1.2/index.md
@@ -303,7 +303,7 @@ The members `data` and `errors` **MUST NOT** coexist in the same document.
 A document **MAY** contain any of these top-level members:
 
 * `jsonapi`: an object describing the server's implementation.
-* `links`: a [links object][links] related to the document at a whole.
+* `links`: a [links object][links] related to the document as a whole.
 * `included`: an array of [resource objects] that are related to the primary
   data and/or each other ("included resources").
 

--- a/_format/1.2/index.md
+++ b/_format/1.2/index.md
@@ -303,7 +303,7 @@ The members `data` and `errors` **MUST NOT** coexist in the same document.
 A document **MAY** contain any of these top-level members:
 
 * `jsonapi`: an object describing the server's implementation.
-* `links`: a [links object][links] related to the primary data.
+* `links`: a [links object][links] related to the document at a whole.
 * `included`: an array of [resource objects] that are related to the primary
   data and/or each other ("included resources").
 


### PR DESCRIPTION
The top-level `links` object is related to the whole document in 2 out of 4 cases: `self` and `describedby` links are related to the document. Not only to its primary data. Even more they are useful even if a document does not have primary data.

A document could not have primary data if 1) being an error response, 2) a response to a successful mutation, and 3) having an extension applied. Top-level links, especially `self`, are commonly used in those cases. And intended to be used.

This PR improves the wording of the specification to avoid confusion. It was motivated by this thread in the discussion forum: https://jsonapi.org/format/

TODO:

- [ ] Backport to v1.1 