### PR TITLE
Fix broken links in the spec docs

### DIFF
--- a/_format/1.1/index.md
+++ b/_format/1.1/index.md
@@ -2251,3 +2251,8 @@ request as equivalent to one in which the square brackets were percent-encoded.
 [member names]: #document-member-names
 [pagination]: #fetching-pagination
 [query parameter family]: #query-parameters-families
+[fetching filtering]: #fetching-filtering
+[fetching pagination]: #fetching-pagination
+[fetching resources]: #fetching-resources
+[fetching sorting]: #fetching-sorting
+[fetching sparse fieldsets]: #fetching-sparse-fieldsets

--- a/_format/1.2/index.md
+++ b/_format/1.2/index.md
@@ -2267,3 +2267,8 @@ request as equivalent to one in which the square brackets were percent-encoded.
 [member names]: #document-member-names
 [pagination]: #fetching-pagination
 [query parameter family]: #query-parameters-families
+[fetching filtering]: #fetching-filtering
+[fetching pagination]: #fetching-pagination
+[fetching resources]: #fetching-resources
+[fetching sorting]: #fetching-sorting
+[fetching sparse fieldsets]: #fetching-sparse-fieldsets


### PR DESCRIPTION
This PR fixes broken links in the specification.

These were observed in a note in section 7.1, "Top Level":

> ![image](https://github.com/user-attachments/assets/82842c46-6da9-4484-a260-9897f4039021)
