### PR TITLE
Fix the Gemfile to work with Ruby 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,19 +2,20 @@ source "https://rubygems.org"
 
 # http://jekyllrb.com/docs/github-pages/
 require 'json'
+require 'uri'
 require 'open-uri'
 versions =
   begin
-    JSON.parse(open('https://pages.github.com/versions.json').read)
+    JSON.parse(URI.parse('https://pages.github.com/versions.json').open.read)
   rescue SocketError
     { 'github-pages' => 67 }
   end
 
 gem 'github-pages', versions['github-pages']
 
-gem "rake", "~> 10.0"
+gem "rake", "~> 13.0"
 gem "rb-fsevent", "~> 0.9"
 gem "compass", "~> 1.0"
 gem "sass", "~> 3.4"
-gem "launchy", "~> 2.3"
+gem "launchy", "~> 3.0"
 gem "redcard", "~> 1.0"


### PR DESCRIPTION
It _may_ be that this will resolve the following failure in CD ([recent example](https://github.com/json-api/json-api/actions/runs/11936155221/job/33269145345#step:4:20)):

```
 [!] 
There was an error parsing `Gemfile`: uninitialized constant Bundler::Dsl::SocketError. Bundler cannot continue.

 #  from /github/workspace/Gemfile:9
 #  -------------------------------------------
 #      JSON.parse(open('https://pages.github.com/versions.json').read)
 >    rescue SocketError
 #      { 'github-pages' => 67 }
 #  -------------------------------------------

Warning: The github-pages gem can't satisfy your Gemfile's dependencies.
```

This has been tested locally, and on Ruby 3.3.6 it allows the commands documented in the README to succeed.

Closes #1778