### PR TITLE
Clarify combination of JSON:API with other standars

### DIFF
--- a/_format/1.2/index.md
+++ b/_format/1.2/index.md
@@ -13,6 +13,8 @@ JSON:API is designed to minimize both the number of requests and the amount of
 data transmitted between clients and servers. This efficiency is achieved
 without compromising readability, flexibility, or discoverability.
 
+JSON:API can and should be combined with additional standards addressing other needs of HTTP APIs such as [OAuth 2.0](https://datatracker.ietf.org/doc/html/rfc6749) for authorization and [Open API](https://spec.openapis.org/oas/latest.html) for documentation. A server supporting JSON:API can support other API standards such as [OData](https://www.odata.org/) or [GraphQL](https://graphql.org/) on the same or other endpoints.
+
 JSON:API requires use of the JSON:API media type
 ([`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json))
 for exchanging data.

--- a/_format/1.2/index.md
+++ b/_format/1.2/index.md
@@ -17,7 +17,13 @@ JSON:API requires use of the JSON:API media type
 ([`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json))
 for exchanging data.
 
-> For additional needs of HTTP APIs, like authentication, documentation, file uploads, and more, JSON:API can and should be combined with additional standards such as [OAuth 2.0](https://datatracker.ietf.org/doc/html/rfc6749) for authorization and [Open API](https://spec.openapis.org/oas/latest.html) for documentation. It is allowed for a server supporting JSON:API to also support other API standards on the same or other endpoints, such as [OData](https://www.odata.org/) or [GraphQL](https://graphql.org/).
+> For additional needs of HTTP APIs, like authentication, documentation, file
+> uploads, and more, JSON:API can and should be combined with additional
+> standards such as [OAuth 2.0](https://datatracker.ietf.org/doc/html/rfc6749)
+> for authorization and [Open API](https://spec.openapis.org/oas/latest.html)
+> for documentation. It is allowed for a server supporting JSON:API to also
+> support other API standards on the same or other endpoints, such as
+> [OData](https://www.odata.org/) or [GraphQL](https://graphql.org/).
 
 ## <a href="#semantics" id="semantics" class="headerlink"></a> Semantics
 

--- a/_format/1.2/index.md
+++ b/_format/1.2/index.md
@@ -13,7 +13,7 @@ JSON:API is designed to minimize both the number of requests and the amount of
 data transmitted between clients and servers. This efficiency is achieved
 without compromising readability, flexibility, or discoverability.
 
-JSON:API can and should be combined with additional standards addressing other needs of HTTP APIs such as [OAuth 2.0](https://datatracker.ietf.org/doc/html/rfc6749) for authorization and [Open API](https://spec.openapis.org/oas/latest.html) for documentation. A server supporting JSON:API can support other API standards such as [OData](https://www.odata.org/) or [GraphQL](https://graphql.org/) on the same or other endpoints.
+For additional needs of HTTP APIs, like authentication, documentation, file uploads, and more, JSON:API can and should be combined with additional standards such as [OAuth 2.0](https://datatracker.ietf.org/doc/html/rfc6749) for authorization and [Open API](https://spec.openapis.org/oas/latest.html) for documentation. It is allowed for a server supporting JSON:API to also support other API standards on the same or other endpoints, such as [OData](https://www.odata.org/) or [GraphQL](https://graphql.org/).
 
 JSON:API requires use of the JSON:API media type
 ([`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json))

--- a/_format/1.2/index.md
+++ b/_format/1.2/index.md
@@ -1,4 +1,5 @@
----version: 1.2
+---
+version: 1.2
 status: draft
 ---
 

--- a/_format/1.2/index.md
+++ b/_format/1.2/index.md
@@ -19,10 +19,6 @@ JSON:API requires use of the JSON:API media type
 
 > For additional needs of HTTP APIs, like authentication, documentation, file uploads, and more, JSON:API can and should be combined with additional standards such as [OAuth 2.0](https://datatracker.ietf.org/doc/html/rfc6749) for authorization and [Open API](https://spec.openapis.org/oas/latest.html) for documentation. It is allowed for a server supporting JSON:API to also support other API standards on the same or other endpoints, such as [OData](https://www.odata.org/) or [GraphQL](https://graphql.org/).
 
-JSON:API requires use of the JSON:API media type
-([`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json))
-for exchanging data.
-
 ## <a href="#semantics" id="semantics" class="headerlink"></a> Semantics
 
 All document members, query parameters, and processing rules defined by

--- a/_format/1.2/index.md
+++ b/_format/1.2/index.md
@@ -13,7 +13,11 @@ JSON:API is designed to minimize both the number of requests and the amount of
 data transmitted between clients and servers. This efficiency is achieved
 without compromising readability, flexibility, or discoverability.
 
-For additional needs of HTTP APIs, like authentication, documentation, file uploads, and more, JSON:API can and should be combined with additional standards such as [OAuth 2.0](https://datatracker.ietf.org/doc/html/rfc6749) for authorization and [Open API](https://spec.openapis.org/oas/latest.html) for documentation. It is allowed for a server supporting JSON:API to also support other API standards on the same or other endpoints, such as [OData](https://www.odata.org/) or [GraphQL](https://graphql.org/).
+JSON:API requires use of the JSON:API media type
+ ([`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json))
+ for exchanging data.
+
+> For additional needs of HTTP APIs, like authentication, documentation, file uploads, and more, JSON:API can and should be combined with additional standards such as [OAuth 2.0](https://datatracker.ietf.org/doc/html/rfc6749) for authorization and [Open API](https://spec.openapis.org/oas/latest.html) for documentation. It is allowed for a server supporting JSON:API to also support other API standards on the same or other endpoints, such as [OData](https://www.odata.org/) or [GraphQL](https://graphql.org/).
 
 JSON:API requires use of the JSON:API media type
 ([`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json))

--- a/_format/1.2/index.md
+++ b/_format/1.2/index.md
@@ -1,5 +1,4 @@
----
-version: 1.2
+---version: 1.2
 status: draft
 ---
 
@@ -14,8 +13,8 @@ data transmitted between clients and servers. This efficiency is achieved
 without compromising readability, flexibility, or discoverability.
 
 JSON:API requires use of the JSON:API media type
- ([`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json))
- for exchanging data.
+([`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json))
+for exchanging data.
 
 > For additional needs of HTTP APIs, like authentication, documentation, file uploads, and more, JSON:API can and should be combined with additional standards such as [OAuth 2.0](https://datatracker.ietf.org/doc/html/rfc6749) for authorization and [Open API](https://spec.openapis.org/oas/latest.html) for documentation. It is allowed for a server supporting JSON:API to also support other API standards on the same or other endpoints, such as [OData](https://www.odata.org/) or [GraphQL](https://graphql.org/).
 


### PR DESCRIPTION
JSON:API can and should be combined with other standards. But there has been some confusion about it in the past. E.g. people tried using it for authentication concerns such as login instead of established standards such as OAuth 2.0. Others assumed an API implementing JSON:API cannot support file upload. There seems to be a need clarifying it in the specification to avoid such confusion going forward.

See https://github.com/json-api/json-api/issues/246#issuecomment-2449156935 for recent discussions regarding this.