### PR TITLE
Fix some typos

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -2155,10 +2155,10 @@ least one of:
 * `id`: a unique identifier for this particular occurrence of the problem.
 * `links`: a [links object][links] that **MAY** contain the following members:
   * `about`: a [link][link] that leads to further details about this
-    particular occurrence of the problem. When derefenced, this URI **SHOULD**
+    particular occurrence of the problem. When dereferenced, this URI **SHOULD**
     return a human-readable description of the error.
   * `type`: a [link][link] that identifies the type of error that this
-    particular error is an instance of. This URI **SHOULD** be dereferencable to
+    particular error is an instance of. This URI **SHOULD** be dereferenceable to
     a human-readable explanation of the general error.
 * `status`: the HTTP status code applicable to this problem, expressed as a
   string value.  This **SHOULD** be provided.
@@ -2210,7 +2210,7 @@ parsing algorithm. The resulting value might not be a string.
 > as delimiters. These issues motivate the exception that JSON:API defines above.
 
 Similarly, to serialize a query parameter into a URI, an implementation **MUST**
-use the [the `application/x-www-form-urlencoded` serializer](https://url.spec.whatwg.org/#concept-urlencoded-serializer),
+use [the `application/x-www-form-urlencoded` serializer](https://url.spec.whatwg.org/#concept-urlencoded-serializer),
 with the corresponding exception that a parameter's value — but not its name —
 may be serialized differently than that algorithm requires, provided the
 serialization does not interfere with the ability to parse back the resulting URI.
@@ -2247,7 +2247,7 @@ request as equivalent to one in which the square brackets were percent-encoded.
 [profiles]: #profiles
 [error details]: #errors
 [error object]: #error-objects
-[error objects]: #errror-objects
+[error objects]: #error-objects
 [member names]: #document-member-names
 [pagination]: #fetching-pagination
 [query parameter family]: #query-parameters-families

--- a/_format/1.2/index.md
+++ b/_format/1.2/index.md
@@ -2171,10 +2171,10 @@ least one of:
 * `id`: a unique identifier for this particular occurrence of the problem.
 * `links`: a [links object][links] that **MAY** contain the following members:
   * `about`: a [link][link] that leads to further details about this
-    particular occurrence of the problem. When derefenced, this URI **SHOULD**
+    particular occurrence of the problem. When dereferenced, this URI **SHOULD**
     return a human-readable description of the error.
   * `type`: a [link][link] that identifies the type of error that this
-    particular error is an instance of. This URI **SHOULD** be dereferencable to
+    particular error is an instance of. This URI **SHOULD** be dereferenceable to
     a human-readable explanation of the general error.
 * `status`: the HTTP status code applicable to this problem, expressed as a
   string value.  This **SHOULD** be provided.
@@ -2226,7 +2226,7 @@ parsing algorithm. The resulting value might not be a string.
 > as delimiters. These issues motivate the exception that JSON:API defines above.
 
 Similarly, to serialize a query parameter into a URI, an implementation **MUST**
-use the [the `application/x-www-form-urlencoded` serializer](https://url.spec.whatwg.org/#concept-urlencoded-serializer),
+use [the `application/x-www-form-urlencoded` serializer](https://url.spec.whatwg.org/#concept-urlencoded-serializer),
 with the corresponding exception that a parameter's value — but not its name —
 may be serialized differently than that algorithm requires, provided the
 serialization does not interfere with the ability to parse back the resulting URI.
@@ -2263,7 +2263,7 @@ request as equivalent to one in which the square brackets were percent-encoded.
 [profiles]: #profiles
 [error details]: #errors
 [error object]: #error-objects
-[error objects]: #errror-objects
+[error objects]: #error-objects
 [member names]: #document-member-names
 [pagination]: #fetching-pagination
 [query parameter family]: #query-parameters-families

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -47,7 +47,7 @@
         <div class="sidebar">
           <nav class="document-outline" id="document-outline">
             {% comment %}
-              Substite the version picker for the sidebar title on spec pages.
+              Substitute the version picker for the sidebar title on spec pages.
             {% endcomment %}
             {% if page.is_spec_page %}
               <div id="version-picker-wrapper" class="sidebar-top">

--- a/examples/index.md
+++ b/examples/index.md
@@ -284,10 +284,10 @@ The `code` member of an error object contains an application-specific code
 representing the type of problem encountered. `code` is similar to `title`
 in that both identify a general type of problem (unlike `detail`, which is
 specific to the particular instance of the problem), but dealing with `code`
-is easier programatically, because the "same" `title` may appear in different
+is easier programmatically, because the "same" `title` may appear in different
 forms due to localization.
 
-For the example below, imagine the API docs specifed the following mapping:
+For the example below, imagine the API docs specified the following mapping:
 
 | Code | Problem                                                   |
 |------|-----------------------------------------------------------|

--- a/implementations/index.md
+++ b/implementations/index.md
@@ -215,7 +215,7 @@ and writing of JSON:API documents.
   * [Yaks](https://github.com/plexus/yaks) Library for building hypermedia APIs, contains a JSON:API output format.
   * [JSONAPI::Serializers](https://github.com/fotinakis/jsonapi-serializers) provides a pure Ruby, readonly serializer implementation.
   * [JSONAPI::Realizer](https://github.com/krainboltgreene/jsonapi-realizer) provides a pure Ruby pattern for turning JSON:API requests into models (has active record support and rails instructions)
-  * [Roar](https://github.com/apotonick/roar) Renders and parses represenations of Ruby objects
+  * [Roar](https://github.com/apotonick/roar) Renders and parses representations of Ruby objects
   * [Jbuilder::JsonAPI](https://github.com/vladfaust/jbuilder-json_api) Simple & lightweight extension for Jbuilder
   * [jsonapi-rb](http://jsonapi-rb.org) Ruby library for efficiently building and consuming JSON:API documents - with Rails and Hanami integrations.
   * [fast_jsonapi](https://github.com/Netflix/fast_jsonapi) A lightning fast JSON:API serializer for Ruby Objects.

--- a/recommendations/index.md
+++ b/recommendations/index.md
@@ -234,7 +234,7 @@ GET /photos/jobs/5234 HTTP/1.1
 Accept: application/vnd.api+json
 ```
 
-Requests for still-pending jobs **SHOULD** return a status `200 OK`, as the server is reporting the status successfully. Optionally, the server can return a `Retry-After` header to provide guidance to the client as to how long it should wait before checking again. Recommendations to retry sooner than 1 second can be accomplised with `Retry-After: 0`.
+Requests for still-pending jobs **SHOULD** return a status `200 OK`, as the server is reporting the status successfully. Optionally, the server can return a `Retry-After` header to provide guidance to the client as to how long it should wait before checking again. Recommendations to retry sooner than 1 second can be accomplished with `Retry-After: 0`.
 
 ```http
 HTTP/1.1 200 OK


### PR DESCRIPTION
I noticed the word "accomplised" while reading the URL recommendations, so I cloned the repo and ran it through the `typos` and `codespell` tools, fixing only misspelled words in the documentation.