### PR TITLE
Fix grammatical error on the landing page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -90,7 +90,7 @@ defaults:
 latest_version: 1.1
 excerpt_separator: ""
 announcement: |
-  **[JSON:API v1.1](/format/) was finalized September 30, 2022! 🎉**
+  **[JSON:API v1.1](/format/) was finalized on September 30, 2022! 🎉**
 
 navigation:
 - title: JSON API


### PR DESCRIPTION
<img width="1425" height="818" alt="Screenshot 2025-07-17 at 3 43 16 AM" src="https://github.com/user-attachments/assets/868b5bae-fea7-45fe-92e0-fe586c41f146" />

The word `on` would make the landing page more beautiful.