### PR TITLE
docs: added `@tsmetadata/json-api` to implementations

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -68,6 +68,7 @@ isomorphic ActiveRecord clone that issues JSON:API requests instead of SQL and i
 * [drupal-jsonapi-params](https://github.com/d34dman/drupal-jsonapi-params) A library for building query parameters when connecting with Drupal CMS's JSON:API.
 * [EntityStore.TS](https://github.com/dipscope/EntityStore.TS) - ORM like abstraction layer for TypeScript which includes extensible [provider](https://github.com/dipscope/JsonApiEntityProvider.TS) for accessing JSON:API servers.
 * [@tsmetadata/json-api](https://github.com/tsmetadata/json-api) - Standardized set of JSON:API metadata decorators.
+* [@tsmetadata/json-api-orm](https://github.com/tsmetadata/json-api-orm) - NoSQL object-relational mapping for JSON:API resource objects decorated with `@tsmetadata/json-api`.
 
 ### <a href="#client-libraries-ios" id="client-libraries-ios" class="headerlink"></a> iOS
 

--- a/implementations/index.md
+++ b/implementations/index.md
@@ -67,6 +67,7 @@ isomorphic ActiveRecord clone that issues JSON:API requests instead of SQL and i
 * [ts-japi](https://github.com/jun-sheaf/ts-japi) - A zero-dependency, highly-modular, js/ts-friendly, recursible, framework-agnostic library for serializing data to the JSON:API specification. Serializes the entire specification.
 * [drupal-jsonapi-params](https://github.com/d34dman/drupal-jsonapi-params) A library for building query parameters when connecting with Drupal CMS's JSON:API.
 * [EntityStore.TS](https://github.com/dipscope/EntityStore.TS) - ORM like abstraction layer for TypeScript which includes extensible [provider](https://github.com/dipscope/JsonApiEntityProvider.TS) for accessing JSON:API servers.
+* [@tsmetadata/json-api](https://github.com/tsmetadata/json-api) - Standardized set of JSON:API metadata decorators.
 
 ### <a href="#client-libraries-ios" id="client-libraries-ios" class="headerlink"></a> iOS
 


### PR DESCRIPTION
I've been working hard on implementing a standard set of metadata decorators for JSON:API in TypeScript.

Why?
- These decorators are pure and add field/class metadata to the class prototype.
- Stage 3 decorators were finalized in TypeScript 5.2+ and adoption at this very moment is poor, despite immense technical possibility.
- Metadata can be accessed by other libraries, meaning `@tsmetadata/json-api` is one of few libraries built purely to allow for third party extension.
- This is a work in progress, but the metadata can be used to power [serializers](https://github.com/tsmetadata/json-api/blob/serializers/src/utils/serializeDocument.ts) and deserializers.
- I'm currently working on a NoSQL ORM utilizing the library where data is stored in a JSON:API-like fashion.

I have plans to support many specifications, but JSON:API is the first. You can learn more [here](https://github.com/tsmetadata/json-api/blob/serializers/src/utils/serializeDocument.ts).