### PR TITLE
backport clarification of top-level links object to v1.1

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -302,7 +302,7 @@ The members `data` and `errors` **MUST NOT** coexist in the same document.
 A document **MAY** contain any of these top-level members:
 
 * `jsonapi`: an object describing the server's implementation.
-* `links`: a [links object][links] related to the primary data.
+* `links`: a [links object][links] related to the document as a whole.
 * `included`: an array of [resource objects] that are related to the primary
   data and/or each other ("included resources").
 


### PR DESCRIPTION
The clarification was merged to v1.2 (upcoming) in #1753. This backports the changes to v1.1.