### PR TITLE
Add max-waters/jsonapi to implementations

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -274,6 +274,7 @@ the moment.
 * [jsh-api](https://github.com/derekdowling/go-json-spec-handler/tree/master/jsh-api) deals with the dirty work of building JSON:API resource endpoints. Built on top of [jsh](https://github.com/derekdowling/go-json-spec-handler)
 * [mfcochauxlaberge/jsonapi](https://github.com/mfcochauxlaberge/jsonapi) offers a large set of tools to build a JSON:API compliant service.
 * [pieoneers/jsonapi-go](https://github.com/pieoneers/jsonapi-go) lightweight JSON API implementation in Go. Make your client and server applications JSON API-enabled in hours not months.
+* [max-waters/jsonapi](https://github.com/max-waters/jsonapi) marshals and unmarshals JSON:API formatted JSON. The mapping is defined with struct tags, and can be overridden by implementing custom marshalling and unmarshaling functions.
 
 ### <a href="#server-libraries-net" id="server-libraries-net" class="headerlink"></a> .NET
 


### PR DESCRIPTION
`max-waters/jsonapi` is a Go package for marshaling and unmarshaling Go structs to and from JSON:API formatted JSON.

Source: https://github.com/max-waters/jsonapi
Go docs: https://pkg.go.dev/github.com/max-waters/jsonapi

Features:

- Struct tags define the mapping between struct fields and the JSON:API id, attributes, relationships and metadata.
- Supports anonymous/embedded struct fields.
- Marshaling and unmarshaling behaviour can be customised by implementing the ResourceMarshaler and ResourceUnmarshaler interfaces, respectively.
- Exposes an API similar to the standard encoding/json package.
