### PR TITLE
Add JsonApi4j Java Server implementation

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -299,6 +299,7 @@ includes related resources.
 * [JSON:API object converter](https://github.com/MieskeB/json-api-spring-boot) converts normal Java objects to JSON:API standard with the use of annotations in the viewmodels (dtos).
 * [Dashjoin Low Code Development Platform](https://github.com/dashjoin/platform) connects to relational, document, and graph databases and makes them available via JSON:API. The platform offers powerful access control mechanisms, a query editor, and graphical layout designers.
 * [jsonapi-simple](https://github.com/devslm/jsonapi-simple) is a simple implementation of the JSON:API specification (only required output fields). This library implements only top-level fields: data, links, errors and meta (using spring boot dependencies) without any relationships, includes and others. It implemented also filtering, sorting and sparse fieldset. [See the documentation](https://devslm.github.io/jsonapi-simple/) for full details.
+* [JsonApi4j](https://github.com/MoonWorm/jsonapi4j) is a comprehensive Java server framework for building JSON:API-compliant APIs with minimal configuration. See [documentation](https://api4.pro/) for more details.
 
 ### <a href="#server-libraries-scala" id="server-libraries-scala" class="headerlink"></a> Scala
 * [scala-jsonapi](https://github.com/scala-jsonapi/scala-jsonapi) A Scala library for producing JSON output (and deserializing JSON input) based on JSON:API specification.


### PR DESCRIPTION
This PR adds [JsonApi4j](https://github.com/MoonWorm/jsonapi4j) to the list of Java Server Implementations.

JsonApi4j is a lightweight Java framework for building [JSON:API](https://jsonapi.org/)-compliant APIs.
It provides a modular architecture with integrations for Spring Boot, and pure Jakarta REST environments (other integrations are in progress, e.g. for Quarkus).
I'm planning to actively maintain and evolve the project. It's already published on Maven Central.

Documentation: https://api4.pro/
Repository: https://github.com/MoonWorm/jsonapi4j