### PR TITLE
media type parameters should be delimited by an immediately preceding semicolony

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -49,7 +49,7 @@ The JSON:API specification supports two media type parameters: `ext` and
 
 > Note: A media type parameter is an extra piece of information that can
 accompany a media type. For example, in the header
-`Content-Type: text/html; charset="utf-8"`, the media type is `text/html` and
+`Content-Type: text/html;charset="utf-8"`, the media type is `text/html` and
 `charset` is a parameter.
 
 ### <a href="#extensions" id="extensions" class="headerlink"></a> Extensions
@@ -120,7 +120,7 @@ versioning. This member might appear as follows:
 
 ```json
 HTTP/1.1 200 OK
-Content-Type: application/vnd.api+json; ext="https://jsonapi.org/ext/version"
+Content-Type: application/vnd.api+json;ext="https://jsonapi.org/ext/version"
 
 // ...
 {
@@ -169,7 +169,7 @@ With such a profile applied, a response might appear as follows:
 
 ```json
 HTTP/1.1 200 OK
-Content-Type: application/vnd.api+json; profile="https://example.com/resource-timestamps"
+Content-Type: application/vnd.api+json;profile="https://example.com/resource-timestamps"
 
 // ...
 {

--- a/_format/1.2/index.md
+++ b/_format/1.2/index.md
@@ -50,7 +50,7 @@ The JSON:API specification supports two media type parameters: `ext` and
 
 > Note: A media type parameter is an extra piece of information that can
 accompany a media type. For example, in the header
-`Content-Type: text/html; charset="utf-8"`, the media type is `text/html` and
+`Content-Type: text/html;charset="utf-8"`, the media type is `text/html` and
 `charset` is a parameter.
 
 ### <a href="#extensions" id="extensions" class="headerlink"></a> Extensions
@@ -121,7 +121,7 @@ versioning. This member might appear as follows:
 
 ```json
 HTTP/1.1 200 OK
-Content-Type: application/vnd.api+json; ext="https://jsonapi.org/ext/version"
+Content-Type: application/vnd.api+json;ext="https://jsonapi.org/ext/version"
 
 // ...
 {
@@ -170,7 +170,7 @@ With such a profile applied, a response might appear as follows:
 
 ```json
 HTTP/1.1 200 OK
-Content-Type: application/vnd.api+json; profile="https://example.com/resource-timestamps"
+Content-Type: application/vnd.api+json;profile="https://example.com/resource-timestamps"
 
 // ...
 {


### PR DESCRIPTION
Ensures that examples given in the specification are inline with HTTP specification:

> Each parameter is usually delimited by an immediately preceding semicolon.

Source: [RFC 9110 - HTTP Semantics: 5.6.6. Parameters](https://httpwg.org/specs/rfc9110.html#rfc.section.5.6.6) [Parameters](https://httpwg.org/specs/rfc9110.html#parameter)

This has been caught in #1768 and #1770.