### PR TITLE
add example for multiple extensions applied

### DIFF
--- a/_format/1.2/index.md
+++ b/_format/1.2/index.md
@@ -93,6 +93,13 @@ values of the `ext` and `profile` parameters **MUST** equal a space-separated
 > specification requires that parameter values be surrounded by quotation marks
 > (U+0022 QUOTATION MARK, "\"").
 
+In the following example, two extensions and one profile have been applied:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.api+json;ext="https://example.com/version https://example.com/bulk";profile="https://example.com/resource-timestamps"
+```
+
 #### <a href="#extension-rules" id="extension-rules" class="headerlink"></a> Rules for Extensions
 
 An extension **MAY** impose additional processing rules or further restrictions


### PR DESCRIPTION
The question how a media type looks like if multiple extensions or profiles have been applied came up twice (#1770, #1768). It was already well defined in the specification:

> The values of the `ext` and `profile` parameters **MUST** equal a space-separated (U+0020 SPACE, " ") list of extension or profile URIs, respectively.

This PR adds an additional example similar to the examples we have in other cases for additional clarity.

Closes #1770 